### PR TITLE
Store one point in each cell.

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -415,6 +415,12 @@ protected:
   void getMaterialFills();
 
   /**
+   * Get one point inside each cell, for accelerating the particle search routine.
+   * This function will get the centroid of the first global element in the cell.
+   */
+  void getPointInCell();
+
+  /**
    * Check whether the power in a particular tally bin is zero, which will throw
    * an error if 'check_zero_tallies = true'.
    * @param[in] power_fraction fractional power of the bin
@@ -817,6 +823,12 @@ protected:
 
   /// Mapping of OpenMC cell indices to a vector of MOOSE element IDs
   std::map<cellInfo, std::vector<unsigned int>> _cell_to_elem;
+
+  /**
+   * A point inside the cell, taken simply as the centroid of the first global
+   * element inside the cell. This is stored to accelerate the particle search.
+   */
+  std::map<cellInfo, Point> _cell_to_point;
 
   /// Whether a cell index, instance pair should be added to the tally filter
   std::map<cellInfo, bool> _cell_has_tally;


### PR DESCRIPTION
This PR adds a data structure that stores one point within each cell; this will be needed when moving to a distributed mesh implementation, because the ranks will still need to all call lookup routines in OpenMC for points that may not be in their decomposition.