### PR TITLE
Rename x_velocity, y_velocity, and z_velocity to velocity_x, etc.

### DIFF
--- a/doc/content/source/postprocessors/field_specs.md
+++ b/doc/content/source/postprocessors/field_specs.md
@@ -3,7 +3,7 @@ The field is specified with the `field` parameter, which may be one of:
 - `pressure`
 - `temperature`
 - `velocity` (magnitude of velocity)
-- `x_velocity`
-- `y_velocity`
-- `z_velocity`
+- `velocity_x` ($x$-component of velocity)
+- `velocity_y` ($y$-component of velocity)
+- `velocity_z` ($z$-component of velocity)
 - `unity`

--- a/include/base/CardinalEnums.h
+++ b/include/base/CardinalEnums.h
@@ -24,9 +24,9 @@ namespace field
   /// Enumeration of possible fields to read from nekRS
   enum NekFieldEnum
   {
-    x_velocity,
-    y_velocity,
-    z_velocity,
+    velocity_x,
+    velocity_y,
+    velocity_z,
     velocity,
     temperature,
     pressure,

--- a/include/base/NekInterface.h
+++ b/include/base/NekInterface.h
@@ -606,21 +606,21 @@ double unity(const int id);
  * @param[in] id GLL index
  * @return x-velocity at index
  */
-double x_velocity(const int id);
+double velocity_x(const int id);
 
 /**
  * Get the y-velocity at given GLL index
  * @param[in] id GLL index
  * @return y-velocity at index
  */
-double y_velocity(const int id);
+double velocity_y(const int id);
 
 /**
  * Get the z-velocity at given GLL index
  * @param[in] id GLL index
  * @return z-velocity at index
  */
-double z_velocity(const int id);
+double velocity_z(const int id);
 
 /**
  * Get the magnitude of the velocity solution at given GLL index

--- a/src/base/CardinalEnums.C
+++ b/src/base/CardinalEnums.C
@@ -7,7 +7,7 @@ MooseEnum getNekOrderEnum()
 
 MooseEnum getNekFieldEnum()
 {
-  return MooseEnum("x_velocity y_velocity z_velocity velocity temperature pressure unity");
+  return MooseEnum("velocity_x velocity_y velocity_z velocity temperature pressure unity");
 }
 
 MooseEnum getOperationEnum()

--- a/src/base/NekInterface.C
+++ b/src/base/NekInterface.C
@@ -1508,19 +1508,19 @@ namespace solution
     return 1.0;
   }
 
-  double x_velocity(const int id)
+  double velocity_x(const int id)
   {
     nrs_t * nrs = (nrs_t *) nrsPtr();
     return nrs->U[id + 0 * nrs->fieldOffset];
   }
 
-  double y_velocity(const int id)
+  double velocity_y(const int id)
   {
     nrs_t * nrs = (nrs_t *) nrsPtr();
     return nrs->U[id + 1 * nrs->fieldOffset];
   }
 
-  double z_velocity(const int id)
+  double velocity_z(const int id)
   {
     nrs_t * nrs = (nrs_t *) nrsPtr();
     return nrs->U[id + 2 * nrs->fieldOffset];
@@ -1573,14 +1573,14 @@ namespace solution
 
     switch (field)
     {
-      case field::x_velocity:
-        f = &solution::x_velocity;
+      case field::velocity_x:
+        f = &solution::velocity_x;
         break;
-      case field::y_velocity:
-        f = &solution::y_velocity;
+      case field::velocity_y:
+        f = &solution::velocity_y;
         break;
-      case field::z_velocity:
-        f = &solution::z_velocity;
+      case field::velocity_z:
+        f = &solution::velocity_z;
         break;
       case field::velocity:
         f = &solution::velocity;
@@ -1661,13 +1661,13 @@ namespace solution
   {
     switch (field)
     {
-      case field::x_velocity:
+      case field::velocity_x:
         value = value * scales.U_ref;
         break;
-      case field::y_velocity:
+      case field::velocity_y:
         value = value * scales.U_ref;
         break;
-      case field::z_velocity:
+      case field::velocity_z:
         value = value * scales.U_ref;
         break;
       case field::velocity:

--- a/src/postprocessors/NekMassFluxWeightedSideIntegral.C
+++ b/src/postprocessors/NekMassFluxWeightedSideIntegral.C
@@ -18,7 +18,7 @@ NekMassFluxWeightedSideIntegral::validParams()
 {
   InputParameters params = NekSidePostprocessor::validParams();
   params.addRequiredParam<MooseEnum>("field", getNekFieldEnum(),
-    "Field, multiplied by mass flux, to integrate; options: x_velocity, y_velocity, z_velocity, "
+    "Field, multiplied by mass flux, to integrate; options: velocity_x, velocity_y, velocity_z, "
     "velocity, temperature, pressure, unity");
   params.addClassDescription("Compute mass flux weighted integral of a field over a boundary of the NekRS mesh");
   return params;

--- a/src/postprocessors/NekSideExtremeValue.C
+++ b/src/postprocessors/NekSideExtremeValue.C
@@ -18,7 +18,7 @@ NekSideExtremeValue::validParams()
 {
   InputParameters params = NekSidePostprocessor::validParams();
   params.addRequiredParam<MooseEnum>("field", getNekFieldEnum(),
-    "Field to find the extreme value of; options: x_velocity, y_velocity, z_velocity, "
+    "Field to find the extreme value of; options: velocity_x, velocity_y, velocity_z, "
     "velocity, temperature, pressure, unity");
   params.addParam<MooseEnum>("value_type", getOperationEnum(),
     "Whether to give the maximum or minimum extreme value; options: 'max' (default), 'min'");

--- a/src/postprocessors/NekSideIntegral.C
+++ b/src/postprocessors/NekSideIntegral.C
@@ -18,7 +18,7 @@ NekSideIntegral::validParams()
 {
   InputParameters params = NekSidePostprocessor::validParams();
   params.addRequiredParam<MooseEnum>("field", getNekFieldEnum(), "Field to integrate;"
-    "options: x_velocity, y_velocity, z_velocity, "
+    "options: velocity_x, velocity_y, velocity_z, "
     "velocity, temperature, pressure, unity");
   params.addClassDescription("Compute the integral of a field over a boundary of the NekRS mesh");
   return params;

--- a/src/postprocessors/NekVolumeExtremeValue.C
+++ b/src/postprocessors/NekVolumeExtremeValue.C
@@ -19,7 +19,7 @@ NekVolumeExtremeValue::validParams()
 {
   InputParameters params = NekPostprocessor::validParams();
   params.addRequiredParam<MooseEnum>("field", getNekFieldEnum(), "Field to find the extreme value of; "
-    "options: x_velocity, y_velocity, z_velocity, "
+    "options: velocity_x, velocity_y, velocity_z, "
     "velocity, temperature, pressure, unity");
   params.addParam<MooseEnum>("value_type", getOperationEnum(),
     "Whether to give the maximum or minimum extreme value; options: 'max' (default), 'min'");

--- a/src/postprocessors/NekVolumeIntegral.C
+++ b/src/postprocessors/NekVolumeIntegral.C
@@ -18,7 +18,7 @@ NekVolumeIntegral::validParams()
 {
   InputParameters params = NekPostprocessor::validParams();
   params.addRequiredParam<MooseEnum>("field", getNekFieldEnum(), "Field to integrate; "
-    "options: x_velocity, y_velocity, z_velocity, "
+    "options: velocity_x, velocity_y, velocity_z, "
     "velocity, temperature, pressure, unity");
   params.addClassDescription("Compute the integral of a field over the NekRS mesh");
   return params;

--- a/test/tests/postprocessors/nek_side_average/nek.i
+++ b/test/tests/postprocessors/nek_side_average/nek.i
@@ -147,122 +147,122 @@
   []
   [x_velocity_avg1]
     type = NekSideAverage
-    field = x_velocity
+    field = velocity_x
     boundary = '1'
   []
   [x_velocity_avg2]
     type = NekSideAverage
-    field = x_velocity
+    field = velocity_x
     boundary = '2'
   []
   [x_velocity_avg3]
     type = NekSideAverage
-    field = x_velocity
+    field = velocity_x
     boundary = '3'
   []
   [x_velocity_avg4]
     type = NekSideAverage
-    field = x_velocity
+    field = velocity_x
     boundary = '4'
   []
   [x_velocity_avg5]
     type = NekSideAverage
-    field = x_velocity
+    field = velocity_x
     boundary = '5'
   []
   [x_velocity_avg6]
     type = NekSideAverage
-    field = x_velocity
+    field = velocity_x
     boundary = '6'
   []
   [x_velocity_avg7]
     type = NekSideAverage
-    field = x_velocity
+    field = velocity_x
     boundary = '7'
   []
   [x_velocity_avg8]
     type = NekSideAverage
-    field = x_velocity
+    field = velocity_x
     boundary = '8'
   []
   [y_velocity_avg1]
     type = NekSideAverage
-    field = y_velocity
+    field = velocity_y
     boundary = '1'
   []
   [y_velocity_avg2]
     type = NekSideAverage
-    field = y_velocity
+    field = velocity_y
     boundary = '2'
   []
   [y_velocity_avg3]
     type = NekSideAverage
-    field = y_velocity
+    field = velocity_y
     boundary = '3'
   []
   [y_velocity_avg4]
     type = NekSideAverage
-    field = y_velocity
+    field = velocity_y
     boundary = '4'
   []
   [y_velocity_avg5]
     type = NekSideAverage
-    field = y_velocity
+    field = velocity_y
     boundary = '5'
   []
   [y_velocity_avg6]
     type = NekSideAverage
-    field = y_velocity
+    field = velocity_y
     boundary = '6'
   []
   [y_velocity_avg7]
     type = NekSideAverage
-    field = y_velocity
+    field = velocity_y
     boundary = '7'
   []
   [y_velocity_avg8]
     type = NekSideAverage
-    field = y_velocity
+    field = velocity_y
     boundary = '8'
   []
   [z_velocity_avg1]
     type = NekSideAverage
-    field = z_velocity
+    field = velocity_z
     boundary = '1'
   []
   [z_velocity_avg2]
     type = NekSideAverage
-    field = z_velocity
+    field = velocity_z
     boundary = '2'
   []
   [z_velocity_avg3]
     type = NekSideAverage
-    field = z_velocity
+    field = velocity_z
     boundary = '3'
   []
   [z_velocity_avg4]
     type = NekSideAverage
-    field = z_velocity
+    field = velocity_z
     boundary = '4'
   []
   [z_velocity_avg5]
     type = NekSideAverage
-    field = z_velocity
+    field = velocity_z
     boundary = '5'
   []
   [z_velocity_avg6]
     type = NekSideAverage
-    field = z_velocity
+    field = velocity_z
     boundary = '6'
   []
   [z_velocity_avg7]
     type = NekSideAverage
-    field = z_velocity
+    field = velocity_z
     boundary = '7'
   []
   [z_velocity_avg8]
     type = NekSideAverage
-    field = z_velocity
+    field = velocity_z
     boundary = '8'
   []
 []

--- a/test/tests/postprocessors/nek_side_extrema/nek.i
+++ b/test/tests/postprocessors/nek_side_extrema/nek.i
@@ -310,289 +310,289 @@
 
   [max_x_velocity_side1]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '1'
     value_type = max
   []
   [max_x_velocity_side2]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '2'
     value_type = max
   []
   [max_x_velocity_side3]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '3'
     value_type = max
   []
   [max_x_velocity_side4]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '4'
     value_type = max
   []
   [max_x_velocity_side5]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '5'
     value_type = max
   []
   [max_x_velocity_side6]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '6'
     value_type = max
   []
   [max_x_velocity_side7]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '7'
     value_type = max
   []
   [max_x_velocity_side8]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '8'
     value_type = max
   []
   [min_x_velocity_side1]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '1'
     value_type = min
   []
   [min_x_velocity_side2]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '2'
     value_type = min
   []
   [min_x_velocity_side3]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '3'
     value_type = min
   []
   [min_x_velocity_side4]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '4'
     value_type = min
   []
   [min_x_velocity_side5]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '5'
     value_type = min
   []
   [min_x_velocity_side6]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '6'
     value_type = min
   []
   [min_x_velocity_side7]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '7'
     value_type = min
   []
   [min_x_velocity_side8]
     type = NekSideExtremeValue
-    field = x_velocity
+    field = velocity_x
     boundary = '8'
     value_type = min
   []
   [max_y_velocity_side1]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '1'
     value_type = max
   []
   [max_y_velocity_side2]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '2'
     value_type = max
   []
   [max_y_velocity_side3]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '3'
     value_type = max
   []
   [max_y_velocity_side4]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '4'
     value_type = max
   []
   [max_y_velocity_side5]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '5'
     value_type = max
   []
   [max_y_velocity_side6]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '6'
     value_type = max
   []
   [max_y_velocity_side7]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '7'
     value_type = max
   []
   [max_y_velocity_side8]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '8'
     value_type = max
   []
   [min_y_velocity_side1]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '1'
     value_type = min
   []
   [min_y_velocity_side2]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '2'
     value_type = min
   []
   [min_y_velocity_side3]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '3'
     value_type = min
   []
   [min_y_velocity_side4]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '4'
     value_type = min
   []
   [min_y_velocity_side5]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '5'
     value_type = min
   []
   [min_y_velocity_side6]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '6'
     value_type = min
   []
   [min_y_velocity_side7]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '7'
     value_type = min
   []
   [min_y_velocity_side8]
     type = NekSideExtremeValue
-    field = y_velocity
+    field = velocity_y
     boundary = '8'
     value_type = min
   []
   [max_z_velocity_side1]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '1'
     value_type = max
   []
   [max_z_velocity_side2]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '2'
     value_type = max
   []
   [max_z_velocity_side3]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '3'
     value_type = max
   []
   [max_z_velocity_side4]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '4'
     value_type = max
   []
   [max_z_velocity_side5]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '5'
     value_type = max
   []
   [max_z_velocity_side6]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '6'
     value_type = max
   []
   [max_z_velocity_side7]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '7'
     value_type = max
   []
   [max_z_velocity_side8]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '8'
     value_type = max
   []
   [min_z_velocity_side1]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '1'
     value_type = min
   []
   [min_z_velocity_side2]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '2'
     value_type = min
   []
   [min_z_velocity_side3]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '3'
     value_type = min
   []
   [min_z_velocity_side4]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '4'
     value_type = min
   []
   [min_z_velocity_side5]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '5'
     value_type = min
   []
   [min_z_velocity_side6]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '6'
     value_type = min
   []
   [min_z_velocity_side7]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '7'
     value_type = min
   []
   [min_z_velocity_side8]
     type = NekSideExtremeValue
-    field = z_velocity
+    field = velocity_z
     boundary = '8'
     value_type = min
   []

--- a/test/tests/postprocessors/nek_volume_average/nek.i
+++ b/test/tests/postprocessors/nek_volume_average/nek.i
@@ -38,14 +38,14 @@
   []
   [x_velocity_average]
     type = NekVolumeAverage
-    field = x_velocity
+    field = velocity_x
   []
   [y_velocity_average]
     type = NekVolumeAverage
-    field = y_velocity
+    field = velocity_y
   []
   [z_velocity_average]
     type = NekVolumeAverage
-    field = z_velocity
+    field = velocity_z
   []
 []

--- a/test/tests/postprocessors/nek_volume_extrema/nek.i
+++ b/test/tests/postprocessors/nek_volume_extrema/nek.i
@@ -57,32 +57,32 @@
   []
   [max_x_velocity]
     type = NekVolumeExtremeValue
-    field = x_velocity
+    field = velocity_x
     value_type = max
   []
   [min_x_velocity]
     type = NekVolumeExtremeValue
-    field = x_velocity
+    field = velocity_x
     value_type = min
   []
   [max_y_velocity]
     type = NekVolumeExtremeValue
-    field = y_velocity
+    field = velocity_y
     value_type = max
   []
   [min_y_velocity]
     type = NekVolumeExtremeValue
-    field = y_velocity
+    field = velocity_y
     value_type = min
   []
   [max_z_velocity]
     type = NekVolumeExtremeValue
-    field = z_velocity
+    field = velocity_z
     value_type = max
   []
   [min_z_velocity]
     type = NekVolumeExtremeValue
-    field = z_velocity
+    field = velocity_z
     value_type = min
   []
 []


### PR DESCRIPTION
This PR simply renames the enumeration values for velocity components when used in the various Nek-style postprocessors. 

For #95, we want the user to be able to extract the velocity components from NekRS onto the MOOSE mesh mirror. Paraview will automatically combine three vector components together if they are named `name_x`, `name_y`, and `name_z`, so we will want to name the velocity components extracted from NekRS to `velocity_x`, `velocity_y`, and `velocity_z`. However, when we made the velocity postprocessors, we named the `field` corresponding to the velocity components as `x_velocity`, etc. This PR simply increases the uniformity among these names by renaming the `field` for the velocity postprocessors so that there is less potential for user confusion.

Anyone who happens to be using these postprocessors will get an error from MOOSE telling them how to update to the latest enum keys.