### PR TITLE
Automate addition of transfer_in postprocessor

### DIFF
--- a/include/base/NekRSProblem.h
+++ b/include/base/NekRSProblem.h
@@ -121,6 +121,9 @@ public:
 protected:
   std::unique_ptr<NumericVector<Number>> _serialized_solution;
 
+  /// Whether the problem is a moving mesh problem i.e. with on-the-fly mesh deformation enabled
+  const bool & _moving_mesh;
+
   /**
    * \brief Whether to only send heat flux to nekRS on the multiapp synchronization steps
    *
@@ -142,7 +145,7 @@ protected:
    * even bother computing the interpolated data, since it's not used if this parameter
    * is set to true.
    */
-  const bool & _minimize_transfers_in;
+  const bool _minimize_transfers_in;
 
   /**
    * \brief Whether to only send temperature from nekRS on the multiapp synchronization steps
@@ -169,9 +172,6 @@ protected:
 
   /// Whether the nekRS solution is performed in nondimensional scales
   const bool & _nondimensional;
-
-  /// Whether the problem is a moving mesh problem i.e. with on-the-fly mesh deformation enabled
-  const bool & _moving_mesh;
 
   //@{
   /**
@@ -298,9 +298,6 @@ protected:
 
   /// Number of points for interpolated fields (temperature, density) on the MOOSE mesh
   int _n_points;
-
-  /// Name of postprocessor containing signal of when a synchronization has occurred
-  const PostprocessorName * _transfer_in_name = nullptr;
 
   /// Postprocessor containing the signal of when a synchronization has occurred
   const PostprocessorValue * _transfer_in = nullptr;

--- a/test/tests/cht/sfr_pincell/nek.i
+++ b/test/tests/cht/sfr_pincell/nek.i
@@ -1,7 +1,6 @@
 [Problem]
   type = NekRSProblem
   minimize_transfers_in = true
-  transfer_in = synchronization_in
   minimize_transfers_out = true
 []
 
@@ -20,9 +19,6 @@
 []
 
 [Postprocessors]
-  [synchronization_in]
-    type = Receiver
-  []
   [nek_flux]
     type = NekHeatFluxIntegral
     boundary = '1'
@@ -236,6 +232,6 @@
 
   [screen]
     type = Console
-    hide = 'average_inlet_T average_outlet_T synchronization_in'
+    hide = 'average_inlet_T average_outlet_T transfer_in'
   []
 []

--- a/test/tests/cht/sfr_pincell/nek_master.i
+++ b/test/tests/cht/sfr_pincell/nek_master.i
@@ -98,7 +98,7 @@
   [synchronization_to_nek]
     type = MultiAppPostprocessorTransfer
     direction = to_multiapp
-    to_postprocessor = synchronization_in
+    to_postprocessor = transfer_in
     from_postprocessor = synchronization_to_nek
     multi_app = nek
   []

--- a/test/tests/conduction/nonidentical_interface/cylinders/nek_master_mini.i
+++ b/test/tests/conduction/nonidentical_interface/cylinders/nek_master_mini.i
@@ -106,7 +106,7 @@
   []
   [synchronization]
     type = MultiAppPostprocessorTransfer
-    to_postprocessor = synchronization_in
+    to_postprocessor = transfer_in
     direction = to_multiapp
     from_postprocessor = synchronization_in
     multi_app = nek

--- a/test/tests/conduction/nonidentical_interface/cylinders/nek_mini.i
+++ b/test/tests/conduction/nonidentical_interface/cylinders/nek_mini.i
@@ -1,7 +1,6 @@
 [Problem]
   type = NekRSProblem
   minimize_transfers_in = true
-  transfer_in = synchronization_in
   minimize_transfers_out = true
 []
 
@@ -28,9 +27,6 @@
     type = NekVolumeExtremeValue
     field = temperature
     value_type = min
-  []
-  [synchronization_in]
-    type = Receiver
   []
 []
 

--- a/test/tests/nek_errors/invalid_transfer_pp/nek.i
+++ b/test/tests/nek_errors/invalid_transfer_pp/nek.i
@@ -1,7 +1,6 @@
 [Problem]
   type = NekRSProblem
   minimize_transfers_in = true
-  transfer_in = synchronize_in
 []
 
 [Mesh]
@@ -14,12 +13,6 @@
 
   [TimeStepper]
     type = NekTimeStepper
-  []
-[]
-
-[Postprocessors]
-  [synchronize_in]
-    type = Receiver
   []
 []
 

--- a/test/tests/nek_errors/invalid_transfer_pp/nek_master.i
+++ b/test/tests/nek_errors/invalid_transfer_pp/nek_master.i
@@ -91,7 +91,7 @@
   []
   [synchronize]
     type = MultiAppPostprocessorTransfer
-    to_postprocessor = synchronize_in
+    to_postprocessor = transfer_in
     from_postprocessor = synchronize_in
     direction = to_multiapp
     multi_app = nek


### PR DESCRIPTION
This PR automatically adds the `transfer_in` postprocessor in NekApp when data transfers _to_ NekRS are only to occur on master app synchronization steps. This PR also automatically sets the correct setting for moving mesh problems to `minimize_transfers_in = true`.

Will update the problems repository after this is merged.

Closes #115