### PR TITLE
Reset OpenMC timers after each Picard iteration.

### DIFF
--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1030,6 +1030,10 @@ void OpenMCCellAverageProblem::externalSolve()
   int err = openmc_run();
   if (err)
     mooseError(openmc_err_msg);
+
+  err = openmc_reset_timers();
+  if (err)
+    mooseError(openmc_err_msg);
 }
 
 void

--- a/src/base/OpenMCProblem.C
+++ b/src/base/OpenMCProblem.C
@@ -326,6 +326,9 @@ void OpenMCProblem::externalSolve()
 {
   int err = openmc_run();
   if (err) openmc::fatal_error(openmc_err_msg);
+
+  err = openmc_reset_timers();
+  if (err) openmc::fatal_error(openmc_err_msg);
 }
 
 void OpenMCProblem::syncSolutions(ExternalProblem::Direction direction)


### PR DESCRIPTION
As discovered by @RonRahaman, we need to explicitly reset OpenMC's timers after each Picard iteration, or else the timing estimates for OpenMC are inaccurate. 