### PR TITLE
Use smarter default for the tally checks

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -385,16 +385,6 @@ protected:
   const Real & _power;
 
   /**
-   * Whether to check the tallies against the global kappa fission tally;
-   * if set to true, and the tallies added for the 'tally_blocks' do not
-   * sum to the global kappa fission tally, an error is thrown. If you are
-   * only performing multiphysics feedback for, say, a single assembly in a
-   * full-core OpenMC model, you must set this check to false, because there
-   * are known fission sources outside the domain of interest.
-   */
-  const bool & _check_tally_sum;
-
-  /**
    * Whether to check if any of the tallies evaluate to zero; if set to true,
    * and a tally is zero, an error is thrown. This can be helpful in identifying
    * cases where you added tallies, but there isn't any fissile material, or
@@ -472,6 +462,21 @@ protected:
    * normalize against the local tally itself so that the correct power is preserved.
    */
   const bool & _normalize_by_global;
+
+  /**
+   * Whether to check the tallies against the global kappa fission tally;
+   * if set to true, and the tallies added for the 'tally_blocks' do not
+   * sum to the global kappa fission tally, an error is thrown. If you are
+   * only performing multiphysics feedback for, say, a single assembly in a
+   * full-core OpenMC model, you must set this check to false, because there
+   * are known fission sources outside the domain of interest.
+   *
+   * If not specified, then this is set to 'true' if normalizing by a global
+   * tally, and to 'false' if normalizing by the local tally (because when we choose
+   * to normalize by the local tally, we're probably using mesh tallies). But you can
+   * of course still set a value for this parameter to override the default.
+   */
+  const bool & _check_tally_sum;
 
   /**
    * Whether the problem has fluid blocks specified; note that this is NOT necessarily

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -37,7 +37,7 @@ validParams<OpenMCCellAverageProblem>()
   params.addParam<std::vector<SubdomainID>>("tally_blocks",
     "Subdomain ID(s) for which to add tallies in the OpenMC model; "
     "only used with cell tallies");
-  params.addParam<bool>("check_tally_sum", true,
+  params.addParam<bool>("check_tally_sum",
     "Whether to check consistency between the cell-wise kappa fission tallies with a global tally");
   params.addParam<bool>("check_zero_tallies", true,
     "Whether to throw an error if any tallies from OpenMC evaluate to zero; "
@@ -82,13 +82,13 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters &params
   _tally_filter(getParam<MooseEnum>("tally_filter").getEnum<filter::CellFilterEnum>()),
   _tally_type(getParam<MooseEnum>("tally_type").getEnum<tally::TallyTypeEnum>()),
   _power(getParam<Real>("power")),
-  _check_tally_sum(getParam<bool>("check_tally_sum")),
   _check_zero_tallies(getParam<bool>("check_zero_tallies")),
   _verbose(getParam<bool>("verbose")),
   _skip_first_incoming_transfer(getParam<bool>("skip_first_incoming_transfer")),
   _specified_scaling(params.isParamSetByUser("scaling")),
   _scaling(getParam<Real>("scaling")),
   _normalize_by_global(getParam<bool>("normalize_by_global_tally")),
+  _check_tally_sum(isParamValid("check_tally_sum") ? getParam<bool>("check_tally_sum") : _normalize_by_global),
   _has_fluid_blocks(params.isParamSetByUser("fluid_blocks")),
   _has_solid_blocks(params.isParamSetByUser("solid_blocks")),
   _needs_global_tally(_check_tally_sum || _normalize_by_global),
@@ -823,6 +823,10 @@ OpenMCCellAverageProblem::addLocalTally(std::vector<openmc::Filter *> & filters,
 void
 OpenMCCellAverageProblem::initializeTallies()
 {
+  // if the tally sum check is turned off, write a message informing the user
+  if (!_check_tally_sum)
+    _console << "Turning OFF tally sum check against global tally" << std::endl;
+
   // create the global tally for normalization
   if (_needs_global_tally)
   {

--- a/test/tests/neutronics/mesh_tally/different_units.i
+++ b/test/tests/neutronics/mesh_tally/different_units.i
@@ -42,7 +42,6 @@
 
   tally_type = mesh
   power = 100.0
-  check_tally_sum = false
   check_zero_tallies = false
 
   # the [Mesh] is in units of meters - VERY IMPORTANT: the mesh template still must be in

--- a/test/tests/neutronics/mesh_tally/multiple_meshes.i
+++ b/test/tests/neutronics/mesh_tally/multiple_meshes.i
@@ -67,7 +67,6 @@
   tally_type = mesh
   mesh_template = '../meshes/sphere.e'
   power = 100.0
-  check_tally_sum = false
   check_zero_tallies = false
 []
 

--- a/test/tests/neutronics/mesh_tally/one_mesh.i
+++ b/test/tests/neutronics/mesh_tally/one_mesh.i
@@ -43,7 +43,6 @@
   tally_type = mesh
   mesh_template = '../meshes/sphere.e'
   power = 100.0
-  check_tally_sum = false
   check_zero_tallies = false
 []
 


### PR DESCRIPTION
Right now, the default for whether we want to compare the local tally sum against a global tally is controlled by the `check_tally_sum` parameter (which always defaulted to true). When we set `normalize_by_global_tally = false`, though, we're probably doing so because we have mesh tallies that don't perfectly preserve the actual fission heat source (compared to curved CSG cells like spheres). So it makes sense to have a different default when `normalize_by_global_tally = false`.

This PR just changes the default, which I thought to do while writing these tutorials so that I could avoid explaining why we need to manually set `check_tally_sum = false` when it's already obvious we were never going to match the global tally b/c we set `normalize_by_global_tally = false`.