### PR TITLE
Correct volume usage for inputs within Cardinal. Refs #30

### DIFF
--- a/problems/spherical_heat_conduction/openmc.i
+++ b/problems/spherical_heat_conduction/openmc.i
@@ -3,16 +3,14 @@
   file = sphere.e
 []
 
-[Variables]
-  [dummy]
-  []
-[]
-
 [Problem]
   type = OpenMCProblem
   power = 0.15 # W
   centers = '0 0 0'
-  volumes = '14.137166941154067'
+
+  # only needed for cell-type feedback, but included here for quick switching
+  volumes = '1.279209e+01'
+
   tally_type = 'mesh'
   pebble_cell_level = 0
   mesh_template = 'sphere.e'
@@ -23,9 +21,12 @@
   num_steps = 50
 []
 
-[Outputs]
-  [exo]
-    type = Exodus
-    output_dimension = 3
+[Postprocessors]
+  [pebble_volume] # show the volume of the pebble for confirmation
+    type = VolumePostprocessor
   []
+[]
+
+[Outputs]
+  exodus = true
 []

--- a/problems/spherical_heat_conduction/openmc_linear.i
+++ b/problems/spherical_heat_conduction/openmc_linear.i
@@ -7,7 +7,10 @@
   type = OpenMCProblem
   power = 0.15 # W
   centers = '0 0 0'
-  volumes = '14.137166941154067'
+
+  # only required for cell-based tallies, but included here anyways for quick switching
+  volumes = '1.279209e+01'
+
   tally_type = 'mesh'
   pebble_cell_level = 0
   mesh_template = 'sphere.e'
@@ -55,6 +58,12 @@
   type = Transient
   dt = 5e-4
   num_steps = 50
+[]
+
+[Postprocessors]
+  [pebble_volume] # show the volume of the pebble for confirmation
+    type = VolumePostprocessor
+  []
 []
 
 [Outputs]

--- a/problems/two_pebbles/openmc.i
+++ b/problems/two_pebbles/openmc.i
@@ -3,16 +3,11 @@
   file = two_sphere.e
 []
 
-[Variables]
-  [dummy]
-  []
-[]
-
 [Problem]
   type = OpenMCProblem
   power = 1000
   centers = '0 0 0 0 0 3.15'
-  volumes = '14.137166941154067 14.137166941154067'
+  volumes = '13.986085'
   tally_type = 'mesh'
   mesh_template = 'sphere.e'
 []
@@ -22,9 +17,22 @@
   num_steps = 50
 []
 
+[Postprocessors]
+  [total_volume]
+    type = VolumePostprocessor
+  []
+  [pebble_volume] # show the volume of each pebble for confirmation
+    type = LinearCombinationPostprocessor
+    pp_names = 'total_volume'
+    pp_coefs = '${fparse 1.0/2.0}'
+  []
+[]
+
 [Outputs]
-  [exo]
-    type = Exodus
-    output_dimension = 3
+  exodus = true
+
+  [console]
+    type = Console
+    hide = 'total_volume'
   []
 []

--- a/src/base/OpenMCProblem.C
+++ b/src/base/OpenMCProblem.C
@@ -32,7 +32,7 @@ validParams<OpenMCProblem>()
   params.addParam<std::vector<FileName>>("centers_file", "Alternative way to provide the coordinates of cells "
     "to transfer data with");
 
-  params.addRequiredParam<std::vector<Real>>("volumes", "volumes of pebbles");
+  params.addParam<std::vector<Real>>("volumes", "volumes of pebbles");
   params.addRequiredParam<MooseEnum>("tally_type", getTallyTypeEnum(), "type of tally to use in OpenMC");
   params.addParam<int>("pebble_cell_level", 0, "Level of pebble cells in the OpenMC model");
   params.addParam<std::string>("mesh_template", "mesh tally template for OpenMC");
@@ -53,18 +53,27 @@ OpenMCProblem::OpenMCProblem(const InputParameters &params) :
   // get the coordinates for each cell center that we wish to transfer data with
   fillCenters();
 
-  // number of supplied volumes must either be 1 (in which case each cell is assumed
-  // to be the same volume) or have a length equal to the number of centers provided
-  if ((_volumes.size() > 1) &&  (_volumes.size() != _centers.size()))
-    paramError("volumes", "When more than one volume is provided, the length must match "
-      "the length of the 'centers' provided!");
-
-  // if only one volume was provided, fill out the _volumes array for heat source normalization
-  // agnostic to whether one or N volumes were provided by the user
-  if (_volumes.size() == 1)
+  if (_tallyType == tally::cell)
   {
-    Real vol = _volumes[0];
-    _volumes = std::vector<double>(_centers.size(), vol);
+    if (!isParamValid("volumes"))
+      paramError("volumes", "Wth cell-based tallies, the volumes of each MOOSE receiving mesh "
+        "must be provided!");
+
+    _volumes = getParam<std::vector<Real>>("volumes");
+
+    // number of supplied volumes must either be 1 (in which case each cell is assumed
+    // to be the same volume) or have a length equal to the number of centers provided
+    if ((_volumes.size() > 1) &&  (_volumes.size() != _centers.size()))
+      paramError("volumes", "When more than one volume is provided, the length must match "
+        "the length of the 'centers' provided!");
+
+    // if only one volume was provided, fill out the _volumes array for heat source normalization
+    // agnostic to whether one or N volumes were provided by the user
+    if (_volumes.size() == 1)
+    {
+      Real vol = _volumes[0];
+      _volumes = std::vector<double>(_centers.size(), vol);
+    }
   }
 
   if (_tallyType == tally::mesh)


### PR DESCRIPTION
Correct volumes used for power normalization for the files in Cardinal. Because all of these inputs actually are based on mesh tallies, these incorrect volumes aren't actually used, but having the right value is useful for people trying to understand the code.

I'll go through large-problems next and update those to the correct values.

I also made `volumes` not required for mesh-based tallies, so that people's inputs can be shorted if they're not using that option.