### PR TITLE
Add console print of number of pebbles

### DIFF
--- a/include/base/OpenMCProblem.h
+++ b/include/base/OpenMCProblem.h
@@ -25,6 +25,8 @@ public:
   virtual void externalSolve() override;
   virtual void syncSolutions(ExternalProblem::Direction direction) override;
 
+  virtual void initialSetup() override;
+
   virtual bool converged() override { return true; }
 
   /// Get the center coordinates for all cells of interest

--- a/src/base/OpenMCProblem.C
+++ b/src/base/OpenMCProblem.C
@@ -315,6 +315,15 @@ void OpenMCProblem::addExternalVariables()
   average_temp.setValues(initial_temperatures);
 }
 
+void
+OpenMCProblem::initialSetup()
+{
+  ExternalProblem::initialSetup();
+
+  int n_centers = _centers.size();
+  _console << "Initializing OpenMC problem with " << Moose::stringify(n_centers) << " coupling points..." << std::endl;
+}
+
 void OpenMCProblem::externalSolve()
 {
   int err = openmc_run();
@@ -368,6 +377,8 @@ void OpenMCProblem::syncSolutions(ExternalProblem::Direction direction)
     }
     case ExternalProblem::Direction::FROM_EXTERNAL_APP:
     {
+      _console << "Extracting heat source from OpenMC... ";
+
       auto& solution = _aux->solution();
 
       auto sys_number = _aux->number();
@@ -421,6 +432,9 @@ void OpenMCProblem::syncSolutions(ExternalProblem::Direction direction)
               }
             }
           }
+
+        _console << "done" << std::endl;
+
         break;
       }
 


### PR DESCRIPTION
For checking that I have the pebble volumes right for the power normalization, it's helpful to have OpenMCProblem print that value to the screen. 

Really small PR, just thought it'd be worth getting this in permanently!