### PR TITLE
Avoid overwrite of scratch space.

### DIFF
--- a/src/base/NekInterface.C
+++ b/src/base/NekInterface.C
@@ -619,12 +619,10 @@ void copyScratchToDevice()
   // to only copy the slices reserved for Cardinal, so that we don't accidentally overwrite other
   // parts of o_usrwrk (which from the order of the UDF calls, would always happen *after* the
   // flux and/or source transfers into nekRS)
-  mesh_t * mesh = temperatureMesh();
-  int n_gll = mesh->Nelements * mesh->Np;
 
   // first two slices are always reserved for the heat flux and volumetric heat source. Either one
   // or both will be present, but we always reserve the first two slices for this coupling data.
-  nrs->o_usrwrk.copyFrom(nrs->usrwrk, 2 * n_gll * sizeof(dfloat), 0);
+  nrs->o_usrwrk.copyFrom(nrs->usrwrk, 2 * scalarFieldOffset() * sizeof(dfloat), 0);
 }
 
 double sideMaxValue(const std::vector<int> & boundary_id, const field::NekFieldEnum & field)


### PR DESCRIPTION
Currently, all of the examples in Cardinal only use `nrs->o_usrwrk` to receive heat flux and/or volumetric heat source to be input to nekRS via boundary conditions or user source kernels. However, users may want to also use this scratch space for other boundary conditions - such as BCs for k and tau that might depend on a wall distance that is saved into `nrs->o_usrwrk`.

Right now, the `copyScratchToDevice` function is called *before* `UDF_ExecuteStep` (there's no changing this). What this causes, however, is for the entire `nrs->o_usrwrk` array to be overwritten by the coupling data from MOOSE. If the user is writing to some of the "slices" in `nrs->o_usrwrk` from the UDF file, _even if those fields aren't used for coupling_, they are overwritten with zeros in `copyScratchToDevice`.

We simply need to have Cardinal only update the "slices" in `nrs->o_usrwrk` that are actually used for coupling, and then let the user control the other slices from the UDF.