### PR TITLE
Add instructions for building Cardinal on the MCS compute nodes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,35 @@ export CXX=mpicxx
 export FC=mpif90
 ```
 
+### Math and Computer Science (MCS) Compute Nodes [6/1/2021]
+
+The following `~/.bashrc` allows you to compile Cardinal on the MCS compute nodes,
+in combination with the compilation steps described above.
+
+```
+export NEKRS_HOME=$HOME/cardinal/install
+```
+
+The MCS compute nodes use [SoftEnv](https://www.mcs.anl.gov/hs/software/systems/softenv/softenv-intro.html)
+to manage the environment. In addition to the above `~/.bashrc`, the following `~/.soft` file
+is required.
+
+```
+@default
++mpich-3.2-gcc-6.2.0
++gcc-6.2.0
++hdf5-1.8.16-gcc-6.2.0-mpich-3.2-parallel
++cmake-3.14.3
+```
+
+Before building, make sure that the output of `cmake --version` is 3.14.3. If for some
+reason the CMake version still points to the older version as part of the default
+environment, you will need to source the environment again with
+
+```
+$ resoft
+```
+
 ### Sawtooth (INL-HPC) [4/29/2021]
 
 The following `~/.bashrc` allows you to compile Cardinal on Sawtooth, in combination
@@ -174,7 +203,9 @@ with the compilation steps described above.
 if [ -f /etc/bashrc ]; then
         . /etc/bashrc
 fi
+
 export NEKRS_HOME=$HOME/cardinal/install
+
 module purge
 module load openmpi/4.0.5_ucx1.9
 module load cmake/3.16.2-gcc-9.3.0-tza7

--- a/src/base/NekInterface.C
+++ b/src/base/NekInterface.C
@@ -590,7 +590,11 @@ void limitTemperature(const double * min_T, const double * max_T)
   for (int i = 0; i < mesh->Nelements; ++i) {
     for (int j = 0; j < mesh->Np; ++j) {
       int id = i * mesh->Np + j;
-      nrs->cds->S[id] = std::clamp(nrs->cds->S[id], minimum, maximum);
+
+      if (nrs->cds->S[id] < minimum)
+        nrs->cds->S[id] = minimum;
+      else if (nrs->cds->S[id] > maximum)
+        nrs->cds->S[id] = maximum;
     }
   }
 


### PR DESCRIPTION
Add instructions for building Cardinal on the MCS compute nodes. Unless I'm missing something, the available packages via SoftEnv are super old, so I think we're restricted to gcc-6.2. In that case, `std::clamp` doesn't exist yet, so I just replaced that convenience function with a bit more verbose implementation (that should be equivalent).