### PR TITLE
Skip mesh duplication for first-order mesh mirrors.

### DIFF
--- a/include/base/NekInterface.h
+++ b/include/base/NekInterface.h
@@ -164,6 +164,13 @@ bool hasTemperatureSolve();
 bool hasHeatSourceKernel();
 
 /**
+ * Get the corner indices for each element
+ * @param[in] n order of mesh (0 = first-order, 1 = second-order)
+ * @return corner indices of the HEX20 elements
+ */
+std::vector<int> cornerGLLIndices(const int & n);
+
+/**
  * Whether the scratch space has already been allocated by the user
  * @return whether scratch space is already allocated
  */

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -811,6 +811,9 @@ protected:
   /// Material-type cells contained within a cell
   std::map<cellInfo, containedCells> _cell_to_contained_material_cells;
 
+  /// Number of material-type cells contained within a cell
+  std::map<cellInfo, int32_t> _cell_to_n_contained;
+
   /// OpenMC cells to which a kappa fission tally is to be added
   std::vector<cellInfo> _tally_cells;
 


### PR DESCRIPTION
For very large meshes, my cases on Bebop are crashing during the call to `createMesh`, possibly due to memory. We don't technically need to call this function, because we already have all the necessary information, for first order meshes at least.

This PR simply replaces the function call by explicit usage of existing mesh info.