### PR TITLE
Remove redundant transfer from tutorial

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -22,8 +22,8 @@ Extensions:
             HPC Systems: hpc.md
             Documentation: source/index.md
             Contributing: contributing.md
-            Developer Guide: developers.md
             Contact/Citing: contact.md
+            News: news.md
     MooseDocs.extensions.appsyntax:
         executable: ${ROOT_DIR}
         includes:

--- a/doc/content/news.md
+++ b/doc/content/news.md
@@ -1,0 +1,20 @@
+# News
+
+This page summarizes recent changes to Cardinal and outlines a number of up-and-coming
+features.
+
+## Up-and-Coming Features
+
+- The NekRS wrapping has basic support for applying MOOSE volume deformations to
+  a NekRS mesh. This is being extended for boundary-based mesh deformations by
+  connecting NekRS's [ALE solver](https://www.osti.gov/biblio/1510253) to MOOSE's
+  tensor mechanics module.
+- OpenMC will soon support unstructured mesh tracking; we will extend the OpenMC
+  wrapping to support tracking directly on a `MooseMesh`, combined with mesh
+  deformations from MOOSE's tensor mechanics module.
+- Add a distributed mesh implementation for the OpenMC wrapping to improve performance
+  for large problems
+
+## Latest News
+
+- [February 2022](news/feb2022.md)

--- a/doc/content/news/feb2022.md
+++ b/doc/content/news/feb2022.md
@@ -1,0 +1,7 @@
+# February 2022 News
+
+- Switch from THM submodule to the open-source THM available in the MOOSE framework
+- Added interface to toggle `assume_separate_tallies` option in OpenMC to improve
+  performance
+- Added a boundary-based coupling of NekRS to a generic MOOSE thermal-fluids code,
+  such as SAM, THM, or RELAP-7. Examples and tutorials will follow soon.

--- a/tutorials/gas_compact_multiphysics/openmc_nek.i
+++ b/tutorials/gas_compact_multiphysics/openmc_nek.i
@@ -167,13 +167,6 @@ N = 1000
     direction = from_multiapp
     multi_app = bison
   []
-  [fluid_temp_to_openmc]
-    type = MultiAppInterpolationTransfer
-    source_variable = nek_bulk_temp
-    variable = nek_temp
-    direction = from_multiapp
-    multi_app = bison
-  []
   [source_to_bison]
     type = MultiAppMeshFunctionTransfer
     source_variable = heat_source
@@ -183,7 +176,6 @@ N = 1000
     from_postprocessors_to_be_preserved = heat_source
     to_postprocessors_to_be_preserved = power
   []
-
   [temp_from_nek]
     type = MultiAppMeshFunctionTransfer
     source_variable = nek_bulk_temp


### PR DESCRIPTION
Unnecessary duplicate transfer in one of the tutorials.