### PR TITLE
Add template argument to the std::set used to check for cell uniqueness.

### DIFF
--- a/src/base/OpenMCProblem.C
+++ b/src/base/OpenMCProblem.C
@@ -114,7 +114,7 @@ OpenMCProblem::OpenMCProblem(const InputParameters &params) :
   }
 
   // ensure that the _cellIndices are unique
-  auto unique_cell_indices = std::set(_cellIndices.begin(), _cellIndices.end());
+  auto unique_cell_indices = std::set<int32_t>(_cellIndices.begin(), _cellIndices.end());
   if (_cellIndices.size() != unique_cell_indices.size()) {
     mooseError("The cells found in the geometry for the centers provided at level '"
                + Moose::stringify(_pebble_cell_level) +


### PR DESCRIPTION
Older compilers won't automatically do the substitution for the template argument in the creation of the `std::set` used to check for cell ID uniqueness in `OpenMCProblem`. This adds the `int32_t` argument explicitly.