### PR TITLE
Remove troublesome test that is covered elsewhere anyways. Refs #214

### DIFF
--- a/test/tests/nek_standalone/ktauChannel/tests
+++ b/test/tests/nek_standalone/ktauChannel/tests
@@ -1,9 +1,0 @@
-[Tests]
-  [volume]
-    type = RunApp
-    input = nek.i
-    min_parallel = 4
-    requirement = "Cardinal shall be able to run the ktauChannel NekRS example with a thin wrapper "
-                  "when using a volume mesh mirror. "
-  []
-[]


### PR DESCRIPTION
Removes the testing for the `ktauChannel` case - it always fails on CIVET for some reason (but does run locally fine). There is a tutorial anyways that covers this capability.

Closes #214