### PR TITLE
Prettify screen output

### DIFF
--- a/doc/content/tutorials/cht2.md
+++ b/doc/content/tutorials/cht2.md
@@ -438,19 +438,8 @@ $ mpiexec -np 12 cardinal-opt -i solid.i
 
 By using the `minimize_transfers_in` feature, you will see in the screen output
 that the data transfers into NekRS only occur on synchronization points with the
-master application - all other time steps display a message like
-
-```
-Skipping boundary heat flux transfer to nekRS, not at synchronization step
-```
-
-Likewise, by using the `minimize_transfers_out` feature, you will see in the
-screen output that the data transfers out of NekRS only occur on synchronization
-points with the master application - all other time steps display a message like
-
-```
-Skipping boundary temperature transfer out of nekRS, not at synchronization step
-```
+master application - all other time steps will omit the messages about normalizing
+heat flux and extracting temperatures from NekRS.
 
 After converting the NekRS output files to a format viewable in Paraview
 (see instructions [here](https://nekrsdoc.readthedocs.io/en/latest/detailed_usage.html#visualizing-output-files)),

--- a/doc/content/tutorials/logfile.md
+++ b/doc/content/tutorials/logfile.md
@@ -1,392 +1,397 @@
 ```
-cell 11543, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11544, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11544, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11544, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11544, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11544, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11544, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11545, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11545, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11545, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11545, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11545, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11545, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11547, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11548, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11548, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11548, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11548, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11548, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11548, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11549, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11549, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11549, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11549, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11549, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11549, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11551, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11552, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11552, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11552, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11552, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11552, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11552, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11553, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11553, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11553, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11553, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11553, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11553, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11555, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11556, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11556, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11556, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11556, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11556, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11556, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11557, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11557, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11557, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11557, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11557, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11557, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11559, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11560, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11560, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11560, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11560, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11560, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11560, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11561, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11561, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11561, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11561, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11561, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11561, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11563, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11564, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11564, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11564, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11564, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11564, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11564, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11565, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11565, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11565, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11565, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11565, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11565, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11567, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11568, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11568, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11568, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11568, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11568, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11568, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11569, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11569, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11569, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11569, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11569, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11569, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11571, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11572, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11572, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11572, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11572, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11572, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11572, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11573, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11573, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11573, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11573, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11573, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11573, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11575, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11576, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11576, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11576, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11576, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11576, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11576, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11577, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11577, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11577, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11577, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11577, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11577, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11579, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11580, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11580, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11580, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11580, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11580, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11580, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11581, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11581, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11581, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11581, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11581, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11581, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11583, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11584, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11584, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11584, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11584, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11584, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11584, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11585, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11585, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11585, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11585, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11585, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11585, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11587, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11588, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11588, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11588, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11588, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11588, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11588, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11589, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11589, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11589, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11589, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11589, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11589, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11591, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11592, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11592, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11592, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11592, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11592, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11592, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11593, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11593, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11593, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11593, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11593, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11593, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11595, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11596, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11596, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11596, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11596, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11596, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11596, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11597, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11597, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11597, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11597, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11597, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11597, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11599, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11600, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11600, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11600, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11600, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11600, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11600, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11601, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11601, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11601, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11601, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11601, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11601, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11603, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11604, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11604, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11604, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11604, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11604, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11604, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11605, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11605, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11605, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11605, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11605, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11605, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11607, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11608, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11608, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11608, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11608, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11608, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11608, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11609, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11609, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11609, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11609, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11609, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11609, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11611, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11612, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11612, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11612, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11612, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11612, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11612, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11613, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11613, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11613, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11613, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11613, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11613, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11615, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11616, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11616, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11616, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11616, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11616, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11616, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11617, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11617, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11617, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11617, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11617, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11617, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11619, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11620, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11620, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11620, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11620, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11620, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11620, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11621, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11621, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11621, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11621, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11621, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11621, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11623, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11624, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11624, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11624, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11624, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11624, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11624, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11625, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11625, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11625, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11625, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11625, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11625, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11627, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11628, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11628, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11628, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11628, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11628, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11628, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11629, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11629, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11629, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11629, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11629, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11629, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11631, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11632, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11632, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11632, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11632, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11632, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11632, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11633, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11633, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11633, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11633, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11633, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11633, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11635, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11636, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11636, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11636, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11636, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11636, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11636, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11637, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11637, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11637, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11637, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11637, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11637, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11639, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11640, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11640, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11640, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11640, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11640, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11640, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11641, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11641, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11641, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11641, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11641, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11641, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11643, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11644, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11644, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11644, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11644, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11644, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11644, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11645, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11645, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11645, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11645, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11645, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11645, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11647, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11648, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11648, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11648, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11648, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11648, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11648, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11649, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11649, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11649, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11649, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11649, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11649, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11651, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11652, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11652, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11652, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11652, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11652, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11652, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11653, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11653, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11653, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11653, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11653, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11653, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11655, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11656, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11656, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11656, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11656, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11656, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11656, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11657, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11657, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11657, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11657, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11657, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11657, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
-cell 11659, instance    0 (of    1):     96 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.55503
-cell 11660, instance    0 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11660, instance    1 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11660, instance    2 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11660, instance    3 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11660, instance    4 (of    6):    616 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11660, instance    5 (of    6):    624 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  2.24696
-cell 11661, instance    0 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83453
-cell 11661, instance    1 (of    6):    172 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.86122
-cell 11661, instance    2 (of    6):    164 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.80783
-cell 11661, instance    3 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):    1.833
-cell 11661, instance    4 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83208
-cell 11661, instance    5 (of    6):    168 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.83603
+Mapping of OpenMC cells to MOOSE mesh elements:
+---------------------------------------------------------------------------------------
+|               Cell                | # Solid | # Fluid | # Uncoupled | Mapped Volume |
+---------------------------------------------------------------------------------------
+| id 11543, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11544, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11544, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11544, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11544, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11544, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11544, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11545, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11545, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11545, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11545, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11545, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11545, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11547, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11548, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11548, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11548, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11548, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11548, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11548, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11549, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11549, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11549, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11549, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11549, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11549, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11551, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11552, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11552, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11552, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11552, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11552, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11552, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11553, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11553, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11553, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11553, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11553, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11553, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11555, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11556, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11556, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11556, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11556, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11556, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11556, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11557, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11557, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11557, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11557, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11557, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11557, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11559, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11560, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11560, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11560, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11560, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11560, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11560, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11561, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11561, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11561, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11561, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11561, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11561, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11563, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11564, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11564, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11564, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11564, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11564, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11564, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11565, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11565, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11565, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11565, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11565, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11565, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11567, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11568, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11568, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11568, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11568, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11568, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11568, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11569, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11569, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11569, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11569, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11569, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11569, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11571, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11572, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11572, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11572, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11572, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11572, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11572, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11573, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11573, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11573, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11573, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11573, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11573, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11575, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11576, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11576, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11576, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11576, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11576, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11576, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11577, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11577, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11577, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11577, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11577, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11577, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11579, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11580, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11580, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11580, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11580, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11580, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11580, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11581, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11581, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11581, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11581, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11581, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11581, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11583, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11584, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11584, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11584, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11584, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11584, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11584, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11585, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11585, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11585, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11585, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11585, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11585, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11587, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11588, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11588, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11588, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11588, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11588, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11588, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11589, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11589, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11589, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11589, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11589, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11589, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11591, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11592, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11592, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11592, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11592, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11592, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11592, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11593, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11593, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11593, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11593, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11593, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11593, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11595, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11596, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11596, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11596, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11596, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11596, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11596, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11597, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11597, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11597, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11597, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11597, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11597, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11599, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11600, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11600, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11600, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11600, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11600, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11600, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11601, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11601, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11601, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11601, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11601, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11601, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11603, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11604, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11604, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11604, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11604, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11604, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11604, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11605, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11605, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11605, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11605, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11605, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11605, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11607, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11608, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11608, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11608, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11608, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11608, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11608, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11609, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11609, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11609, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11609, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11609, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11609, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11611, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11612, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11612, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11612, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11612, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11612, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11612, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11613, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11613, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11613, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11613, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11613, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11613, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11615, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11616, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11616, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11616, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11616, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11616, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11616, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11617, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11617, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11617, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11617, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11617, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11617, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11619, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11620, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11620, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11620, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11620, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11620, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11620, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11621, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11621, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11621, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11621, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11621, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11621, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11623, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11624, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11624, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11624, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11624, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11624, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11624, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11625, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11625, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11625, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11625, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11625, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11625, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11627, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11628, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11628, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11628, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11628, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11628, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11628, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11629, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11629, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11629, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11629, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11629, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11629, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11631, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11632, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11632, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11632, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11632, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11632, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11632, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11633, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11633, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11633, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11633, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11633, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11633, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11635, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11636, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11636, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11636, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11636, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11636, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11636, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11637, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11637, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11637, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11637, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11637, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11637, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11639, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11640, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11640, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11640, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11640, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11640, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11640, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11641, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11641, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11641, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11641, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11641, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11641, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11643, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11644, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11644, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11644, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11644, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11644, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11644, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11645, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11645, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11645, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11645, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11645, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11645, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11647, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11648, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11648, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11648, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11648, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11648, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11648, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11649, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11649, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11649, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11649, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11649, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11649, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11651, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11652, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11652, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11652, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11652, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11652, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11652, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11653, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11653, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11653, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11653, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11653, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11653, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11655, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11656, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11656, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11656, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11656, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11656, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11656, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11657, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11657, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11657, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11657, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11657, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11657, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+| id 11659, instance    0 (of    1) |      96 |       0 |           0 |  1.555032e-06 |
+| id 11660, instance    0 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11660, instance    1 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11660, instance    2 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11660, instance    3 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11660, instance    4 (of    6) |     616 |       0 |           0 |  2.246955e-06 |
+| id 11660, instance    5 (of    6) |     624 |       0 |           0 |  2.246955e-06 |
+| id 11661, instance    0 (of    6) |     168 |       0 |           0 |  1.834525e-06 |
+| id 11661, instance    1 (of    6) |     172 |       0 |           0 |  1.861221e-06 |
+| id 11661, instance    2 (of    6) |     164 |       0 |           0 |  1.807832e-06 |
+| id 11661, instance    3 (of    6) |     168 |       0 |           0 |  1.832998e-06 |
+| id 11661, instance    4 (of    6) |     168 |       0 |           0 |  1.832082e-06 |
+| id 11661, instance    5 (of    6) |     168 |       0 |           0 |  1.836028e-06 |
+---------------------------------------------------------------------------------------
 ```

--- a/doc/content/tutorials/pincell1.md
+++ b/doc/content/tutorials/pincell1.md
@@ -445,86 +445,91 @@ First, let's examine how the mapping between OpenMC and MOOSE was established.
 When we run with `verbose = true`, you will see the following mapping information displayed:
 
 ```
-cell   1, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell   3, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell   5, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell   7, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell   9, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  11, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  13, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  15, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  17, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  19, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  21, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  23, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  25, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  27, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  29, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  31, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  33, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  35, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  37, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  39, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  41, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  43, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  45, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  47, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  49, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  51, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  53, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  55, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  57, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  59, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  61, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  63, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  65, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  67, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  69, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  71, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  73, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  75, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  77, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  79, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  81, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  83, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  85, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  87, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  89, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  91, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  93, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  95, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell  97, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell  99, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 101, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 103, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 105, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 107, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 109, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 111, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 113, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 115, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 117, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 119, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 121, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 123, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 125, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 127, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 129, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 131, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 133, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 135, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 137, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 139, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 141, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 143, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 145, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 147, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 149, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 151, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 153, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 155, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
-cell 157, instance   0 (of   1):   200 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  3.56463
-cell 159, instance   0 (of   1):    60 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  1.13545
+Mapping of OpenMC cells to MOOSE mesh elements:
+-----------------------------------------------------------------------------------
+|             Cell              | # Solid | # Fluid | # Uncoupled | Mapped Volume |
+-----------------------------------------------------------------------------------
+| id   1, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id   3, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id   5, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id   7, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id   9, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  11, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  13, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  15, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  17, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  19, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  21, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  23, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  25, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  27, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  29, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  31, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  33, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  35, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  37, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  39, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  41, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  43, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  45, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  47, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  49, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  51, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  53, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  55, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  57, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  59, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  61, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  63, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  65, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  67, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  69, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  71, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  73, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  75, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  77, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  79, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  81, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  83, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  85, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  87, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  89, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  91, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  93, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  95, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id  97, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id  99, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 101, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 103, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 105, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 107, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 109, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 111, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 113, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 115, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 117, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 119, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 121, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 123, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 125, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 127, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 129, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 131, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 133, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 135, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 137, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 139, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 141, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 143, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 145, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 147, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 149, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 151, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 153, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 155, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+| id 157, instance   0 (of   1) |     200 |       0 |           0 |  3.564630e+00 |
+| id 159, instance   0 (of   1) |      60 |       0 |           0 |  1.135448e+00 |
+-----------------------------------------------------------------------------------
 ```
 
 This shows that a total of 80 OpenMC cells mapped to the MOOSE blocks (blocks 1, 2, and 3 -

--- a/doc/content/tutorials/triso.md
+++ b/doc/content/tutorials/triso.md
@@ -233,9 +233,14 @@ First, let's examine how the mapping between OpenMC and MOOSE was established.
 When we run with `verbose = true`, you will see the following mapping information displayed:
 
 ```
-cell 1, instance 0 (of 3): 256 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  13.2213
-cell 1, instance 1 (of 3): 256 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  13.2213
-cell 1, instance 2 (of 3): 256 solid elems  0 fluid elems  0 uncoupled elems  |  Mapped elems volume (cm3):  13.2213
+Mapping of OpenMC cells to MOOSE mesh elements:
+-----------------------------------------------------------------------------
+|          Cell           | # Solid | # Fluid | # Uncoupled | Mapped Volume |
+-----------------------------------------------------------------------------
+| id 1, instance 0 (of 3) |     256 |       0 |           0 |  1.322128e-05 |
+| id 1, instance 1 (of 3) |     256 |       0 |           0 |  1.322128e-05 |
+| id 1, instance 2 (of 3) |     256 |       0 |           0 |  1.322128e-05 |
+-----------------------------------------------------------------------------
 ```
 
 The three cells representing the pebbles are mapped to the corresponding MOOSE elements for each pebble.

--- a/include/base/NekRSProblem.h
+++ b/include/base/NekRSProblem.h
@@ -244,12 +244,6 @@ protected:
  /// volumetric heat source variable read from by nekRS
   unsigned int _heat_source_var;
 
-  /// Descriptive string for data transfer going in to nekRS
-  std::string _incoming;
-
-  /// Descriptive string for data transfer coming from nekRS
-  std::string _outgoing;
-
   /// Postprocessor containing the signal of when a synchronization has occurred
   const PostprocessorValue * _transfer_in = nullptr;
 

--- a/src/base/NekRSProblemBase.C
+++ b/src/base/NekRSProblemBase.C
@@ -24,6 +24,7 @@
 #include "TimedPrint.h"
 #include "MooseUtils.h"
 #include "CardinalUtils.h"
+#include "VariadicTable.h"
 
 #include "nekrs.hpp"
 #include "nekInterface/nekInterfaceAdapter.hpp"
@@ -111,9 +112,18 @@ NekRSProblemBase::NekRSProblemBase(const InputParameters &params) : ExternalProb
   nekrs::solution::initializeDimensionalScales(_U_ref, _T_ref, _dT_ref, _L_ref, _rho_0, _Cp_0);
 
   if (_nondimensional)
-    _console << "The NekRS model uses the following non-dimensional scales: " <<
-      "\n length: " << _L_ref << "\n velocity: " << _U_ref << "\n temperature: " << _T_ref <<
-      "\n temperature increment: " << _dT_ref << std::endl;
+  {
+    VariadicTable<Real, Real, Real, Real> vt({"Length      ", "Velocity    ", "Temperature ", "d(Temperature)"});
+    vt.setColumnFormat({VariadicTableColumnFormat::SCIENTIFIC,
+      VariadicTableColumnFormat::SCIENTIFIC,
+      VariadicTableColumnFormat::SCIENTIFIC,
+      VariadicTableColumnFormat::SCIENTIFIC});
+
+    vt.addRow(_L_ref, _U_ref, _T_ref, _dT_ref);
+    _console << "\nNekRS characteristic scales:" << std::endl;
+    vt.print(_console);
+    _console << std::endl;
+  }
 
   // It's too complicated to make sure that the dimensional form _also_ works when our
   // reference coordinates are different from what MOOSE is expecting, so just throw an error

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -704,7 +704,7 @@ OpenMCCellAverageProblem::checkCellMappedSubdomains()
     const auto cell_info = c.first;
 
     if (at_least_one_in_tallies && at_least_one_not_in_tallies)
-      mooseError(printCell(cell_info) + " maps to blocks with different tally settings!\n"
+      mooseError("cell " + printCell(cell_info) + " maps to blocks with different tally settings!\n"
         "Block " + Moose::stringify(block_in_tallies) + " is in 'tally_blocks', but "
         "block " + Moose::stringify(block_not_in_tallies) + " is not.");
 
@@ -1055,7 +1055,7 @@ OpenMCCellAverageProblem::checkContainedCellsStructure(const cellInfo & cell_inf
 {
   // make sure the number of keys is the same
   if (reference.size() != compare.size())
-    mooseError("The cell caching failed to identify identical number of cell IDs filling " + printCell(cell_info) +
+    mooseError("The cell caching failed to identify identical number of cell IDs filling cell " + printCell(cell_info) +
       "\nYou must set 'identical_tally_cell_fills' to false");
 
   for (const auto & entry : reference)
@@ -1065,7 +1065,7 @@ OpenMCCellAverageProblem::checkContainedCellsStructure(const cellInfo & cell_inf
     // check that each key exists
     if (!compare.count(key))
       mooseError("Not all tally cells contain cell ID " + Moose::stringify(cellID(key)) +
-        ". The offender is: " + printCell(cell_info) +
+        ". The offender is: cell " + printCell(cell_info) +
         ".\nYou must set 'identical_tally_cell_fills' to false!");
 
     // for each int32_t key, compare the std::vector<int32_t> map
@@ -1097,7 +1097,7 @@ OpenMCCellAverageProblem::compareContainedCells(std::map<cellInfo, containedCell
 
     // make sure the key exists
     if (!compare.count(cell_info))
-      mooseError("The cell caching failed to map " + printCell(cell_info));
+      mooseError("The cell caching failed to map cell " + printCell(cell_info));
 
     // for each cellInfo key, compare the contained cells map
     auto reference_map = reference[cell_info];
@@ -1118,7 +1118,7 @@ OpenMCCellAverageProblem::compareContainedCells(std::map<cellInfo, containedCell
       // and the instances should exactly match
       if (reference_instances != compare_instances)
         mooseError("The cell caching failed to get correct instances for material cell ID " +
-          Moose::stringify(cellID(nested_entry.first)) + " within " + printCell(cell_info) +
+          Moose::stringify(cellID(nested_entry.first)) + " within cell " + printCell(cell_info) +
           ".\nYou must set 'identical_tally_cell_fills' to false!" +
           "\n\nThis error might appear if there are OpenMC cells filled with the same universe/lattice "
           "\nfilling the tally cells, but that don't have tallies added to them.");
@@ -1252,7 +1252,7 @@ OpenMCCellAverageProblem::storeTallyCells()
 
         // otherwise, warn the user that they've specified tallies for some non-fissile cells
         print_warning = true;
-        warning << "\n  " << printCell(cell_info);
+        warning << "\n  cell " << printCell(cell_info);
       }
 
       _tally_cells.push_back(cell_info);
@@ -1266,8 +1266,8 @@ OpenMCCellAverageProblem::storeTallyCells()
 
       if (_check_equal_mapped_tally_volumes)
         if (std::abs(mapped_tally_volume - _cell_to_elem_volume[cell_info]) / mapped_tally_volume > 1e-3)
-          mooseError("Detected un-equal mapped tally volumes!\n " +
-            printCell(first_tally_cell) + " maps to a volume of " + Moose::stringify(_cell_to_elem_volume[first_tally_cell]) + " (cm3)\n " +
+          mooseError("Detected un-equal mapped tally volumes!\n cell " +
+            printCell(first_tally_cell) + " maps to a volume of " + Moose::stringify(_cell_to_elem_volume[first_tally_cell]) + " (cm3)\n cell " +
             printCell(cell_info) + " maps to a volume of " + Moose::stringify(_cell_to_elem_volume[cell_info]) + " (cm3).\n\n"
             "If the tallied cells in your OpenMC model are of identical volumes, this means that you can get\n"
             "distortion of the volumetric heat source output. For instance, suppose you have two equal-size OpenMC\n"
@@ -1524,7 +1524,7 @@ OpenMCCellAverageProblem::sendTemperatureToOpenMC()
         int err = openmc_cell_set_temperature(id, average_temp, &instance, false);
 
         if (err)
-          mooseError("In attempting to set " + printCell(cell_info) + " to temperature " +
+          mooseError("In attempting to set cell " + printCell(cell_info) + " to temperature " +
             Moose::stringify(average_temp) + " (K), OpenMC reported:\n\n" + std::string(openmc_err_msg));
       }
     }
@@ -1585,7 +1585,7 @@ OpenMCCellAverageProblem::sendDensityToOpenMC()
     // because it could be a very common mistake to forget to set an initial condition
     // for density if OpenMC runs first
     if (average_density <= 0.0)
-      mooseError("Densities less than or equal to zero cannot be set in the OpenMC model!\n " + printCell(cell_info) +
+      mooseError("Densities less than or equal to zero cannot be set in the OpenMC model!\n cell " + printCell(cell_info) +
         " set to density " + Moose::stringify(average_density) + " (kg/m3)");
 
     if (_verbose)
@@ -1597,7 +1597,7 @@ OpenMCCellAverageProblem::sendDensityToOpenMC()
     // throw a special error if the cell is void, because the OpenMC error isn't very
     // clear what the mistake is
     if (material_indices[0] == MATERIAL_VOID)
-      mooseError("Cannot set density for " + printCell(cell_info) +
+      mooseError("Cannot set density for cell " + printCell(cell_info) +
         " because this cell is void (vacuum)!");
 
     if (fill_type != static_cast<int>(openmc::Fill::MATERIAL))
@@ -1830,7 +1830,7 @@ OpenMCCellAverageProblem::getHeatSourceFromOpenMC()
           _console << " cell " << printCell(cell_info) << " power fraction: " << std::setw(3) <<
             Moose::stringify(power_fraction) << std::endl;
 
-        checkZeroTally(power_fraction, printCell(cell_info));
+        checkZeroTally(power_fraction, "cell " + printCell(cell_info));
         fillElementalAuxVariable(_heat_source_var, c.second, volumetric_power);
       }
       break;
@@ -1999,7 +1999,7 @@ OpenMCCellAverageProblem::cellFill(const cellInfo & cell_info, int & fill_type) 
   int err = openmc_cell_get_fill(cell_info.first, &fill_type, &materials, &n_materials);
 
   if (err)
-    mooseError("In attempting to get fill of " + printCell(cell_info) +
+    mooseError("In attempting to get fill of cell " + printCell(cell_info) +
       ", OpenMC reported:\n\n" + std::string(openmc_err_msg));
 
   std::vector<int32_t> material_indices;
@@ -2099,7 +2099,7 @@ OpenMCCellAverageProblem::cellTemperature(const cellInfo & cell_info)
   int err = openmc_cell_get_temperature(material_cell.first, &material_cell.second, &T);
 
   if (err)
-    mooseError("In attempting to get temperature of " + printCell(cell_info) +
+    mooseError("In attempting to get temperature of cell " + printCell(cell_info) +
       ", OpenMC reported:\n\n" + std::string(openmc_err_msg));
 
   return T;

--- a/test/tests/openmc_errors/block_mappings/tests
+++ b/test/tests/openmc_errors/block_mappings/tests
@@ -47,7 +47,7 @@
   [multiple_phases]
     type = RunException
     input = multiple_phases.i
-    expect_err = "cell 4, instance 0 \(of 1\):  16 solid elems  3486 fluid elems  0 uncoupled elems  |  Mapped elems volume:  264.336\n\n"
+    expect_err = "Cell id 4, instance 0 (of 1) mapped to 16 solid elements, 3486 fluid elements, and 0 uncoupled elements.\n"
                  "Each OpenMC cell, instance pair must map to elements of the same phase."
     requirement = "The system shall error if one OpenMC cell maps to more than one phase"
   []

--- a/test/tests/openmc_errors/block_mappings/tests
+++ b/test/tests/openmc_errors/block_mappings/tests
@@ -47,14 +47,14 @@
   [multiple_phases]
     type = RunException
     input = multiple_phases.i
-    expect_err = "Cell id 4, instance 0 (of 1) mapped to 16 solid elements, 3486 fluid elements, and 0 uncoupled elements.\n"
+    expect_err = "Cell id 4, instance 0 \(of 1\) mapped to 16 solid elements, 3486 fluid elements, and 0 uncoupled elements.\n"
                  "Each OpenMC cell, instance pair must map to elements of the same phase."
     requirement = "The system shall error if one OpenMC cell maps to more than one phase"
   []
   [multiple_tally_settings]
     type = RunException
     input = multiple_tally_settings.i
-    expect_err = "cell 4, instance 0 \(of 1\) maps to blocks with different tally settings!\nBlock 100 is in 'tally_blocks', but block 200 is not."
+    expect_err = "cell id 4, instance 0 \(of 1\) maps to blocks with different tally settings!\nBlock 100 is in 'tally_blocks', but block 200 is not."
     requirement = "The system shall error if one OpenMC cell maps to multiple subdomains that don't all have the same tally setting"
   []
   [absent_block]

--- a/test/tests/openmc_errors/densities/tests
+++ b/test/tests/openmc_errors/densities/tests
@@ -2,14 +2,13 @@
   [zero_density]
     type = RunException
     input = zero_density.i
-    expect_err = "Densities less than or equal to zero cannot be set in the OpenMC model!\n"
-                 " cell 1, instance 0 \(of 1\) set to density 0 \(kg/m3\)"
+    expect_err = "Densities less than or equal to zero cannot be set in the OpenMC model!"
     requirement = "The system shall error if we attempt to set a density less than or equal to zero in OpenMC"
   []
   [void_density]
     type = RunException
     input = void_density.i
-    expect_err = "Cannot set density for cell 2, instance 0 \(of 1\) because this cell is void \(vacuum\)!"
+    expect_err = "Cannot set density for cell id 2, instance 0 \(of 1\) because this cell is void \(vacuum\)!"
     requirement = "The system shall error if we attempt to set a density in a void OpenMC cell"
   []
 []

--- a/test/tests/openmc_errors/tallies/tests
+++ b/test/tests/openmc_errors/tallies/tests
@@ -2,7 +2,7 @@
   [zero_tallies]
     type = RunException
     input = zero_tallies.i
-    expect_err = "Heat source computed for cell 4, instance 0 \(of 1\) is zero!\n\n"
+    expect_err = "Heat source computed for cell id 4, instance 0 \(of 1\) is zero!\n\n"
                  "This may occur if there is no fissile material in this region, if you have very few particles, or if you have a geometry setup error."
     requirement = "The system shall error if a tally is zero because this probably indicates a mistake."
   []

--- a/test/tests/openmc_errors/xs_temperatures/tests
+++ b/test/tests/openmc_errors/xs_temperatures/tests
@@ -2,7 +2,7 @@
   [interpolation_min]
     type = RunException
     input = interpolation_min.i
-    expect_err = "In attempting to set cell 1, instance 0 \(of 1\) to temperature -100 \(K\), OpenMC reported:\n\n"
+    expect_err = "In attempting to set cell id 1, instance 0 \(of 1\) to temperature -100 \(K\), OpenMC reported:\n\n"
                  "Temperature is below minimum temperature at which data is available."
     requirement = "The system shall error if we attempt to set a temperature in OpenMC below the "
                   "lower bound of available data when using the interpolation method."
@@ -10,7 +10,7 @@
   [interpolation_max]
     type = RunException
     input = interpolation_max.i
-    expect_err = "In attempting to set cell 1, instance 0 \(of 1\) to temperature 100000 \(K\), OpenMC reported:\n\n"
+    expect_err = "In attempting to set cell id 1, instance 0 \(of 1\) to temperature 100000 \(K\), OpenMC reported:\n\n"
                  "Temperature is above maximum temperature at which data is available."
     requirement = "The system shall error if we attempt to set a temperature in OpenMC above the "
                   "upper bound of available data when using the interpolation method."


### PR DESCRIPTION
This updates the OpenMC and Nek wrappings to use the `VariadicTable` in MOOSE to prettify the screen output.