### PR TITLE
OpenMCProblem distributed mesh support

### DIFF
--- a/src/base/OpenMCProblem.C
+++ b/src/base/OpenMCProblem.C
@@ -375,8 +375,6 @@ void OpenMCProblem::syncSolutions(ExternalProblem::Direction direction)
       // get the transfer mesh
       auto & transfer_mesh = _mesh.getMesh();
 
-      auto pid = _communicator.rank();
-
       switch (_tallyType)
       {
         case tally::cell:


### PR DESCRIPTION
This is a follow-on to #42 towards addressing #7.

Some of the initialization in the `NekRSMesh` seen in the other PR isn't present here because the `OpenMCProblem`'s transfer mesh is a `MooseMesh` object which takes care of that setup automatically (I think).

https://github.com/idaholab/moose/blob/next/framework/src/mesh/MooseMesh.C#L358-L375

In line with what @roystgnr mentions in #42, I'm hoping that others will test on their own as well.