### PR TITLE
Allow all output from NekRS to be turned off.

### DIFF
--- a/include/base/NekRSProblemBase.h
+++ b/include/base/NekRSProblemBase.h
@@ -161,6 +161,9 @@ protected:
    */
   const bool & _write_fld_files;
 
+  /// Whether to turn off all field file writing
+  const bool & _disable_fld_file_output;
+
   /// Number of surface elements in the data transfer mesh, across all processes
   int _n_surface_elems;
 

--- a/src/base/NekRSProblem.C
+++ b/src/base/NekRSProblem.C
@@ -189,7 +189,7 @@ NekRSProblem::initialSetup()
   }
 
   // save initial mesh for moving mesh problems to match deformation in exodus output files
-  if (_moving_mesh)
+  if (_moving_mesh && !_disable_fld_file_output)
     nekrs::outfld(_timestepper->nondimensionalDT(_time));
 }
 


### PR DESCRIPTION
Sometimes if you are just postprocessing, you don't want to have the wrapping write any output files. This adds an option to turn all the output writing from Nek off.