### PR TITLE
Add a check for unique cell indices in OpenMCProblem

### DIFF
--- a/src/base/OpenMCProblem.C
+++ b/src/base/OpenMCProblem.C
@@ -103,8 +103,9 @@ OpenMCProblem::OpenMCProblem(const InputParameters &params) :
   // ensure that the _cellIndices are unique
   auto unique_cell_indices = std::set(_cellIndices.begin(), _cellIndices.end());
   if (_cellIndices.size() != unique_cell_indices.size()) {
-    mooseError("The cells found in the geometry at level '" + Moose::stringify(_pebble_cell_level) +
-               "' are not unique. Please check the 'pebble_cell_level' parameter." );
+    mooseError("The cells found in the geometry for the centers provided at level '"
+               + Moose::stringify(_pebble_cell_level) +
+               "' are not unique. Please check the centers and the 'pebble_cell_level' parameter." );
   }
 
   switch (_tallyType)


### PR DESCRIPTION
This resolves #34 by adding a check that the set of cells found for the centers provided to the problem are unique to guarantee that none of the tally spaces overlap. This does _not_ guarantee that the correct set of cells have been identified, however. For example, if the `pebble_cell_level` is set (incorrectly) such that we find cells used to fill the pebble lattice, the cell indices will be a unique set but the tally will only occur in the area of the pebble that overlaps with that lattice cell. This is where the tally sum check from #43 becomes important.

This PR also resolves #35 by making `pebble_cell_level`  a required parameter of the OpenMCProblem.