### PR TITLE
Review comments mesh tallies

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,14 @@ Cardinal will still build, run, and test fine without SAM.
 
 ### Fetch the Submodules
 
-First, fetch all the submodules containing the MOOSE, nekRS, OpenMC, and SAM dependencies. If you
-will *not* be using the SAM submodule within Cardinal, you will need to individually clone
-only the open-source submodules:
+First, fetch all the submodules containing the dependencies. Do *NOT* use this command:
+
+```
+$ git submodule update --init --recursive
+```
+
+unless you have access to SAM. SAM is an *optional* dependency in Cardinal, and if you do not
+have access to SAM, then you need to individually check out only the open-source submodules:
 
 ```
 $ git submodule update --init contrib/nekRS
@@ -68,7 +73,8 @@ If you are using SAM (which is an optional dependncy), you will then also need t
 $ git submodule update --init contrib/SAM
 ```
 
-You will be prompted for login credentials to ANL's xgitlab site. If you do not have credentials,
+You will be prompted for login credentials to ANL's
+`https://git-nse.egs.anl.gov` site. If you do not have credentials,
 you will need to contact the SAM development team to request access.
 
 ### Set the MPI Wrappers

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -876,21 +876,15 @@ OpenMCCellAverageProblem::initializeTallies()
       _console << "Adding mesh tally based on " << _mesh_template_filename << " at " <<
         Moose::stringify(_mesh_translations.size()) << " locations ... " << printNewline();
 
-      // find the highest mesh ID in the OpenMC problem in the event that there's other mesh
-      // tallies besides what is added here
-      int mesh_id = 0;
-      for (const auto & mesh : openmc::model::meshes)
-        mesh_id = std::max(mesh_id, mesh->id_);
-
-      // create a new mesh
+      // create a new mesh; by setting the ID to -1, OpenMC will automatically detect the
+      // next available ID
       auto mesh = std::make_unique<openmc::LibMesh>(_mesh_template_filename);
-      mesh->id_ = ++mesh_id;
+      mesh->set_id(-1);
       mesh->output_ = false;
 
-      _mesh_template = mesh.get();
-
       int32_t mesh_index = openmc::model::meshes.size();
-      openmc::model::mesh_map[mesh->id_] = mesh_index;
+
+      _mesh_template = mesh.get();
       openmc::model::meshes.push_back(std::move(mesh));
 
       for (unsigned int i = 0; i < _mesh_translations.size(); ++i)


### PR DESCRIPTION
This addresses the review comments for the closed (#94) mesh tally additions to `OpenMCCellAverageProblem`. 

I also added more instructions to the README, because it seems that everyone's default is to try to fetch all submodules as once (which is quite reasonable), which gives you confusing error messages if you don't have access to SAM.