### PR TITLE
Protect against bin postprocessors with a non-dimensional temperature.

### DIFF
--- a/include/userobjects/NekUserObject.h
+++ b/include/userobjects/NekUserObject.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ThreadedGeneralUserObject.h"
+#include "NekRSProblemBase.h"
 #include "CardinalEnums.h"
 
 /**
@@ -26,4 +27,8 @@ public:
    * @param[in] field field
    */
   virtual void checkValidField(const field::NekFieldEnum & field) const;
+
+protected:
+  /// Underlying problem object
+  const NekRSProblemBase * _nek_problem;
 };

--- a/src/userobjects/NekSpatialBinUserObject.C
+++ b/src/userobjects/NekSpatialBinUserObject.C
@@ -20,6 +20,10 @@ NekSpatialBinUserObject::NekSpatialBinUserObject(const InputParameters & paramet
     _field(getParam<MooseEnum>("field").getEnum<field::NekFieldEnum>()),
     _map_space_by_qp(getParam<bool>("map_space_by_qp"))
 {
+  if (_nek_problem->nondimensional() && _field == field::temperature)
+    mooseError("Spatial bin user objects are not yet available for non-dimensional solutions with temperature! "
+      "Please change your MOOSE-wrapped input file to be in the same non-dimensional units as your NekRS case.");
+
   if (_bin_names.size() == 0)
     paramError("bins", "Length of vector must be greater than zero!");
 

--- a/src/userobjects/NekUserObject.C
+++ b/src/userobjects/NekUserObject.C
@@ -1,5 +1,4 @@
 #include "NekUserObject.h"
-#include "NekRSProblemBase.h"
 
 InputParameters
 NekUserObject::validParams()
@@ -11,8 +10,8 @@ NekUserObject::validParams()
 NekUserObject::NekUserObject(const InputParameters & parameters)
   : ThreadedGeneralUserObject(parameters)
 {
-  const NekRSProblemBase * nek_problem = dynamic_cast<const NekRSProblemBase *>(&_fe_problem);
-  if (!nek_problem)
+  _nek_problem = dynamic_cast<const NekRSProblemBase *>(&_fe_problem);
+  if (!_nek_problem)
   {
     std::string extra_help = _fe_problem.type() == "FEProblem" ? " (the default)" : "";
     mooseError("UserObject with name '" + name() + "' can only be used with wrapped Nek cases!\n"


### PR DESCRIPTION
The dimensionalization process for the spatially binned volume integrals and averages currently dimensionalizes based on the volume of the entire mesh - up until now, this has been okay for the `NekVolumeAverage`/`NekVolumeIntegral` postprocessors, but this will actually give incorrect results with the spatially-binned integrals for which the bin volume is different from the total mesh volume. 

Until I figure out a way around this, add an error to make sure no one tries to use this.