### PR TITLE
Add check that non-material filled cells are fissile for adding tallies

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -769,6 +769,9 @@ protected:
    */
   std::vector<coupling::CouplingFields> _elem_phase {};
 
+  /// Maximum number of contained cells in the coupling
+  int _max_n_contained;
+
   /// Number of solid elements in the MOOSE mesh
   int _n_moose_solid_elems;
 

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -500,7 +500,7 @@ protected:
    * @param[in] cell_info cell ID, instance
    * @return whether cell contains fissile material
    */
-  bool cellHasFissileMaterials(const cellInfo & cell_info) const;
+  bool cellHasFissileMaterials(const cellInfo & cell_info);
 
   /**
    * Set an auxiliary elemental variable to a specified value

--- a/test/tests/neutronics/feedback/triso/nonfissile/geometry.xml
+++ b/test/tests/neutronics/feedback/triso/nonfissile/geometry.xml
@@ -1,0 +1,1 @@
+../geometry.xml

--- a/test/tests/neutronics/feedback/triso/nonfissile/materials.xml
+++ b/test/tests/neutronics/feedback/triso/nonfissile/materials.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material depletable="true" id="1" name="fuel" temperature="300.0">
+    <density units="kg/m3" value="10820" />
+    <nuclide ao="1.5" name="C0" />
+    <nuclide ao="0.4998105" name="O16" />
+    <nuclide ao="0.0001895" name="O17" />
+  </material>
+  <material id="2" name="water" temperature="300.0">
+    <density units="kg/m3" value="100.0" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+  </material>
+  <material id="3" name="Helium coolant" temperature="500.0">
+    <density units="kg/m3" value="1.0" />
+    <nuclide ao="2e-06" name="He3" />
+    <nuclide ao="0.999998" name="He4" />
+  </material>
+  <material id="4" name="Helium coolant" temperature="500.0">
+    <density units="kg/m3" value="1.0" />
+    <nuclide ao="2e-06" name="He3" />
+    <nuclide ao="0.999998" name="He4" />
+  </material>
+  <material id="5" name="Helium coolant" temperature="500.0">
+    <density units="kg/m3" value="1.0" />
+    <nuclide ao="2e-06" name="He3" />
+    <nuclide ao="0.999998" name="He4" />
+  </material>
+</materials>

--- a/test/tests/neutronics/feedback/triso/nonfissile/openmc.i
+++ b/test/tests/neutronics/feedback/triso/nonfissile/openmc.i
@@ -1,0 +1,25 @@
+[Mesh]
+  [solid]
+    type = FileMeshGenerator
+    file = ../solid.e
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+
+  power = 100.0
+  scaling = 100.0
+  solid_blocks = '1 2'
+  tally_blocks = '2'
+  tally_type = cell
+  solid_cell_level = 1
+[]
+
+[Executioner]
+  type = Transient
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/neutronics/feedback/triso/nonfissile/settings.xml
+++ b/test/tests/neutronics/feedback/triso/nonfissile/settings.xml
@@ -1,0 +1,1 @@
+../settings.xml

--- a/test/tests/neutronics/feedback/triso/nonfissile/tests
+++ b/test/tests/neutronics/feedback/triso/nonfissile/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [nonfissile_fill]
+    type = RunException
+    input = openmc.i
+    cli_args = '--error'
+    expect_err = 'Skipping tallies for:'
+    requirement = 'The system shall show a warning if non-fissile non-material cells attempt to add tallies'
+  []
+[]


### PR DESCRIPTION
With the recent addition of @pshriwise's to OpenMC that lets us get all the material cells within a parent cell, we can now actually see whether any of those contained material cells contain fissile material, for the sake of printing warnings.

Closes #74