### PR TITLE
Move minimize transfer feature into NekRS base class.

### DIFF
--- a/include/base/NekRSProblem.h
+++ b/include/base/NekRSProblem.h
@@ -95,18 +95,6 @@ public:
   virtual void addExternalVariables() override;
 
   /**
-   * Whether data should be synchronized in to nekRS
-   * \return whether inward data synchronization should occur
-   */
-  virtual bool synchronizeIn();
-
-  /**
-   * Whether data should be synchronized out of nekRS
-   * \return whether outward data synchronization should occur
-   */
-  virtual bool synchronizeOut();
-
-  /**
    * Determine the maximum interpolated temperature on the NekRSMesh for diagnostic info
    * \return maximum interpolated surface temperature
    */
@@ -127,52 +115,6 @@ protected:
 
   /// Whether the problem is a moving mesh problem i.e. with on-the-fly mesh deformation enabled
   const bool & _moving_mesh;
-
-  /**
-   * \brief Whether to only send heat flux to nekRS on the multiapp synchronization steps
-   *
-   * nekRS is often subcycled relative to the application controlling it -
-   * that is, nekRS may be run with a time step 10x smaller than a conduction MOOSE app.
-   * The NekRSProblemBase interface in MOOSE, however, currently synchronizes (i.e. sends
-   * data to/from nekRS) on _every_ nekRS time step. If 'interpolate_transfers = false'
-   * in the master application, then the heat flux going into nekRS is fixed for each
-   * of the subcycled time steps it takes, so these extra data transfers are
-   * completely unnecssary. This flag indicates whether a somewhat hacky postprocessor
-   * data transfer should be used for nekRS to figure out whether each time step is
-   * the first immediately following a transfer from it's master application, and
-   * then only send heat flux into nekRS's arrays if the data from MOOSE is new.
-   *
-   * NOTE: if 'interpolate_transfers = true' in the master application, then the data
-   * coming into nekRS is _unique_ on each subcycled time step, so setting this to
-   * true will in effect override `interpolate_transfers` to be false. For the best
-   * performance, you should set `interpolate_transfers` to false so that you don't
-   * even bother computing the interpolated data, since it's not used if this parameter
-   * is set to true.
-   */
-  const bool & _minimize_transfers_in;
-
-  /**
-   * \brief Whether to only send temperature from nekRS on the multiapp synchronization steps
-   *
-   * nekRS is often subcycled relative to the application controlling it -
-   * that is, nekRS may be run with a time step 10x smaller than a conduction MOOSE app.
-   * The NekRSProblemBase interface in MOOSE, however, currently synchronizes (i.e. sends
-   * data to/from nekRS) on _every_ nekRS time step. If 'interpolate_transfers = false'
-   * in the master application, then the temperature coming from nekRS is fixed
-   * (from the master's perspective) for each
-   * of the subcycled time steps it takes, so these extra data transfers are
-   * completely unnecssary. This flag indicates whether the coincidence of the
-   * simulation time with the 'target_time' should be used to only transfer data out
-   * of nekRS on the synchronization steps when that data will actually be used.
-   *
-   * NOTE: if 'interpolate_transfers = true' in the master application, then the data
-   * sent from nekRS is _unique_ on each subcycled time step, so setting this to
-   * true will in effect override `interpolate_transfers` to be false. For the best
-   * performance, you should set `interpolate_transfers` to false so that you don't
-   * even bother computing the interpolated data, since it's not used if this parameter
-   * is set to true.
-   */
-  const bool & _minimize_transfers_out;
 
   /// Whether a heat source will be applied to NekRS from MOOSE
   const bool & _has_heat_source;
@@ -243,9 +185,6 @@ protected:
 
  /// volumetric heat source variable read from by nekRS
   unsigned int _heat_source_var;
-
-  /// Postprocessor containing the signal of when a synchronization has occurred
-  const PostprocessorValue * _transfer_in = nullptr;
 
   /// flag to indicate whether this is the first pass to serialize the solution
   static bool _first;


### PR DESCRIPTION
This moves the `minimize_transfer_in/out` feature into the `NekRSProblemBase` so that we don't need to repeat the same logic inside the up-and-coming `NekRSStandalonProblem`.

fyi @ahuxford 