### PR TITLE
Re-add ktauChannel test after adding missing file

### DIFF
--- a/test/tests/nek_standalone/ktauChannel/channel.usr
+++ b/test/tests/nek_standalone/ktauChannel/channel.usr
@@ -1,0 +1,1 @@
+../../../../contrib/nekRS/examples/ktauChannel/channel.usr

--- a/test/tests/nek_standalone/ktauChannel/tests
+++ b/test/tests/nek_standalone/ktauChannel/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [volume]
+    type = RunApp
+    input = nek.i
+    min_parallel = 4
+    requirement = "Cardinal shall be able to run the ktauChannel NekRS example with a thin wrapper "
+                  "when using a volume mesh mirror. "
+  []
+[]


### PR DESCRIPTION
I discovered that a test file was accidentally never committed, which would explain why these tests worked locally for me but not on CIVET. Adding to see if that file fixes the random failure issue.