### PR TITLE
Add documentation for auxkernels. Refs #96

### DIFF
--- a/doc/content/source/auxkernels/CellDensityAux.md
+++ b/doc/content/source/auxkernels/CellDensityAux.md
@@ -1,0 +1,27 @@
+# CellDensityAux
+
+!syntax description /AuxKernels/CellDensityAux
+
+## Description
+
+Displays the OpenMC fluid density (kg/m$^3$) mapped to the MOOSE elements
+denoted as fluid by [OpenMCCellAverageProblem](/problems/OpenMCCellAverageProblem.md).
+In other words, this auxiliary kernel can be used to visualize the density that
+gets set on the OpenMC cells based on the MOOSE elements that map to each cell.
+
+If a MOOSE element is not fluid or did not map at all to an OpenMC cell,
+then this auxiliary kernel returns $-1$.
+
+## Example Input Syntax
+
+As an example, the `cell_density` auxiliary kernel will extract the OpenMC cell density
+and map it to the MOOSE elements corresponding to each OpenMC cell.
+
+!listing test/tests/neutronics/feedback/lattice/openmc.i
+  block=AuxKernels
+
+!syntax parameters /AuxKernels/CellDensityAux
+
+!syntax inputs /AuxKernels/CellDensityAux
+
+!syntax children /AuxKernels/CellDensityAux

--- a/doc/content/source/auxkernels/CellIDAux.md
+++ b/doc/content/source/auxkernels/CellIDAux.md
@@ -1,0 +1,30 @@
+# CellIDAux
+
+!syntax description /AuxKernels/CellIDAux
+
+## Description
+
+Displays the OpenMC cell ID mapped to the MOOSE elements.
+In other words, this auxiliary kernel can be used to visualize the cell that
+maps to each MOOSE element.
+
+If a MOOSE element did not map at all to an OpenMC cell,
+then this auxiliary kernel returns $-1$.
+
+## Example Input Syntax
+
+As an example, the `cell_id` auxiliary kernel will extract the OpenMC cell density
+and map it to the MOOSE elements corresponding to each OpenMC cell.
+
+!listing test/tests/neutronics/feedback/lattice/openmc.i
+  block=AuxKernels
+
+For this particular input, the OpenMC geometry repeats the same universe
+several times throughout the geometry; therefore, the same cell ID is repeated
+several times in the geometry.
+
+!syntax parameters /AuxKernels/CellIDAux
+
+!syntax inputs /AuxKernels/CellIDAux
+
+!syntax children /AuxKernels/CellIDAux

--- a/doc/content/source/auxkernels/CellInstanceAux.md
+++ b/doc/content/source/auxkernels/CellInstanceAux.md
@@ -1,0 +1,34 @@
+# CellInstanceAux
+
+!syntax description /AuxKernels/CellInstanceAux
+
+## Description
+
+Displays the OpenMC cell instance mapped to the MOOSE elements. If there are
+no distributed cells in your OpenMC geometry, then the instance for every cell
+is zero. But if you have distributed cells such as for problems with lattices
+or if you repeat the same universe multiple places throughout the geometry,
+then this auxiliary kernel
+can be used to visualize the cell instance that
+maps to each MOOSE element.
+
+If a MOOSE element did not map at all to an OpenMC cell,
+then this auxiliary kernel returns $-1$.
+
+## Example Input Syntax
+
+As an example, the `cell_instance` auxiliary kernel will extract the OpenMC cell instance
+and map it to the MOOSE elements corresponding to each OpenMC cell.
+
+!listing test/tests/neutronics/feedback/lattice/openmc.i
+  block=AuxKernels
+
+This particular OpenMC geometry repeats the same universe several times throughout
+the geometry, so the instance for a particular cell will range from 0 to $N-1$, where
+$N$ is the number of times the cell is repeated through the geometry.
+
+!syntax parameters /AuxKernels/CellInstanceAux
+
+!syntax inputs /AuxKernels/CellInstanceAux
+
+!syntax children /AuxKernels/CellInstanceAux

--- a/doc/content/source/auxkernels/CellMaterialIDAux.md
+++ b/doc/content/source/auxkernels/CellMaterialIDAux.md
@@ -1,0 +1,27 @@
+# CellMaterialIDAux
+
+!syntax description /AuxKernels/CellMaterialIDAux
+
+## Description
+
+Displays the OpenMC fluid material ID mapped to the MOOSE elements
+denoted as fluid by [OpenMCCellAverageProblem](/problems/OpenMCCellAverageProblem.md).
+In other words, this auxiliary kernel can be used to visualize the material ID that
+maps to each MOOSE element.
+
+If a MOOSE element is not fluid or did not map at all to an OpenMC cell,
+then this auxiliary kernel returns $-1$.
+
+## Example Input Syntax
+
+As an example, the `material_id` auxiliary kernel will extract the OpenMC material ID
+and map it to the MOOSE elements corresponding to each OpenMC cell.
+
+!listing test/tests/neutronics/feedback/lattice/openmc.i
+  block=AuxKernels
+
+!syntax parameters /AuxKernels/CellMaterialIDAux
+
+!syntax inputs /AuxKernels/CellMaterialIDAux
+
+!syntax children /AuxKernels/CellMaterialIDAux

--- a/doc/content/source/auxkernels/CellTemperatureAux.md
+++ b/doc/content/source/auxkernels/CellTemperatureAux.md
@@ -1,0 +1,35 @@
+# CellTemperatureAux
+
+!syntax description /AuxKernels/CellTemperatureAux
+
+## Description
+
+Displays the OpenMC cell temperature (K) mapped to the MOOSE elements.
+In other words, this auxiliary kernel can be used to visualize the temperature that
+gets set on the OpenMC cells based on the MOOSE elements that map to each cell.
+
+Note that this temperature is not necessarily the temperature at which cross
+sections are evaluated at - the `temperature_method` element in OpenMC's
+`settings.xml` file is either one of "nearest" or "interpolation". That is, if
+you have set the temperature method in OpenMC to nearest, then you will actually
+evaluate cross sections at the data set closest to the temperature shown by this
+auxiliary kernel. If you instead set the temperature method in OpenMC to interpolation,
+then you will actually evaluate cross sections as a stochastic interpolation
+between the two nearest data sets.
+
+If a MOOSE element did not map at all to an OpenMC cell,
+then this auxiliary kernel returns $-1$.
+
+## Example Input Syntax
+
+As an example, the `cell_temperature` auxiliary kernel will extract the OpenMC cell temperature
+and map it to the MOOSE elements corresponding to each OpenMC cell.
+
+!listing test/tests/neutronics/feedback/lattice/openmc.i
+  block=AuxKernels
+
+!syntax parameters /AuxKernels/CellTemperatureAux
+
+!syntax inputs /AuxKernels/CellTemperatureAux
+
+!syntax children /AuxKernels/CellTemperatureAux

--- a/src/auxkernels/CellTemperatureAux.C
+++ b/src/auxkernels/CellTemperatureAux.C
@@ -8,7 +8,7 @@ template<>
 InputParameters validParams<CellTemperatureAux>()
 {
   InputParameters params = validParams<OpenMCAuxKernel>();
-  params.addClassDescription("Display the OpenMC cell temperature at each MOOSE element");
+  params.addClassDescription("Display the OpenMC cell temperature (K) at each MOOSE element");
   return params;
 }
 


### PR DESCRIPTION
Adds documentation for the auxkernels. Compiled documentation for each auxkernel can be seen here: https://cardinal.cels.anl.gov/source/index.html