### PR TITLE
added call to save initial nekrs mesh for issue #119

### DIFF
--- a/src/base/NekRSProblem.C
+++ b/src/base/NekRSProblem.C
@@ -299,7 +299,7 @@ NekRSProblem::initialSetup()
   // nekRS calls UDF_ExecuteStep once before the time stepping begins
   nekrs::udfExecuteStep(_start_time, _t_step, false /* not an output step */);
 
-  // save initial mesh for moving mesh/deformation problems to match exodus output files
+  // save initial mesh for moving mesh problems to match deformation in exodus output files
   if (_moving_mesh)
     nekrs::outfld(_timestepper->nondimensionalDT(_time));
 }


### PR DESCRIPTION
This PR adds a call to save the initial nekrs mesh for moving mesh problems in `NekRSProblem::initialSetup()` so that the nekRS output and the MOOSE-wrapped nek app output match.