### PR TITLE
Correct execute_on flags for source temperature user object.

### DIFF
--- a/problems/spherical_heat_conduction/master.i
+++ b/problems/spherical_heat_conduction/master.i
@@ -90,7 +90,7 @@
     type = NearestPointAverage
     variable = temp
     points = '0 0 0'
-    execute_on = 'timestep_end'
+    execute_on = 'initial timestep_end'
   []
 []
 


### PR DESCRIPTION
We need to have `initial` in the `execute_on` flag for the temperature transfer into OpenMC, or else we are attempting to send zero temperature (which is outside the loaded data range for OpenMC).