### PR TITLE
Use conservative transfers for OpenMC wrapping. 

### DIFF
--- a/test/tests/neutronics/feedback/different_units/openmc_master.i
+++ b/test/tests/neutronics/feedback/different_units/openmc_master.i
@@ -87,6 +87,9 @@
 []
 
 [Transfers]
+
+  # For illustration, this cases uses a copy transfer because we use exactly the
+  # same mesh and quadrature order as in the coupled OpenMC wrapping
   [heat_source_from_openmc]
     type = MultiAppCopyTransfer
     direction = from_multiapp

--- a/test/tests/neutronics/feedback/lattice/openmc.i
+++ b/test/tests/neutronics/feedback/lattice/openmc.i
@@ -67,15 +67,6 @@
 
 [Executioner]
   type = Transient
-
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
-  [Quadrature]
-    type = GAUSS
-    order = THIRD
-  []
 []
 
 [Postprocessors]

--- a/test/tests/neutronics/feedback/lattice/openmc_master.i
+++ b/test/tests/neutronics/feedback/lattice/openmc_master.i
@@ -113,6 +113,7 @@
 
 [Outputs]
   exodus = true
+  hide = 'source_integral'
 []
 
 [MultiApps]
@@ -126,11 +127,13 @@
 
 [Transfers]
   [heat_source_from_openmc]
-    type = MultiAppCopyTransfer
+    type = MultiAppMeshFunctionTransfer
     direction = from_multiapp
     multi_app = openmc
     variable = heat_source
     source_variable = heat_source
+    from_postprocessors_to_be_preserved = heat_source
+    to_postprocessors_to_be_preserved = source_integral
   []
   [temp_to_openmc]
     type = MultiAppMeshFunctionTransfer
@@ -145,5 +148,13 @@
     multi_app = openmc
     variable = density
     source_variable = density
+  []
+[]
+
+[Postprocessors]
+  [source_integral]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+    execute_on = transfer
   []
 []

--- a/test/tests/neutronics/feedback/single_level/openmc.i
+++ b/test/tests/neutronics/feedback/single_level/openmc.i
@@ -67,15 +67,6 @@
 
 [Executioner]
   type = Transient
-
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
-  [Quadrature]
-    type = GAUSS
-    order = THIRD
-  []
 []
 
 [Postprocessors]

--- a/test/tests/neutronics/feedback/single_level/openmc_master.i
+++ b/test/tests/neutronics/feedback/single_level/openmc_master.i
@@ -113,6 +113,7 @@
 
 [Outputs]
   exodus = true
+  hide = 'source_integral'
 []
 
 [MultiApps]
@@ -126,11 +127,13 @@
 
 [Transfers]
   [heat_source_from_openmc]
-    type = MultiAppCopyTransfer
+    type = MultiAppMeshFunctionTransfer
     direction = from_multiapp
     multi_app = openmc
     variable = heat_source
     source_variable = heat_source
+    from_postprocessors_to_be_preserved = heat_source
+    to_postprocessors_to_be_preserved = source_integral
   []
   [temp_to_openmc]
     type = MultiAppMeshFunctionTransfer
@@ -145,5 +148,13 @@
     multi_app = openmc
     variable = density
     source_variable = density
+  []
+[]
+
+[Postprocessors]
+  [source_integral]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+    execute_on = transfer
   []
 []

--- a/test/tests/neutronics/feedback/unmapped_moose/openmc.i
+++ b/test/tests/neutronics/feedback/unmapped_moose/openmc.i
@@ -76,15 +76,6 @@
 
 [Executioner]
   type = Transient
-
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
-  [Quadrature]
-    type = GAUSS
-    order = THIRD
-  []
 []
 
 [Postprocessors]

--- a/test/tests/neutronics/feedback/unmapped_moose/openmc_master.i
+++ b/test/tests/neutronics/feedback/unmapped_moose/openmc_master.i
@@ -126,6 +126,7 @@
 
 [Outputs]
   exodus = true
+  hide = 'source_integral'
 []
 
 [MultiApps]
@@ -139,11 +140,13 @@
 
 [Transfers]
   [heat_source_from_openmc]
-    type = MultiAppCopyTransfer
+    type = MultiAppMeshFunctionTransfer
     direction = from_multiapp
     multi_app = openmc
     variable = heat_source
     source_variable = heat_source
+    from_postprocessors_to_be_preserved = heat_source
+    to_postprocessors_to_be_preserved = source_integral
   []
   [temp_to_openmc]
     type = MultiAppMeshFunctionTransfer
@@ -158,5 +161,13 @@
     multi_app = openmc
     variable = density
     source_variable = density
+  []
+[]
+
+[Postprocessors]
+  [source_integral]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+    execute_on = transfer
   []
 []

--- a/test/tests/neutronics/heat_source/default_tally_blocks.i
+++ b/test/tests/neutronics/heat_source/default_tally_blocks.i
@@ -67,10 +67,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/neutronics/heat_source/distrib_cell/solid.i
+++ b/test/tests/neutronics/heat_source/distrib_cell/solid.i
@@ -70,10 +70,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/neutronics/heat_source/distrib_cell/warn_zero_tallies.i
+++ b/test/tests/neutronics/heat_source/distrib_cell/warn_zero_tallies.i
@@ -70,10 +70,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/neutronics/heat_source/overlap_all.i
+++ b/test/tests/neutronics/heat_source/overlap_all.i
@@ -68,10 +68,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/neutronics/heat_source/overlap_fluid.i
+++ b/test/tests/neutronics/heat_source/overlap_fluid.i
@@ -77,10 +77,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/neutronics/heat_source/overlap_solid.i
+++ b/test/tests/neutronics/heat_source/overlap_solid.i
@@ -77,10 +77,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/neutronics/heat_source/partial_overlap_moose_union.i
+++ b/test/tests/neutronics/heat_source/partial_overlap_moose_union.i
@@ -73,10 +73,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/neutronics/heat_source/partial_overlap_openmc_union.i
+++ b/test/tests/neutronics/heat_source/partial_overlap_openmc_union.i
@@ -75,10 +75,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/neutronics/mesh_tally/different_units.i
+++ b/test/tests/neutronics/mesh_tally/different_units.i
@@ -56,10 +56,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/neutronics/mesh_tally/multiple_meshes.i
+++ b/test/tests/neutronics/mesh_tally/multiple_meshes.i
@@ -74,10 +74,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/neutronics/mesh_tally/multiple_meshes_global.i
+++ b/test/tests/neutronics/mesh_tally/multiple_meshes_global.i
@@ -74,10 +74,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/neutronics/mesh_tally/one_mesh.i
+++ b/test/tests/neutronics/mesh_tally/one_mesh.i
@@ -50,10 +50,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/neutronics/mesh_tally/one_mesh_global.i
+++ b/test/tests/neutronics/mesh_tally/one_mesh_global.i
@@ -46,10 +46,11 @@
   type = Transient
   num_steps = 1
 
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
+  # The quadrature rule used for integrating in 'heat_source' postprocessor
+  # doesnt match the order for the problem if theres no nonlinear variables,
+  # so we set the quadrature order here manually. Normally, OpenMCs heat source
+  # is sent to another MOOSE app, which via a conservative transfer can be used
+  # to ensure conservation.
   [Quadrature]
     type = GAUSS
     order = THIRD

--- a/test/tests/openmc_errors/densities/zero_density.i
+++ b/test/tests/openmc_errors/densities/zero_density.i
@@ -48,11 +48,6 @@
 [Executioner]
   type = Transient
   num_steps = 1
-
-  [Quadrature]
-    type = GAUSS
-    order = THIRD
-  []
 []
 
 [Outputs]

--- a/test/tests/openmc_errors/mesh_tally/incorrect_file.i
+++ b/test/tests/openmc_errors/mesh_tally/incorrect_file.i
@@ -46,15 +46,6 @@
 [Executioner]
   type = Transient
   num_steps = 1
-
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
-  [Quadrature]
-    type = GAUSS
-    order = THIRD
-  []
 []
 
 [Postprocessors]

--- a/test/tests/openmc_errors/mesh_tally/incorrect_order.i
+++ b/test/tests/openmc_errors/mesh_tally/incorrect_order.i
@@ -58,15 +58,6 @@
 [Executioner]
   type = Transient
   num_steps = 1
-
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
-  [Quadrature]
-    type = GAUSS
-    order = THIRD
-  []
 []
 
 [Postprocessors]

--- a/test/tests/openmc_errors/mesh_tally/incorrect_scaling.i
+++ b/test/tests/openmc_errors/mesh_tally/incorrect_scaling.i
@@ -49,15 +49,6 @@
 [Executioner]
   type = Transient
   num_steps = 1
-
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
-  [Quadrature]
-    type = GAUSS
-    order = THIRD
-  []
 []
 
 [Postprocessors]

--- a/test/tests/openmc_errors/tallies/zero_tallies.i
+++ b/test/tests/openmc_errors/tallies/zero_tallies.i
@@ -67,15 +67,6 @@
 [Executioner]
   type = Transient
   num_steps = 1
-
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
-  [Quadrature]
-    type = GAUSS
-    order = THIRD
-  []
 []
 
 [Postprocessors]

--- a/test/tests/openmc_errors/xs_temperatures/interpolation_max.i
+++ b/test/tests/openmc_errors/xs_temperatures/interpolation_max.i
@@ -51,11 +51,6 @@
 [Executioner]
   type = Transient
   num_steps = 1
-
-  [Quadrature]
-    type = GAUSS
-    order = THIRD
-  []
 []
 
 [Outputs]

--- a/test/tests/openmc_errors/xs_temperatures/interpolation_min.i
+++ b/test/tests/openmc_errors/xs_temperatures/interpolation_min.i
@@ -51,11 +51,6 @@
 [Executioner]
   type = Transient
   num_steps = 1
-
-  [Quadrature]
-    type = GAUSS
-    order = THIRD
-  []
 []
 
 [Outputs]

--- a/test/tests/postprocessors/eigenvalue/openmc.i
+++ b/test/tests/postprocessors/eigenvalue/openmc.i
@@ -52,15 +52,6 @@
 [Executioner]
   type = Transient
   num_steps = 1
-
-  # we need this to match the quadrature used in the receiving MOOSE app
-  # (does not exist in this input file) so that the elem->volume() computed
-  # for normalization within OpenMCCellAverageProblem is the same as in the
-  # receiving MOOSE app.
-  [Quadrature]
-    type = GAUSS
-    order = THIRD
-  []
 []
 
 [Postprocessors]


### PR DESCRIPTION
This PR adjusts the OpenMC transfers to use a conservative transfer (which preserves heat source) without having to manually set the right quadrature rule. This is a bit simpler and easier to describe from the perspective of documentation.

Closes #112