### PR TITLE
General OpenMC model generation script for pebble beds

### DIFF
--- a/scripts/openmc_pebble_ped_model.py
+++ b/scripts/openmc_pebble_ped_model.py
@@ -530,11 +530,13 @@ m_colors = {m_fuel: 'brown',
             m_graphite_c_buffer: 'LightSteelBlue',
             m_graphite_pyc: 'blue',
             m_sic: 'orange',
-            m_reflector: 'green',
             m_graphite_matrix: 'cyan',
             m_graphite_inner: 'DeepSkyBlue',
             m_graphite_outer: 'Navy',
             m_flibe: 'yellow'}
+
+if reflector_is_present:
+    m_colors[m_reflector] = 'green'
 
 plot1          = openmc.Plot()
 plot1.filename = 'plot1'


### PR DESCRIPTION
This PR adds a single OpenMC Python script for the generation of our pebble bed models. With the correct set of arguments,
this script can produce the same OpenMC geometry and material XML files that currently exist in `large-problems`. (There are small differences in the settings file, I'll get to that in a bit.) It is my hope for us to use this for all problems going forward to ensure that the OpenMC models generated for the pebble bed cases are consistent. 

I've verified this for the 1568, 11k, 127k, and 300k models which use the pebble cell lattice to accelerate particle tracking. Here are the arguments to provide to the script for each of these cases:

1568 pebble case:

```shell
$ openmc_pebble_ped_model.py -l 20 20 20 -t 10 10 10  -p 50000 -i 50 -a 200 -e 12.125
```
11k pebble case:

```shell
$ openmc_pebble_ped_model.py -l 10 10 10 -t 20 20 20  -p 50000 -i 50 -a 200 -e 16.125
```

127k pebble case:
```shell
$ openmc_pebble_ped_model.py -l 10 10 10 -t 20 20 20  -p 50000 -i 50 -a 200 -e 0.00001 -f 40.0
```

300k pebble case:
```shell
$ openmc_pebble_ped_model.py -l 40 40 40 -t 20 20 20  -p 50000 -i 50 -a 200
```

I'll put these in the associated README files for each problem and remove the `openmc_model.py` files in a future PR in large-problems. Some of the argument gymnastics around adding the reflector for the larger problems isn't beautiful, but it ensures we get the exact same `geometry.xml` files as of this PR. We can make incremental improvements on this going forward without worrying about this reproducibility I think.

Here's an explanation of all those options listed above:

```
usage: openmc_pebble_ped_model.py [-h] [-e EXTRA_REFL] [-v] [-r] [-b BC]
                                  [-p PARTICLES] [-i INACTIVE] [-a ACTIVE]
                                  [-l PSHAPE PSHAPE PSHAPE]
                                  [-t TSHAPE TSHAPE TSHAPE] [-f]

Script for producing a pebble bed geometry from a file of pebble centers.

optional arguments:
  -h, --help            show this help message and exit
  -e EXTRA_REFL         Additional reflector thickness
  -v                    Enable verbose output
  -r                    Enable random TRISO distribution
  -b BC                 Reactor external B.C.
  -p PARTICLES          Particles per batch
  -i INACTIVE           Inactive batches
  -a ACTIVE             Active batches
  -l PSHAPE PSHAPE PSHAPE
                        Pebble lattice shape
  -t TSHAPE TSHAPE TSHAPE
                        TRISO lattice shape
  -f                    Include surrounding reflector

This script expects the presence of a 'pebble_centers_rescaled.txt' file in
which all pebble centers are represented for pebbles with a radius of 1.5 cm.
```

Notable (but inconsequential) input file changes:
  - voxel plots are now included by default in the XMLs
  - summary output is disabled in the OpenMC settings. These can take a considerable amount of time to generate for the large problems. We don't currently need them for postprocessing, but in the event that we do we can always remove this setting and produce the `summary.h5` separately from the simluation.
  - the `material_cell_offsets` option has been disabled in the settings. For large problems, these are only used for `CellInstance` tallies (which we don't use currently) and the data structures can take a long time to generate and consume a lot of memory.
  - the default temperature value is written as a float instead of an int in the XML
  
  @aprilnovak @emerzari Note that this does not contain the model updates we discussed regarding the Cell tallies. I wanted to add this script in a state that can reproduce what we do have now (even if it needs improvement) and then add the fix separately.

**Edited to reflect updates to the script made to address comments in this PR.**
