### PR TITLE
Rename NearestPointAverage in preparation for moving to MOOSE.

### DIFF
--- a/include/userobjects/CardinalNearestPointAverage.h
+++ b/include/userobjects/CardinalNearestPointAverage.h
@@ -14,21 +14,21 @@
 #include "ElementAverageValue.h"
 #include "ElementVariableVectorPostprocessor.h"
 // Forward Declarations
-class NearestPointAverage;
+class CardinalNearestPointAverage;
 
 template <>
-InputParameters validParams<NearestPointAverage>();
+InputParameters validParams<CardinalNearestPointAverage>();
 
 /**
  * Given a list of points this object computes the variable integral
  * closest to each one of those points.
  */
-class NearestPointAverage
+class CardinalNearestPointAverage
   : public NearestPointBase<ElementAverageValue,
                             ElementVariableVectorPostprocessor>
 {
 public:
-  NearestPointAverage(const InputParameters & parameters);
+  CardinalNearestPointAverage(const InputParameters & parameters);
 
   virtual Real spatialValue(const Point & point) const override;
 

--- a/src/userobjects/CardinalNearestPointAverage.C
+++ b/src/userobjects/CardinalNearestPointAverage.C
@@ -8,13 +8,13 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 // MOOSE includes
-#include "NearestPointAverage.h"
+#include "CardinalNearestPointAverage.h"
 
-registerMooseObject("MooseApp", NearestPointAverage);
+registerMooseObject("MooseApp", CardinalNearestPointAverage);
 
 template <>
 InputParameters
-validParams<NearestPointAverage>()
+validParams<CardinalNearestPointAverage>()
 {
   InputParameters params = nearestPointBaseValidParams<ElementAverageValue,
                                                        ElementVariableVectorPostprocessor>();
@@ -25,7 +25,7 @@ validParams<NearestPointAverage>()
   return params;
 }
 
-NearestPointAverage::NearestPointAverage(
+CardinalNearestPointAverage::CardinalNearestPointAverage(
     const InputParameters & parameters)
   : NearestPointBase<ElementAverageValue, ElementVariableVectorPostprocessor>(
         parameters),
@@ -35,7 +35,7 @@ NearestPointAverage::NearestPointAverage(
 }
 
 Real
-NearestPointAverage::spatialValue(const Point & point) const
+CardinalNearestPointAverage::spatialValue(const Point & point) const
 {
   unsigned int i = nearestPointIndex(point);
 
@@ -49,7 +49,7 @@ NearestPointAverage::spatialValue(const Point & point) const
 }
 
 Real
-NearestPointAverage::userObjectValue(unsigned int i) const
+CardinalNearestPointAverage::userObjectValue(unsigned int i) const
 {
   if (i >= _np_post_processor_values.size())
     mooseError("The vector length of vector post processor is ",
@@ -61,7 +61,7 @@ NearestPointAverage::userObjectValue(unsigned int i) const
 }
 
 void
-NearestPointAverage::finalize()
+CardinalNearestPointAverage::finalize()
 {
   if (_user_objects.size() != _np_post_processor_values.size())
     mooseError("The vector length of the vector postproessor ",
@@ -78,7 +78,7 @@ NearestPointAverage::finalize()
 }
 
 unsigned int
-NearestPointAverage::nearestPointIndex(const Point & p) const
+CardinalNearestPointAverage::nearestPointIndex(const Point & p) const
 {
   unsigned int closest = 0;
   Real closest_distance = std::numeric_limits<Real>::max();

--- a/test/tests/neutronics/solid/openmc_master.i
+++ b/test/tests/neutronics/solid/openmc_master.i
@@ -101,7 +101,7 @@ b=${fparse 300-1000/(zmax-zmin)*zmin}
 
 [UserObjects]
   [average_temp]
-    type = NearestPointAverage
+    type = CardinalNearestPointAverage
     variable = temp
     points_file = pebble_centers_rescaled.txt
     execute_on = 'initial timestep_end'

--- a/test/tests/neutronics/solid/openmc_master_zero.i
+++ b/test/tests/neutronics/solid/openmc_master_zero.i
@@ -98,7 +98,7 @@ b=${fparse 300-500/(zmax-zmin)*zmin}
 
 [UserObjects]
   [average_temp]
-    type = NearestPointAverage
+    type = CardinalNearestPointAverage
     variable = temp
     points_file = pebble_centers_rescaled.txt
     execute_on = 'initial timestep_end'

--- a/test/tests/neutronics/solid/zero_power.i
+++ b/test/tests/neutronics/solid/zero_power.i
@@ -97,7 +97,7 @@ b=${fparse 300-500/(zmax-zmin)*zmin}
 
 [UserObjects]
   [average_temp]
-    type = NearestPointAverage
+    type = CardinalNearestPointAverage
     variable = temp
     points_file = pebble_centers_rescaled.txt
     execute_on = 'initial timestep_end'

--- a/test/tests/transfers/nearest_point/master.i
+++ b/test/tests/transfers/nearest_point/master.i
@@ -74,7 +74,7 @@
 
 [UserObjects]
   [./average_f_master] # this computes the average that well send to sub
-    type = NearestPointAverage
+    type = CardinalNearestPointAverage
     variable = f
     points = '0 0 0
               4 0 0

--- a/test/tests/transfers/nearest_point/sub.i
+++ b/test/tests/transfers/nearest_point/sub.i
@@ -73,7 +73,7 @@
                  8 1 0'
   []
   [./average_g_sub] # This computes the average that will be transferred to master
-    type = NearestPointAverage
+    type = CardinalNearestPointAverage
     variable = g
     points = '0 0 0
               4 0 0


### PR DESCRIPTION
I'm moving NearestPointAverage into MOOSE since it's quite a general feature that I'd also like to leverage in Pronghorn. To avoid any issues with Cardinal causing the MOOSE PR to fail, I'm just temporarily renaming this transfer here.