### PR TITLE
Add option to assume separate tallies.

### DIFF
--- a/doc/content/source/problems/OpenMCCellAverageProblem.md
+++ b/doc/content/source/problems/OpenMCCellAverageProblem.md
@@ -481,6 +481,28 @@ specified in a unit 100.0 times larger than the OpenMC unit of centimeters.
 !listing test/tests/neutronics/feedback/different_units/openmc.i
   block=Problem
 
+#### Tally Optimizations
+
+"Spatially separate" tallies are tallies where a particle can only score to one
+bin for a given event - for instance, a tally with one bin per fuel pebble is a
+spatially separate tally because a particle scoring to fission in pebble $A$ cannot
+also score to fission in pebble $B$. For situations like this, OpenMC allows you
+to specify that tallies are [spatially separate](https://docs.openmc.org/en/latest/io_formats/tallies.html#assume-separate-element), which can offer a big performance improvement. If you know
+that your problem satisfies all of the following criteria, you can set
+`assume_separate_tallies = true` to greatly speed up the particle tracking rate:
+
+- `check_tally_sum = true`; when you set this parameter to true, Cardinal
+  automatically adds a **global** `kappa-fission` tally to check that your local
+  tally that couples to MOOSE didn't "miss" any fissile regions. However, when
+  you add a global tally like this, any other tallies are no longer spatially
+  separate.
+- `normalize_by_global_tally = true`; when you set this parameter to true,
+  Cardinal will again automatically add a **global** `kappa-fission` tally in order
+  to normalize the local `kappa-fission` tally that is coupled to MOOSE.
+  For the same reasons as above, your tallies will no longer be spatially separate.
+- Your `tallies.xml` file does not contain any other tallies that would fail
+  to be spatially separate from the tallies automatically added by Cardinal.
+
 #### Relaxation
 
 OpenMC is coupled to MOOSE via fixed point iteration, also referred to

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -695,6 +695,15 @@ protected:
   const bool & _check_identical_tally_cell_fills;
 
   /**
+   * Whether it can be assumed that all of the tallies (both those set by the user
+   * in the XML file, as well as those created automatically by Cardinal) are
+   * spatially separate. This means that once a particle scores to one tally bin, it wouldn't
+   * score to ANY other tally bins. This can dramatically increase tracking rates
+   * for problems with many tallies.
+   */
+  const bool & _assume_separate_tallies;
+
+  /**
    * Whether the problem has fluid blocks specified; note that this is NOT necessarily
    * indicative that the mapping was successful in finding any cells corresponding to those blocks
    */

--- a/test/tests/openmc_errors/tallies/separate_tallies.i
+++ b/test/tests/openmc_errors/tallies/separate_tallies.i
@@ -1,0 +1,92 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../../neutronics/meshes/sphere.e
+  []
+  [solid]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 0
+                 0 0 4
+                 0 0 8'
+  []
+  [solid_ids]
+    type = SubdomainIDGenerator
+    input = solid
+    subdomain_id = '100'
+  []
+  [fluid]
+    type = FileMeshGenerator
+    file = ../block_mappings/stoplight.exo
+  []
+  [fluid_ids]
+    type = SubdomainIDGenerator
+    input = fluid
+    subdomain_id = '200'
+  []
+  [combine]
+    type = CombinerGenerator
+    inputs = 'solid_ids fluid_ids'
+  []
+
+  parallel_type = replicated
+[]
+
+# This AuxVariable and AuxKernel is only here to get the postprocessors
+# to evaluate correctly. This can be deleted after MOOSE issue #17534 is fixed.
+[AuxVariables]
+  [dummy]
+  []
+[]
+
+[AuxKernels]
+  [dummy]
+    type = ConstantAux
+    variable = dummy
+    value = 0.0
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 100.0
+  solid_blocks = '100'
+  fluid_blocks = '200'
+  tally_type = cell
+  tally_blocks = '100'
+  solid_cell_level = 0
+  fluid_cell_level = 0
+
+  assume_separate_tallies = true
+
+  # This turns off the density and temperature update on the first syncSolutions;
+  # this uses whatever temperature and densities are set in OpenMCs XML files for first step
+  initial_properties = xml
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Postprocessors]
+  [heat_source]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+  []
+  [fluid_heat_source]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+    block = '200'
+  []
+  [solid_heat_source]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+    block = '100'
+  []
+[]
+
+[Outputs]
+  exodus = true
+  hide = 'dummy density'
+[]

--- a/test/tests/openmc_errors/tallies/tests
+++ b/test/tests/openmc_errors/tallies/tests
@@ -6,4 +6,10 @@
                  "This may occur if there is no fissile material in this region, if you have very few particles, or if you have a geometry setup error."
     requirement = "The system shall error if a tally is zero because this probably indicates a mistake."
   []
+  [separate_tallies]
+    type = RunException
+    input = separate_tallies.i
+    expect_err = "Cannot assume separate tallies"
+    requirement = "The system shall error if attempting to use separate tallies when a global tally exists"
+  []
 []


### PR DESCRIPTION
For problems with many tallies that are just added automatically by Cardinal, we can get a big speedup if assuming those tallies are spatially separate. I tested this with the Radiant unit cell geometry, and got active batch particle rates to roughly double by leveraging the fact that the tallies are spatially separate.

Closes #331