### PR TITLE
Replace some data structures for element phases

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -250,6 +250,13 @@ public:
 
 protected:
   /**
+   * Get the element coupling phase
+   * @param[in] elem
+   * @return coupling phase
+   */
+  const coupling::CouplingFields elemPhase(const Elem * elem) const;
+
+  /**
    * Read the parameters needed for triggers
    * @param[in] params input parameters
    */

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -792,11 +792,8 @@ protected:
   /// Mapping of MOOSE elements to the OpenMC cell they map to (if any)
   std::vector<cellInfo> _elem_to_cell{};
 
-  /**
-   * Phase of each element in the MOOSE mesh according to settings in the 'fluid_blocks'
-   * and 'solid_blocks' parameters.
-   */
-  std::vector<coupling::CouplingFields> _elem_phase{};
+  /// Phase of each cell
+  std::map<cellInfo, coupling::CouplingFields> _cell_phase;
 
   /// Number of solid elements in the MOOSE mesh
   int _n_moose_solid_elems;

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -86,6 +86,20 @@ public:
    */
   std::string pathOutput() const { return _path_output; }
 
+  /**
+   * Get the total (i.e. summed across all ranks, if distributed)
+   * number of elements in a given block
+   * @param[in] block_id subdomainID
+   * return number of elements in block
+   */
+  unsigned int numElemsInSubdomain(const SubdomainID & id) const;
+
+  /**
+   * Whether the element is owned by this rank
+   * @return whether element is owned by this rank
+   */
+  bool isLocalElem(const Elem * elem) const;
+
 protected:
   /**
    * Set an auxiliary elemental variable to a specified value


### PR DESCRIPTION
Cardinal currently tracks the element phase in order to give some error messages to the user; in preparation for a future distributed mesh implementation, this PR just reorganizes these to calculate phase on the fly and store phase based on the cell (instead of the element).