### PR TITLE
Automatically add postprocessors for the flux and source normalization

### DIFF
--- a/src/base/NekRSProblem.C
+++ b/src/base/NekRSProblem.C
@@ -497,7 +497,7 @@ NekRSProblem::sendBoundaryHeatFluxToNek()
 void
 NekRSProblem::sendVolumeHeatSourceToNek()
 {
-  _console << "Sending heat source to nekRS volume... " << std::endl;
+  _console << "Sending heat source to nekRS volume... ";
 
   auto & solution = _aux->solution();
   auto sys_number = _aux->number();
@@ -763,11 +763,19 @@ NekRSProblem::addExternalVariables()
     // sending app (such as BISON) into 'avg_flux'.
     addAuxVariable("MooseVariable", "avg_flux", var_params);
     _avg_flux_var = _aux->getFieldVariable<Real>(0, "avg_flux").number();
+
+    // add the postprocessor that receives the flux integral for normalization
+    auto pp_params = _factory.getValidParams("Receiver");
+    addPostprocessor("Receiver", "flux_integral", pp_params);
   }
 
   if (_volume)
   {
     addAuxVariable("MooseVariable", "heat_source", var_params);
     _heat_source_var = _aux->getFieldVariable<Real>(0, "heat_source").number();
+
+    // add the postprocessor that receives the source integral for normalization
+    auto pp_params = _factory.getValidParams("Receiver");
+    addPostprocessor("Receiver", "source_integral", pp_params);
   }
 }

--- a/test/tests/cht/nondimensional/nek.i
+++ b/test/tests/cht/nondimensional/nek.i
@@ -37,9 +37,6 @@
   [synchronization_in]
     type = Receiver
   []
-  [flux_integral]
-    type = Receiver
-  []
 
   # side integral
   [area_1]

--- a/test/tests/cht/pebble/nek.i
+++ b/test/tests/cht/pebble/nek.i
@@ -25,10 +25,6 @@
 []
 
 [Postprocessors]
-  [flux_integral]
-    type = Receiver
-  []
-
   # This is the heat flux in the nekRS solution, i.e. it is not an integral
   # of nrs->usrwrk, instead this is directly an integral of k*grad(T)*hat(n).
   # So this should closely match 'flux_integral'

--- a/test/tests/cht/sfr_pincell/nek.i
+++ b/test/tests/cht/sfr_pincell/nek.i
@@ -23,9 +23,6 @@
   [synchronization_in]
     type = Receiver
   []
-  [flux_integral]
-    type = Receiver
-  []
   [nek_flux]
     type = NekHeatFluxIntegral
     boundary = '1'

--- a/test/tests/conduction/boundary_and_volume/prism/nek.i
+++ b/test/tests/conduction/boundary_and_volume/prism/nek.i
@@ -21,12 +21,6 @@
 []
 
 [Postprocessors]
-  [source_integral]
-    type = Receiver
-  []
-  [flux_integral]
-    type = Receiver
-  []
   [max_T]
     type = NekVolumeExtremeValue
     field = temperature

--- a/test/tests/conduction/identical_interface/cube/nek.i
+++ b/test/tests/conduction/identical_interface/cube/nek.i
@@ -15,12 +15,6 @@
   []
 []
 
-[Postprocessors]
-  [flux_integral]
-    type = Receiver
-  []
-[]
-
 [Outputs]
   exodus = true
   execute_on = 'final'

--- a/test/tests/conduction/identical_interface/pyramid/nek.i
+++ b/test/tests/conduction/identical_interface/pyramid/nek.i
@@ -16,9 +16,6 @@
 []
 
 [Postprocessors]
-  [flux_integral]
-    type = Receiver
-  []
   [max_temp_nek]
     type = NekVolumeExtremeValue
     field = temperature

--- a/test/tests/conduction/identical_volume/cube/nek.i
+++ b/test/tests/conduction/identical_volume/cube/nek.i
@@ -17,9 +17,6 @@
 []
 
 [Postprocessors]
-  [source_integral]
-    type = Receiver
-  []
   [flux_out]
     type = NekHeatFluxIntegral
     boundary = '1 2 3 4 5 6'

--- a/test/tests/conduction/nonidentical_interface/cylinders/nek.i
+++ b/test/tests/conduction/nonidentical_interface/cylinders/nek.i
@@ -16,9 +16,6 @@
 []
 
 [Postprocessors]
-  [flux_integral]
-    type = Receiver
-  []
   [max_temp_nek]
     type = NekVolumeExtremeValue
     field = temperature

--- a/test/tests/conduction/nonidentical_interface/cylinders/nek_mini.i
+++ b/test/tests/conduction/nonidentical_interface/cylinders/nek_mini.i
@@ -19,9 +19,6 @@
 []
 
 [Postprocessors]
-  [flux_integral]
-    type = Receiver
-  []
   [max_temp_nek]
     type = NekVolumeExtremeValue
     field = temperature

--- a/test/tests/conduction/nonidentical_volume/cylinder/nek.i
+++ b/test/tests/conduction/nonidentical_volume/cylinder/nek.i
@@ -17,9 +17,6 @@
 []
 
 [Postprocessors]
-  [source_integral]
-    type = Receiver
-  []
   [max_T]
     type = NekVolumeExtremeValue
     field = temperature

--- a/test/tests/conduction/nonidentical_volume/nondimensional/nek.i
+++ b/test/tests/conduction/nonidentical_volume/nondimensional/nek.i
@@ -32,9 +32,6 @@
 []
 
 [Postprocessors]
-  [source_integral]
-    type = Receiver
-  []
   [max_T]
     type = NekVolumeExtremeValue
     field = temperature

--- a/test/tests/nek_errors/invalid_transfer_pp/nek.i
+++ b/test/tests/nek_errors/invalid_transfer_pp/nek.i
@@ -18,9 +18,6 @@
 []
 
 [Postprocessors]
-  [flux_integral]
-    type = Receiver
-  []
   [synchronize_in]
     type = Receiver
   []

--- a/test/tests/nek_errors/used_scratch/nek.i
+++ b/test/tests/nek_errors/used_scratch/nek.i
@@ -15,12 +15,6 @@
   [../]
 []
 
-[Postprocessors]
-  [flux_integral]
-    type = Receiver
-  []
-[]
-
 [Outputs]
   exodus = true
   hide = 'flux_integral'

--- a/test/tests/nek_temp/first_order/nek.i
+++ b/test/tests/nek_temp/first_order/nek.i
@@ -73,9 +73,6 @@
     variable = difference
     value_type = min
   []
-  [flux_integral]
-    type = Receiver
-  []
 []
 
 [Outputs]

--- a/test/tests/nek_temp/first_order/nek_volume.i
+++ b/test/tests/nek_temp/first_order/nek_volume.i
@@ -73,16 +73,10 @@
     variable = difference
     value_type = min
   []
-  [flux_integral]
-    type = Receiver
-  []
-  [source_integral]
-    type = Receiver
-  []
 []
 
 [Outputs]
   exodus = true
   execute_on = 'final'
-  hide = 'flux_integral source_integral heat_source'
+  hide = 'source_integral heat_source'
 []

--- a/test/tests/nek_temp/second_order/nek.i
+++ b/test/tests/nek_temp/second_order/nek.i
@@ -1,6 +1,5 @@
 [Problem]
   type = NekRSProblem
-  flux_integral = flux_integral
 []
 
 [Mesh]
@@ -73,9 +72,6 @@
     type = NodalExtremeValue
     variable = difference
     value_type = min
-  []
-  [flux_integral]
-    type = Receiver
   []
 []
 

--- a/test/tests/nek_temp/second_order/nek_volume.i
+++ b/test/tests/nek_temp/second_order/nek_volume.i
@@ -73,16 +73,10 @@
     variable = difference
     value_type = min
   []
-  [flux_integral]
-    type = Receiver
-  []
-  [source_integral]
-    type = Receiver
-  []
 []
 
 [Outputs]
   exodus = true
   execute_on = 'final'
-  hide = 'flux_integral source_integral heat_source'
+  hide = 'source_integral heat_source'
 []

--- a/test/tests/postprocessors/nek_heat_flux_integral/nek.i
+++ b/test/tests/postprocessors/nek_heat_flux_integral/nek.i
@@ -56,7 +56,4 @@
     type = NekHeatFluxIntegral
     boundary = '8'
   []
-  [flux_integral]
-    type = Receiver
-  []
 []

--- a/test/tests/postprocessors/nek_side_average/nek.i
+++ b/test/tests/postprocessors/nek_side_average/nek.i
@@ -105,7 +105,4 @@
     field = pressure
     boundary = '8'
   []
-  [flux_integral]
-    type = Receiver
-  []
 []

--- a/test/tests/postprocessors/nek_side_extrema/nek.i
+++ b/test/tests/postprocessors/nek_side_extrema/nek.i
@@ -209,8 +209,4 @@
     boundary = '8'
     value_type = min
   []
-
-  [flux_integral]
-    type = Receiver
-  []
 []

--- a/test/tests/postprocessors/nek_side_extrema/nek_p.i
+++ b/test/tests/postprocessors/nek_side_extrema/nek_p.i
@@ -120,7 +120,4 @@
     boundary = '8'
     value_type = min
   []
-  [flux_integral]
-    type = Receiver
-  []
 []

--- a/test/tests/postprocessors/nek_side_integral/nek.i
+++ b/test/tests/postprocessors/nek_side_integral/nek.i
@@ -144,7 +144,4 @@
     field = pressure
     boundary = '8'
   []
-  [flux_integral]
-    type = Receiver
-  []
 []

--- a/test/tests/postprocessors/nek_volume_average/nek.i
+++ b/test/tests/postprocessors/nek_volume_average/nek.i
@@ -33,7 +33,4 @@
     type = NekVolumeAverage
     field = pressure
   []
-  [source_integral]
-    type = Receiver
-  []
 []

--- a/test/tests/postprocessors/nek_volume_extrema/nek.i
+++ b/test/tests/postprocessors/nek_volume_extrema/nek.i
@@ -44,7 +44,4 @@
     field = pressure
     value_type = min
   []
-  [flux_integral]
-    type = Receiver
-  []
 []

--- a/test/tests/postprocessors/nek_volume_integral/nek.i
+++ b/test/tests/postprocessors/nek_volume_integral/nek.i
@@ -18,7 +18,7 @@
 [Outputs]
   [out]
     type = CSV
-    hide = 'flux_integral source_integral'
+    hide = 'source_integral'
     execute_on = 'final'
   []
 []
@@ -35,11 +35,5 @@
   [pressure_integral]
     type = NekVolumeIntegral
     field = pressure
-  []
-  [flux_integral]
-    type = Receiver
-  []
-  [source_integral]
-    type = Receiver
   []
 []

--- a/test/tests/postprocessors/nek_weighted_side_average/nek.i
+++ b/test/tests/postprocessors/nek_weighted_side_average/nek.i
@@ -84,7 +84,4 @@
     field = temperature
     boundary = '6'
   []
-  [flux_integral]
-    type = Receiver
-  []
 []

--- a/test/tests/postprocessors/nek_weighted_side_integral/nek.i
+++ b/test/tests/postprocessors/nek_weighted_side_integral/nek.i
@@ -54,7 +54,4 @@
     field = temperature
     boundary = '6'
   []
-  [flux_integral]
-    type = Receiver
-  []
 []


### PR DESCRIPTION
Automatically add postprocessors when necessary, following the same design idea that we use when adding `nek_temp` and `avg_flux`.

After this is merged, I'll do an update to the problems repo.

Closes #87