### PR TITLE
Adjusting calls to setContainedCells for new optimization in OpenMC

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -99,8 +99,25 @@ public:
   /**
    * Apply transformations to point
    * @param[in] point
+   * @return transformed point
    */
-  virtual Point transformPoint(const Point & pt) const { return _symmetry->transformPoint(pt); }
+  virtual Point transformPoint(const Point & pt, bool scale=false) const {
+    return this->hasPointTransformations() ? _symmetry->transformPoint(pt) : pt;
+  }
+
+  /**
+   * Apply transformations and scale point from MOOSE into the OpenMC domain
+   * @param[in] point
+   * @return transformed point
+   */
+  Point transformPointToOpenMC(const Point & pt) const {
+    Point pnt_out = transformPoint(pt);
+
+    // scale point to OpenMC domain
+    pnt_out *= _scaling;
+
+    return pnt_out;
+  }
 
   /**
    * This class uses elem->volume() in order to normalize the fission power produced
@@ -258,9 +275,10 @@ protected:
   /**
    * Fill the cached contained cells data structure for a given cell
    * @param[in] cell_info cell to find contained material cells for
+   * @param[in] hint location hint used to accelerate the search
    * @param[out] map contained cell map
    */
-  void setContainedCells(const cellInfo & cell_info, std::map<cellInfo, containedCells> & map);
+  void setContainedCells(const cellInfo & cell_info, const Point& hint, std::map<cellInfo, containedCells> & map);
 
   /**
    * Check that the structure of the contained material cells for two tally cells matches;

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -101,7 +101,7 @@ public:
    * @param[in] point
    * @return transformed point
    */
-  virtual Point transformPoint(const Point & pt, bool scale=false) const {
+  virtual Point transformPoint(const Point & pt) const {
     return this->hasPointTransformations() ? _symmetry->transformPoint(pt) : pt;
   }
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -930,9 +930,11 @@ OpenMCCellAverageProblem::initializeElementToCellMapping()
 }
 
 void
-OpenMCCellAverageProblem::setContainedCells(const cellInfo & cell_info, std::map<cellInfo, containedCells> & map)
+OpenMCCellAverageProblem::setContainedCells(const cellInfo & cell_info, const Point& hint, std::map<cellInfo, containedCells> & map)
 {
   containedCells contained_cells;
+
+  openmc::Position p{hint(0), hint(1), hint(2)};
 
   const auto & cell = openmc::model::cells[cell_info.first];
   if (cell->type_ == openmc::Fill::MATERIAL)
@@ -941,7 +943,7 @@ OpenMCCellAverageProblem::setContainedCells(const cellInfo & cell_info, std::map
     contained_cells[cell_info.first] = instances;
   }
   else
-    contained_cells = cell->get_contained_cells(cell_info.second);
+    contained_cells = cell->get_contained_cells(cell_info.second, &p);
 
   map[cell_info] = contained_cells;
 }
@@ -955,9 +957,10 @@ OpenMCCellAverageProblem::cacheContainedCells()
   // just compute and then exit
   if (!_identical_tally_cell_fills)
   {
-    for (const auto & c : _cell_to_elem)
-      setContainedCells(c.first, _cell_to_contained_material_cells);
-
+    for (const auto & c : _cell_to_elem) {
+      const Point& p = _mesh.elemPtr(c.second[0])->vertex_average();
+      setContainedCells(c.first, transformPointToOpenMC(p), _cell_to_contained_material_cells);
+    }
     return;
   }
 
@@ -971,23 +974,27 @@ OpenMCCellAverageProblem::cacheContainedCells()
   for (const auto & c : _cell_to_elem)
   {
     auto cell_info = c.first;
+    const auto* elem = _mesh.elemPtr(c.second[0]);
+    // use an element position to speed up openmc::Cell::get_contained_cells calls
+    Point hint = transformPointToOpenMC(elem->vertex_average());
+    openmc::Position openmc_hint{hint(0), hint(1), hint(2)};
 
     // if the cell doesn't have a tally, default to normal behavior
     if (!_cell_has_tally[cell_info])
-      setContainedCells(cell_info, _cell_to_contained_material_cells);
+      setContainedCells(cell_info, hint, _cell_to_contained_material_cells);
     else
     {
       const auto & cell = openmc::model::cells[cell_info.first];
       if (cell->type_ == openmc::Fill::MATERIAL)
       {
         // behavior is the same for material-filled cells
-        setContainedCells(cell_info, _cell_to_contained_material_cells);
+        setContainedCells(cell_info, hint, _cell_to_contained_material_cells);
       }
       else
       {
         if (first_tally_cell)
         {
-          first_tally_cell_cc = cell->get_contained_cells(cell_info.second);
+          first_tally_cell_cc = cell->get_contained_cells(cell_info.second, &openmc_hint);
           _cell_to_contained_material_cells[cell_info] = first_tally_cell_cc;
           first_tally_cell = false;
           second_tally_cell = true;
@@ -996,7 +1003,7 @@ OpenMCCellAverageProblem::cacheContainedCells()
         {
           n++;
 
-          second_tally_cell_cc = cell->get_contained_cells(cell_info.second);
+          second_tally_cell_cc = cell->get_contained_cells(cell_info.second, &openmc_hint);
           _cell_to_contained_material_cells[cell_info] = second_tally_cell_cc;
           second_tally_cell = false;
 
@@ -1051,8 +1058,10 @@ OpenMCCellAverageProblem::cacheContainedCells()
     TIME_SECTION("verifyCacheContainedCells", 4, "Verifying Cached Contained Cells", true);
 
     std::map<cellInfo, containedCells> checking_cell_fills;
-    for (const auto & c : _cell_to_elem)
-      setContainedCells(c.first, checking_cell_fills);
+    for (const auto & c : _cell_to_elem) {
+      const Point& p = _mesh.elemPtr(c.second[0])->vertex_average();
+      setContainedCells(c.first, transformPointToOpenMC(p), checking_cell_fills);
+    }
 
     std::map<cellInfo, containedCells> ordered_reference(checking_cell_fills.begin(), checking_cell_fills.end());
     std::map<cellInfo, containedCells> ordered(_cell_to_contained_material_cells.begin(), _cell_to_contained_material_cells.end());
@@ -1486,12 +1495,9 @@ OpenMCCellAverageProblem::findCell(const Point & point)
   _particle.clear();
   _particle.u() = {0., 0., 1.};
 
-  Point pt = point;
+  Point pt = transformPointToOpenMC(point);
 
-  if (_symmetry)
-    pt = _symmetry->transformPoint(pt);
-
-  _particle.r() = {pt(0) * _scaling, pt(1) * _scaling, pt(2) * _scaling};
+  _particle.r() = {pt(0), pt(1), pt(2)};
   return !openmc::exhaustive_find_cell(_particle);
 }
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -977,7 +977,6 @@ OpenMCCellAverageProblem::cacheContainedCells()
     const auto* elem = _mesh.elemPtr(c.second[0]);
     // use an element position to speed up openmc::Cell::get_contained_cells calls
     Point hint = transformPointToOpenMC(elem->vertex_average());
-    openmc::Position openmc_hint{hint(0), hint(1), hint(2)};
 
     // if the cell doesn't have a tally, default to normal behavior
     if (!_cell_has_tally[cell_info])
@@ -994,17 +993,16 @@ OpenMCCellAverageProblem::cacheContainedCells()
       {
         if (first_tally_cell)
         {
-          first_tally_cell_cc = cell->get_contained_cells(cell_info.second, &openmc_hint);
-          _cell_to_contained_material_cells[cell_info] = first_tally_cell_cc;
+          setContainedCells(cell_info, hint, _cell_to_contained_material_cells);
+          first_tally_cell_cc = _cell_to_contained_material_cells[cell_info];
           first_tally_cell = false;
           second_tally_cell = true;
         }
         else if (second_tally_cell)
         {
           n++;
-
-          second_tally_cell_cc = cell->get_contained_cells(cell_info.second, &openmc_hint);
-          _cell_to_contained_material_cells[cell_info] = second_tally_cell_cc;
+          setContainedCells(cell_info, hint, _cell_to_contained_material_cells);
+          second_tally_cell_cc = _cell_to_contained_material_cells[cell_info];
           second_tally_cell = false;
 
           // we will check for equivalence in the end mapping later; but here we still need


### PR DESCRIPTION
Updating calls to `setContainedCells` for a hint to be passed to OpenMC to accelerate the search for a cell's upward path through the geometry. Further description of the need for this can be found here: 

openmc-dev/openmc#1966

This also updates the OpenMC submodule to a version that includes this new optimization.