### PR TITLE
Set initial temperatures on NearestPointReceiver using the OpenMC model values

### DIFF
--- a/src/base/OpenMCProblem.C
+++ b/src/base/OpenMCProblem.C
@@ -257,7 +257,7 @@ void OpenMCProblem::addExternalVariables()
         Moose::stringify(c(1)) + ", " + Moose::stringify(c(2)) + ")");
 
     auto& cell = openmc::model::cells[p.coord_[p.n_coord_ - 1].cell];
-    initial_temperatures.push_back(cell->temperature(cell->temperature(p.cell_instance_)));
+    initial_temperatures.push_back(cell->temperature(p.cell_instance_));
 
   }
 


### PR DESCRIPTION
For the non-coupled OpenMC problems, no temperature values are set on the `NearestPointReceiver` for the `average_temp` variable. This results in a temperature of `0` passed to the OpenMC problem. 

For cross-section datasets with only one temperature, OpenMC abandons the specified temperature interpolation method and defaults to the "nearest temperature" method for xs lookups. It then is able to proceeds with temperatures of `0` without an issue (we have a healthy temperature tolerance of 1000K set in these models right now). So in this case we're effectively running the simulation at whatever temperature is available in the data.

For xs data with multiple temperatures, however, we run into a problem. OpenMC discovers multiple temperatures and maintains the temperature interpolation method for xs lookups. When attempting to set a cell temperature outside of the available data in this mode, OpenMC then throws an exception.

The fix here is to add a `find_cell` loop in `OpenMCProblems::addExternalVariables()` to determine the temperature at the location of the pebble centers provided to the OpenMC problem. These temperatures are then used to populate the `NearestPointReceiver` user object upon setup of the OpenMC problem.

Note that this is distinct from the `find_cell` loop that we do to setup the cell tally. In that loop, we search for cells at a specific level of the geometry which may not be material-filled and in turn will have a valid temperature. In this new loop we use the cell at the lowest level of the geometry (`p.n_coord_`) to get the temperatures as that cell is guaranteed to be filled with a material and have a temperature property.