### PR TITLE
Change remote for nekRS fork.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/openmc-dev/openmc.git
 [submodule "contrib/nekRS"]
 	path = contrib/nekRS
-	url = https://xgitlab.cels.anl.gov/neams-th-coe/nekRS.git
+	url = https://github.com/neams-th-coe/nekRS.git
 [submodule "contrib/moose"]
 	path = contrib/moose
 	url = https://github.com/idaholab/moose.git


### PR DESCRIPTION
Because xgitlab is retiring at the end of June, we need to move our nekRS fork out of xgitlab - I figured putting our fork on gitlab matches where we have Cardinal and will allow us to easily change the access from private -> public when/if we open source Cardinal.