### PR TITLE
Remove redundant fixed_meshes parameter on NekRSMesh

### DIFF
--- a/include/base/NekRSProblem.h
+++ b/include/base/NekRSProblem.h
@@ -118,6 +118,12 @@ public:
    */
   virtual double minInterpolatedTemperature() const;
 
+  /**
+   * Whether the mesh is moving
+   * @return whether the mesh is moving
+   */
+  virtual bool movingMesh() const { return _moving_mesh; }
+
 protected:
   std::unique_ptr<NumericVector<Number>> _serialized_solution;
 

--- a/include/mesh/NekRSMesh.h
+++ b/include/mesh/NekRSMesh.h
@@ -187,12 +187,6 @@ public:
    */
   const Real & scaling() const { return _scaling; }
 
-  /**
-   * Whether the nekRS mesh is fixed in the simulation (not moving, no AMR)
-   * @return whether the mesh is fixed
-   */
-  virtual bool fixedMesh() const { return _fixed_meshes; }
-
   /// Print diagnostic information related to the mesh
   virtual void printMeshInfo() const;
 
@@ -209,14 +203,6 @@ protected:
    * volume-based coupling for the entire mesh.
    */
   const bool & _volume;
-
-  /**
-   * Whether the nekRS mesh is fixed (no mesh movement or adaptive mesh refinement)
-   *
-   * This setting can be used to indicate that volumes and areas used for normalizing
-   * the Nek postprocessors can be computed just once at the start of the simulation.
-   */
-  const bool & _fixed_meshes;
 
   /// Boundary ID(s) through which to couple Nek to MOOSE
   const std::vector<int> * _boundary;

--- a/src/mesh/NekRSMesh.C
+++ b/src/mesh/NekRSMesh.C
@@ -26,15 +26,13 @@ validParams<NekRSMesh>()
   params.addParam<bool>("volume", false, "Whether the nekRS volume will be coupled to MOOSE");
   params.addParam<MooseEnum>("order", getNekOrderEnum(), "Order of the mesh interpolation between nekRS and MOOSE");
   params.addRangeCheckedParam<Real>("scaling", 1.0, "scaling > 0.0", "Scaling factor to apply to the mesh");
-  params.addParam<bool>("fixed_meshes", false, "Whether the nekRS domain is fixed (no mesh movement "
-    "or adaptive mesh refinement) and some areas and volumes can be cached for postprocessors");
+  params.addClassDescription("Construct a mirror of the NekRS mesh in boundary and/or volume format");
   return params;
 }
 
 NekRSMesh::NekRSMesh(const InputParameters & parameters) :
   MooseMesh(parameters),
   _volume(getParam<bool>("volume")),
-  _fixed_meshes(getParam<bool>("fixed_meshes")),
   _boundary(isParamValid("boundary") ? &getParam<std::vector<int>>("boundary") : nullptr),
   _order(getParam<MooseEnum>("order").getEnum<order::NekOrderEnum>()),
   _scaling(getParam<Real>("scaling")),

--- a/src/postprocessors/NekPostprocessor.C
+++ b/src/postprocessors/NekPostprocessor.C
@@ -27,8 +27,9 @@ NekPostprocessor::NekPostprocessor(const InputParameters & parameters) :
   if (!_nek_problem)
     mooseError("Postprocessor with name '" + name() + "' can only be used with NekRSProblem!");
 
+  _fixed_mesh = !(_nek_problem->movingMesh());
+
   // NekRSProblem enforces that we then use NekRSMesh, so we don't need to check that
   // this pointer isn't NULL
   _nek_mesh = dynamic_cast<const NekRSMesh *>(&_mesh);
-  _fixed_mesh = _nek_mesh ? _nek_mesh->fixedMesh() : false;
 }

--- a/test/tests/postprocessors/nek_side_average/nek.i
+++ b/test/tests/postprocessors/nek_side_average/nek.i
@@ -5,7 +5,6 @@
 [Mesh]
   type = NekRSMesh
   boundary = '1 2 3 4 5 6 7 8'
-  fixed_mesh = true
 []
 
 [Executioner]

--- a/test/tests/postprocessors/nek_volume_average/nek.i
+++ b/test/tests/postprocessors/nek_volume_average/nek.i
@@ -5,7 +5,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  fixed_mesh = true
 []
 
 [Executioner]


### PR DESCRIPTION
When we added `moving_mesh` to NekRSProblem, we no longer need the `fixed_meshes` parameter on NekRSMesh, because they both indicate the same thing.