### PR TITLE
Add option to import OpenMC properties

### DIFF
--- a/include/base/CardinalEnums.h
+++ b/include/base/CardinalEnums.h
@@ -28,6 +28,7 @@ MooseEnum getTallyTypeEnum();
 MooseEnum getEigenvalueEnum();
 MooseEnum getRelaxationEnum();
 MooseEnum getTallyTriggerEnum();
+MooseEnum getInitialPropertiesEnum();
 
 namespace order
 {
@@ -112,6 +113,14 @@ namespace coupling
     temperature,
     density_and_temperature,
     none
+  };
+
+  /// Where to get the initial temperature and density settings for OpenMC
+  enum OpenMCInitialCondition
+  {
+    hdf5,
+    moose,
+    xml
   };
 }
 

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -487,6 +487,14 @@ protected:
   const tally::TallyTypeEnum _tally_type;
 
   /**
+   * Where to get the initial OpenMC temperatures and densities from;
+   * can be either hdf5 (from a properties.h5 file), xml (whatever is already
+   * set in the XML files), or moose (meaning whatever ICs are set on the
+   * 'temp' and 'density' variables).
+   */
+  const coupling::OpenMCInitialCondition _initial_condition;
+
+  /**
    * Type of relaxation to apply to the OpenMC solution; relaxation is
    * applied to the heat source tally.
    */
@@ -548,23 +556,10 @@ protected:
   bool _using_lowest_fluid_level;
 
   /**
-   * Whether to skip the first density and temperature transfer into OpenMC; this
-   * can be used to apply OpenMC's initial values for density and temperature in its
-   * XML files rather than whatever is transferred into OpenMC from MOOSE.
-   */
-  const bool & _skip_first_incoming_transfer;
-
-  /**
    * Whether OpenMC properties (temperature and density) should be exported
    * after being updated in syncSolutions.
    */
   const bool & _export_properties;
-
-  /**
-   * Whether OpenMC properties (temperature and density) should be imported
-   * before starting the run.
-   */
-  const bool & _import_properties;
 
   /// Whether a mesh scaling was specified by the user
   const bool _specified_scaling;

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -560,6 +560,12 @@ protected:
    */
   const bool & _export_properties;
 
+  /**
+   * Whether OpenMC properties (temperature and density) should be imported
+   * before starting the run.
+   */
+  const bool & _import_properties;
+
   /// Whether a mesh scaling was specified by the user
   const bool _specified_scaling;
 

--- a/src/base/CardinalEnums.C
+++ b/src/base/CardinalEnums.C
@@ -57,3 +57,8 @@ MooseEnum getTallyTriggerEnum()
 {
   return MooseEnum("variance std_dev rel_err none", "none");
 }
+
+MooseEnum getInitialPropertiesEnum()
+{
+  return MooseEnum("hdf5 moose xml", "moose");
+}

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -72,6 +72,9 @@ OpenMCCellAverageProblem::validParams()
   params.addParam<bool>("export_properties", false,
     "Whether to export OpenMC's temperature and density properties after updating "
     "them in the syncSolutions call.");
+  params.addParam<bool>("import_properties", false,
+     "Whether to export OpenMC's temperature and density properties before starting "
+     "the first OpenMC transport step.");
   params.addRangeCheckedParam<Real>("scaling", 1.0, "scaling > 0.0",
     "Scaling factor to apply to mesh to get to units of centimeters that OpenMC expects; "
     "setting 'scaling = 100.0', for instance, indicates that the mesh is in units of meters");
@@ -161,6 +164,7 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters &params
   _check_zero_tallies(getParam<bool>("check_zero_tallies")),
   _skip_first_incoming_transfer(getParam<bool>("skip_first_incoming_transfer")),
   _export_properties(getParam<bool>("export_properties")),
+  _import_properties(getParam<bool>("import_properties")),
   _specified_scaling(params.isParamSetByUser("scaling")),
   _scaling(getParam<Real>("scaling")),
   _normalize_by_global(getParam<bool>("normalize_by_global_tally")),
@@ -326,6 +330,11 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters &params
 
     _cell_to_n_contained[cell_info] = n_contained;
   }
+
+  if (_import_properties) {
+    openmc_properties_import("properties.h5");
+  }
+
 }
 
 void

--- a/test/tests/neutronics/feedback/multi_component_temp/openmc.i
+++ b/test/tests/neutronics/feedback/multi_component_temp/openmc.i
@@ -28,7 +28,7 @@ solid_blocks = '1 3'
   tally_type = cell
   solid_cell_level = 1
   fluid_cell_level = 1
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   temperature_variables = 'solid_temp solid_temp fluid_temp'
   temperature_blocks = '${solid_blocks} 2'

--- a/test/tests/neutronics/feedback/multiple_levels/openmc.i
+++ b/test/tests/neutronics/feedback/multiple_levels/openmc.i
@@ -65,7 +65,7 @@
   # to 450, and the exterior temperature to 300. Checking that the temperatures obtained with
   # CellTemperatureAux match these values will confirm that the correct cell level is
   # fetched in the exterior region, which is at a level of 0 (greater than the lowest_solid_cell_level).
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   # block 5 should map to an OpenMC region on level 0 in the geometry; by setting
   # the lowest cell level, we will just map to level 0 in this region instead of 1.

--- a/test/tests/neutronics/heat_source/default_tally_blocks.i
+++ b/test/tests/neutronics/heat_source/default_tally_blocks.i
@@ -59,7 +59,7 @@
 
   # This turns off the density and temperature update on the first syncSolutions;
   # this uses whatever temperature and densities are set in OpenMCs XML files for first step
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 []
 
 [Executioner]

--- a/test/tests/neutronics/heat_source/distrib_cell/solid.i
+++ b/test/tests/neutronics/heat_source/distrib_cell/solid.i
@@ -58,7 +58,7 @@
 
   # This turns off the density and temperature update on the first syncSolutions;
   # this uses whatever temperature and densities are set in OpenMCs XML files for first step
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   verbose = true
   fluid_cell_level = 0

--- a/test/tests/neutronics/heat_source/distrib_cell/warn_zero_tallies.i
+++ b/test/tests/neutronics/heat_source/distrib_cell/warn_zero_tallies.i
@@ -58,7 +58,7 @@
 
   # This turns off the density and temperature update on the first syncSolutions;
   # this uses whatever temperature and densities are set in OpenMCs XML files for first step
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   verbose = true
   fluid_cell_level = 0

--- a/test/tests/neutronics/heat_source/overlap_all.i
+++ b/test/tests/neutronics/heat_source/overlap_all.i
@@ -60,7 +60,7 @@
 
   # This turns off the density and temperature update on the first syncSolutions;
   # this uses whatever temperature and densities are set in OpenMCs XML files for first step
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 []
 
 [Executioner]

--- a/test/tests/neutronics/heat_source/overlap_fluid.i
+++ b/test/tests/neutronics/heat_source/overlap_fluid.i
@@ -62,7 +62,7 @@
 
   # This turns off the density and temperature update on the first syncSolutions;
   # this uses whatever temperature and densities are set in OpenMCs XML files for first step
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   # We are skipping some feedback with fissile regions, so we need to turn off the check
   check_tally_sum = false

--- a/test/tests/neutronics/heat_source/overlap_solid.i
+++ b/test/tests/neutronics/heat_source/overlap_solid.i
@@ -62,7 +62,7 @@
 
   # This turns off the density and temperature update on the first syncSolutions;
   # this uses whatever temperature and densities are set in OpenMCs XML files for first step
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   # We are skipping some feedback with fissile regions, so we need to turn off the check
   check_tally_sum = false

--- a/test/tests/neutronics/heat_source/partial_overlap_moose_union.i
+++ b/test/tests/neutronics/heat_source/partial_overlap_moose_union.i
@@ -61,7 +61,7 @@
   tally_type = cell
   # This turns off the density and temperature update on the first syncSolutions;
   # this uses whatever temperature and densities are set in OpenMCs XML files for first step
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   verbose = true
   solid_cell_level = 0

--- a/test/tests/neutronics/heat_source/partial_overlap_openmc_union.i
+++ b/test/tests/neutronics/heat_source/partial_overlap_openmc_union.i
@@ -60,7 +60,7 @@
 
   # This turns off the density and temperature update on the first syncSolutions;
   # this uses whatever temperature and densities are set in OpenMCs XML files for first step
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   # We are skipping some feedback with fissile regions, so we need to turn off the check
   check_tally_sum = false

--- a/test/tests/neutronics/mesh_tally/different_units.i
+++ b/test/tests/neutronics/mesh_tally/different_units.i
@@ -30,7 +30,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   solid_blocks = '100'
-  skip_first_incoming_transfer = true
+  initial_properties = xml
   verbose = true
   solid_cell_level = 0
 

--- a/test/tests/neutronics/mesh_tally/different_units_and_translations.i
+++ b/test/tests/neutronics/mesh_tally/different_units_and_translations.i
@@ -53,7 +53,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   solid_blocks = '100 200 300'
-  skip_first_incoming_transfer = true
+  initial_properties = xml
   verbose = true
   solid_cell_level = 0
   normalize_by_global_tally = false

--- a/test/tests/neutronics/mesh_tally/fission_tally_std_dev.i
+++ b/test/tests/neutronics/mesh_tally/fission_tally_std_dev.i
@@ -30,7 +30,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   solid_blocks = '100'
-  skip_first_incoming_transfer = true
+  initial_properties = xml
   verbose = true
   solid_cell_level = 0
   normalize_by_global_tally = true

--- a/test/tests/neutronics/mesh_tally/multiple_meshes.i
+++ b/test/tests/neutronics/mesh_tally/multiple_meshes.i
@@ -53,7 +53,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   solid_blocks = '100 200 300'
-  skip_first_incoming_transfer = true
+  initial_properties = xml
   verbose = true
   solid_cell_level = 0
   normalize_by_global_tally = false

--- a/test/tests/neutronics/mesh_tally/multiple_meshes_global.i
+++ b/test/tests/neutronics/mesh_tally/multiple_meshes_global.i
@@ -55,7 +55,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   solid_blocks = '100 200 300'
-  skip_first_incoming_transfer = true
+  initial_properties = xml
   verbose = true
   solid_cell_level = 0
   normalize_by_global_tally = true

--- a/test/tests/neutronics/mesh_tally/one_mesh.i
+++ b/test/tests/neutronics/mesh_tally/one_mesh.i
@@ -30,7 +30,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   solid_blocks = '100'
-  skip_first_incoming_transfer = true
+  initial_properties = xml
   verbose = true
   solid_cell_level = 0
   normalize_by_global_tally = false

--- a/test/tests/neutronics/mesh_tally/one_mesh_global.i
+++ b/test/tests/neutronics/mesh_tally/one_mesh_global.i
@@ -30,7 +30,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   solid_blocks = '100'
-  skip_first_incoming_transfer = true
+  initial_properties = xml
   verbose = true
   solid_cell_level = 0
   normalize_by_global_tally = true

--- a/test/tests/neutronics/openmc_xml/batches.i
+++ b/test/tests/neutronics/openmc_xml/batches.i
@@ -26,7 +26,7 @@
   solid_cell_level = 0
   tally_type = cell
   normalize_by_global_tally = false
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   # In the XML files, we set 50 total batches, but here change it to 60
   batches = 60

--- a/test/tests/neutronics/openmc_xml/inactive.i
+++ b/test/tests/neutronics/openmc_xml/inactive.i
@@ -26,7 +26,7 @@
   solid_cell_level = 0
   tally_type = cell
   normalize_by_global_tally = false
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   # In the XML files, we set 10 inactive batches, but here we change it to 20
   inactive_batches = 20

--- a/test/tests/neutronics/openmc_xml/particles.i
+++ b/test/tests/neutronics/openmc_xml/particles.i
@@ -26,7 +26,7 @@
   solid_cell_level = 0
   tally_type = cell
   normalize_by_global_tally = false
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   # In the XML files, we set 100 particles, but here we override that to use 200 particles
   particles = 200

--- a/test/tests/neutronics/symmetry/openmc.i
+++ b/test/tests/neutronics/symmetry/openmc.i
@@ -64,7 +64,7 @@ height = 6.343                           # height of the full core (m)
 
 [Problem]
   type = OpenMCCellAverageProblem
-  skip_first_incoming_transfer = true
+  initial_properties = 'xml'
 
   power = 1000.0
   scaling = 100.0

--- a/test/tests/neutronics/triggers/k_std_dev.i
+++ b/test/tests/neutronics/triggers/k_std_dev.i
@@ -26,7 +26,7 @@
   solid_cell_level = 0
   tally_type = cell
   normalize_by_global_tally = false
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   k_trigger = std_dev
   k_trigger_threshold = 1.2e-2

--- a/test/tests/neutronics/triggers/mesh_tally_rel_err.i
+++ b/test/tests/neutronics/triggers/mesh_tally_rel_err.i
@@ -31,7 +31,7 @@
                        0 0 4
                        0 0 8'
   normalize_by_global_tally = false
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   tally_trigger = rel_err
   tally_trigger_threshold = 5e-1

--- a/test/tests/neutronics/triggers/tally_rel_err.i
+++ b/test/tests/neutronics/triggers/tally_rel_err.i
@@ -26,7 +26,7 @@
   solid_cell_level = 0
   tally_type = cell
   normalize_by_global_tally = false
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   tally_trigger = rel_err
   tally_trigger_threshold = 2e-2

--- a/test/tests/openmc_errors/block_mappings/multiple_phases.i
+++ b/test/tests/openmc_errors/block_mappings/multiple_phases.i
@@ -48,7 +48,7 @@
   tally_blocks = '100'
   solid_cell_level = 0
   fluid_cell_level = 0
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 []
 
 [Executioner]

--- a/test/tests/openmc_errors/block_mappings/multiple_tally_settings.i
+++ b/test/tests/openmc_errors/block_mappings/multiple_tally_settings.i
@@ -45,7 +45,7 @@
   tally_type = cell
   tally_blocks = '100'
   solid_cell_level = 0
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 []
 
 [Executioner]

--- a/test/tests/openmc_errors/block_mappings/skipping_moose_feedback.i
+++ b/test/tests/openmc_errors/block_mappings/skipping_moose_feedback.i
@@ -52,7 +52,7 @@
   tally_blocks = '100'
   solid_cell_level = 0
   fluid_cell_level = 0
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 []
 
 [Executioner]

--- a/test/tests/openmc_errors/cell_instances/insufficient_materials/solid.i
+++ b/test/tests/openmc_errors/cell_instances/insufficient_materials/solid.i
@@ -17,7 +17,7 @@
   verbose = true
   check_tally_sum = false
   check_zero_tallies = false
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 []
 
 [Executioner]

--- a/test/tests/openmc_errors/incorrect_aux_setup/incorrect_var_type.i
+++ b/test/tests/openmc_errors/incorrect_aux_setup/incorrect_var_type.i
@@ -39,7 +39,7 @@
   tally_type = cell
   tally_blocks = '100'
   solid_cell_level = 0
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 []
 
 [Executioner]

--- a/test/tests/openmc_errors/input_params/invalid_batches.i
+++ b/test/tests/openmc_errors/input_params/invalid_batches.i
@@ -19,7 +19,7 @@
   solid_cell_level = 0
   tally_type = cell
   normalize_by_global_tally = false
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   # there are only 10 inactive batches, so we should error
   batches = 8

--- a/test/tests/openmc_errors/input_params/invalid_max_batches.i
+++ b/test/tests/openmc_errors/input_params/invalid_max_batches.i
@@ -19,7 +19,7 @@
   solid_cell_level = 0
   tally_type = cell
   normalize_by_global_tally = false
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   # there are only 10 inactive batches, so we should error
   max_batches = 8

--- a/test/tests/openmc_errors/input_params/missing_properties.i
+++ b/test/tests/openmc_errors/input_params/missing_properties.i
@@ -1,0 +1,32 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../../neutronics/meshes/sphere.e
+  []
+  [solid_ids]
+    type = SubdomainIDGenerator
+    input = sphere
+    subdomain_id = '100'
+  []
+
+  parallel_type = replicated
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 100.0
+  solid_blocks = '100'
+  solid_cell_level = 0
+  tally_type = cell
+  normalize_by_global_tally = false
+  initial_properties = hdf5
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/test/tests/openmc_errors/input_params/tests
+++ b/test/tests/openmc_errors/input_params/tests
@@ -13,4 +13,10 @@
                  "Number of active batches must be greater than zero."
     requirement = "The system shall error if attempting to set a negative number of active batches"
   []
+  [missing_properties]
+    type = RunException
+    input = missing_properties.i
+    expect_err = "In attempting to load temperature and density from a properties.h5 file, OpenMC reported:"
+    requirement = "The system shall error if a properties file is loaded but does not exist"
+  []
 []

--- a/test/tests/openmc_errors/level/phase_too_high/fluid_too_high.i
+++ b/test/tests/openmc_errors/level/phase_too_high/fluid_too_high.i
@@ -44,7 +44,7 @@
 
   # skip the data transfer of temperature into OpenMC for the first time step
   # so that we can just use the ICs set in OpenMCs XML files
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   solid_cell_level = 1
 

--- a/test/tests/openmc_errors/level/total_too_high/level_too_high.i
+++ b/test/tests/openmc_errors/level/total_too_high/level_too_high.i
@@ -30,7 +30,7 @@
 
   # skip the data transfer of temperature into OpenMC for the first time step
   # so that we can just use the ICs set in OpenMCs XML files
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 
   solid_cell_level = 1
 []

--- a/test/tests/openmc_errors/mesh_tally/incorrect_file.i
+++ b/test/tests/openmc_errors/mesh_tally/incorrect_file.i
@@ -30,7 +30,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   solid_blocks = '0'
-  skip_first_incoming_transfer = true
+  initial_properties = xml
   verbose = true
   solid_cell_level = 0
 

--- a/test/tests/openmc_errors/mesh_tally/incorrect_order.i
+++ b/test/tests/openmc_errors/mesh_tally/incorrect_order.i
@@ -37,7 +37,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   solid_blocks = '0'
-  skip_first_incoming_transfer = true
+  initial_properties = xml
   verbose = true
   solid_cell_level = 0
 

--- a/test/tests/openmc_errors/mesh_tally/incorrect_scaling.i
+++ b/test/tests/openmc_errors/mesh_tally/incorrect_scaling.i
@@ -30,7 +30,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   solid_blocks = '100'
-  skip_first_incoming_transfer = true
+  initial_properties = xml
   verbose = true
   solid_cell_level = 0
 

--- a/test/tests/openmc_errors/tallies/zero_tallies.i
+++ b/test/tests/openmc_errors/tallies/zero_tallies.i
@@ -60,7 +60,7 @@
 
   # This turns off the density and temperature update on the first syncSolutions;
   # this uses whatever temperature and densities are set in OpenMCs XML files for first step
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 []
 
 [Executioner]

--- a/test/tests/postprocessors/eigenvalue/openmc.i
+++ b/test/tests/postprocessors/eigenvalue/openmc.i
@@ -45,7 +45,7 @@
 
   # This turns off the density and temperature update on the first syncSolutions;
   # this uses whatever temperature and densities are set in OpenMCs XML files for first step
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 []
 
 [Executioner]

--- a/test/tests/postprocessors/fission_tally_relative_error/openmc.i
+++ b/test/tests/postprocessors/fission_tally_relative_error/openmc.i
@@ -48,7 +48,7 @@
 
   # This turns off the density and temperature update on the first syncSolutions;
   # this uses whatever temperature and densities are set in OpenMCs XML files for first step
-  skip_first_incoming_transfer = true
+  initial_properties = xml
 []
 
 [Executioner]

--- a/tutorials/gas_assembly/tests
+++ b/tutorials/gas_assembly/tests
@@ -33,7 +33,7 @@
   #  # with cli_args; because this tutorial takes a long time to run, we also restrict this check to just a
   #  # single time step, and turn off the coupling to THM and MOOSE heat conduction (we cover those input
   #  # files in the other tests here).
-  #  command = '../../cardinal-opt -i common_input.i openmc.i Mesh/solid/file=coarse_mesh.e Problem/inactive_batches=5 Problem/batches=10 Outputs/exodus=false Outputs/csv=false MultiApps/active='' Transfers/active='' Executioner/num_steps=1 Problem/skip_first_incoming_transfer=true Problem/check_tally_sum=false'
+  #  command = '../../cardinal-opt -i common_input.i openmc.i Mesh/solid/file=coarse_mesh.e Problem/inactive_batches=5 Problem/batches=10 Outputs/exodus=false Outputs/csv=false MultiApps/active='' Transfers/active='' Executioner/num_steps=1 Problem/initial_properties=xml Problem/check_tally_sum=false'
   #  prereq = create_solid_mesh
   #  requirement = "Cardinal shall be able to solve OpenMC neutron transport for a TRISO compact."
   #[]


### PR DESCRIPTION
This adds the ability to import properties before starting OpenMC transport in Cardinal to reproduce an OpenMC transport step in a coupled simulation if needed.