### PR TITLE
Revising how METHOD implies CMAKE_BUILD_TYPE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ HDF5_LIBDIR ?= $(HDF5_ROOT)/lib
 HDF5_INCLUDES := -I$(HDF5_INCLUDE_DIR) -I$(HDF5_ROOT)/include
 
 # BUILD_TYPE will be passed to CMake via CMAKE_BUILD_TYPE
-ifeq ($(METHOD),opt)
-	BUILD_TYPE := Release
-else 
+ifeq ($(METHOD),dbg)
 	BUILD_TYPE := Debug
+else 
+	BUILD_TYPE := Release
 endif
 
 OCCA_CUDA_ENABLED=0


### PR DESCRIPTION
This revises how the `METHOD` env variable implies `CMAKE_BUILD_TYPE` for OpenMC, NekRS and its dependents (particularly, OCCA).

Previously, the corerspondence was:
* `dbg` implied `Debug`
* `opt` implied `Release`
* `oprof` implied `Debug`

With this PR, `oprof` now implies `Release`.  
* This makes more sense for profiling runs, which is a good long-term enhancement.  
* It also avoids including `-Werror` in OCCA builds when `METHOD` is `oprof`, which is currently preventing us from building Cardinal with`oprof`.  nekRS requires an old version of OCCA, which includes the deprecated `<sys/sysctl.h>` header, which in turn causes a fatal error with the `-Werror` flag.   This was fixed in OCCA's upstream several months ago, but the changes haven't been brought into NekRS yet.  