### PR TITLE
Add additional error help for finding libmesh-config

### DIFF
--- a/doc/content/start.md
+++ b/doc/content/start.md
@@ -278,6 +278,20 @@ This means that you need to:
 
 !alert-end!
 
+!alert! note
+Do you get an error like the following when running the test suite?
+
+```
+Error! Could not find 'libmesh-config' in any of the usual libmesh's locations!
+```
+
+This means that you need to explicitly set `LIBMESH_DIR` to point
+to where you have `moose/libmesh`. If you're using MOOSE's conda environment, this
+means setting `LIBMESH_DIR` to `$CONDA_PREFIX/libmesh`. If not using the conda
+environment, set to `cardinal/contrib/moose/libmesh`.
+
+!alert-end!
+
 You can also try running the various test input files directly (i.e. outside
 the testing framework). For example, you can try to run a [!ac](CHT) for a
 [!ac](SFR) pincell with:


### PR DESCRIPTION
Multiple people (myself included) have encountered an error when running the test suite due to not finding `libmesh-config`. This adds some instructions for how to fix the error.