### PR TITLE
Allow PETSC_ARCH to not be set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,11 @@ ADDITIONAL_CPPFLAGS := $(HDF5_INCLUDES) $(OPENMC_INCLUDES) $(NEKRS_INCLUDES)
 # ======================================================================================
 
 # Use compiler info discovered by PETSC
-include $(PETSC_DIR)/$(PETSC_ARCH)/lib/petsc/conf/petscvariables
+ifeq ($(PETSC_ARCH),)
+	include $(PETSC_DIR)/$(PETSC_ARCH)/lib/petsc/conf/petscvariables
+else
+	include $(PETSC_DIR)/lib/petsc/conf/petscvariables
+endif
 
 # ======================================================================================
 # MOOSE core objects


### PR DESCRIPTION
Some PETSc installations do not use PETSC_ARCH, thus cardinal would not build.
This enables builds against such PETSc installations.