### PR TITLE
fixes small typo in start.md of documentation

### DIFF
--- a/doc/content/start.md
+++ b/doc/content/start.md
@@ -159,7 +159,7 @@ Because we need to download this test suite when we run our regression tests, yo
 also quickly get this cross section data set by running
 
 ```
-$ ./scripts/download_openmc_cross_sections.sh
+$ ./scripts/download-openmc-cross-sections.sh
 ```
 
 Alternatively, if you would prefer other libraries, please visit the


### PR DESCRIPTION
In the `Required Submodules` section, changes the third command to update the nekRS submodule, instead of updating the moose submodule again.
The text should change from
```
$ git submodule update --init contrib/moose
$ git submodule update --init --recursive contrib/openmc
$ git submodule update --init contrib/moose
```
to
```
$ git submodule update --init contrib/moose
$ git submodule update --init --recursive contrib/openmc
$ git submodule update --init contrib/nekRS
```