### PR TITLE
Update location of SAM repo.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/idaholab/moose.git
 [submodule "contrib/SAM"]
 	path = contrib/SAM
-	url = https://xgitlab.cels.anl.gov/SAM/SAM.git
+	url = https://git-nse.egs.anl.gov/SAM/SAM.git


### PR DESCRIPTION
The SAM repository migrated from xgitlab.cels.anl.gov over to git-nse.egs.anl.gov. This just updates the URL for the SAM repo.