### PR TITLE
Put mesh behind file mesh generator to allow distributed mesh

### DIFF
--- a/test/tests/neutronics/source/mesh.i
+++ b/test/tests/neutronics/source/mesh.i
@@ -1,0 +1,54 @@
+r_pin = 0.39218
+clad_ir = 0.40005
+clad_or = 0.45720
+L = 300.0
+
+num_layers = 10
+
+[Mesh]
+  [clad] # This makes a circular annulus that will represent the clad
+    type = AnnularMeshGenerator
+    nr = 3
+    nt = 20
+    rmin = ${clad_ir}
+    rmax = ${clad_or}
+    quad_subdomain_id = 1
+    tri_subdomain_id = 0
+  []
+  [extrude_clad] # this extrudes the circular annulus in the axial direction
+    type = FancyExtruderGenerator
+    input = clad
+    heights = '${L}'
+    num_layers = '${num_layers}'
+    direction = '0 0 1'
+  []
+  [rename_clad] # this renames some sidesets on the clad to avoid name clashes
+    type = RenameBoundaryGenerator
+    input = extrude_clad
+    old_boundary = '1 0' # outer surface, inner surface
+    new_boundary = '5 4'
+  []
+  [fuel] # this makes a circle that will represent the fuel
+    type = AnnularMeshGenerator
+    nr = 10
+    nt = 20
+    rmin = 0
+    rmax = ${r_pin}
+    quad_subdomain_id = 2
+    tri_subdomain_id = 3
+    growth_r = -1.2
+  []
+  [extrude] # this extrudes the circle in the axial direction
+    type = FancyExtruderGenerator
+    input = fuel
+    heights = '${L}'
+    num_layers = '${num_layers}'
+    direction = '0 0 1'
+  []
+  [combine]
+    type = CombinerGenerator
+    inputs = 'rename_clad extrude'
+  []
+
+  parallel_type = replicated
+[]

--- a/test/tests/neutronics/source/openmc.i
+++ b/test/tests/neutronics/source/openmc.i
@@ -1,53 +1,7 @@
-r_pin = 0.39218
-clad_ir = 0.40005
-clad_or = 0.45720
-L = 300.0
-
-num_layers = 10
-
 [Mesh]
-  [clad] # This makes a circular annulus that will represent the clad
-    type = AnnularMeshGenerator
-    nr = 3
-    nt = 20
-    rmin = ${clad_ir}
-    rmax = ${clad_or}
-    quad_subdomain_id = 1
-    tri_subdomain_id = 0
-  []
-  [extrude_clad] # this extrudes the circular annulus in the axial direction
-    type = FancyExtruderGenerator
-    input = clad
-    heights = '${L}'
-    num_layers = '${num_layers}'
-    direction = '0 0 1'
-  []
-  [rename_clad] # this renames some sidesets on the clad to avoid name clashes
-    type = RenameBoundaryGenerator
-    input = extrude_clad
-    old_boundary = '1 0' # outer surface, inner surface
-    new_boundary = '5 4'
-  []
-  [fuel] # this makes a circle that will represent the fuel
-    type = AnnularMeshGenerator
-    nr = 10
-    nt = 20
-    rmin = 0
-    rmax = ${r_pin}
-    quad_subdomain_id = 2
-    tri_subdomain_id = 3
-    growth_r = -1.2
-  []
-  [extrude] # this extrudes the circle in the axial direction
-    type = FancyExtruderGenerator
-    input = fuel
-    heights = '${L}'
-    num_layers = '${num_layers}'
-    direction = '0 0 1'
-  []
-  [combine]
-    type = CombinerGenerator
-    inputs = 'rename_clad extrude'
+  [file]
+    type = FileMeshGenerator
+    file = mesh_in.e
   []
 []
 

--- a/test/tests/neutronics/source/tests
+++ b/test/tests/neutronics/source/tests
@@ -1,7 +1,14 @@
 [Tests]
+  [mesh]
+    type = RunApp
+    input = mesh.i
+    cli_args = '--mesh-only'
+    requirement = "The correct mesh shall be created for the sources test."
+  []
   [sources]
     type = CheckFiles
     input = openmc.i
+    prereq = mesh
     check_files = 'initial_source_0.h5 initial_source_1.h5 initial_source_2.h5'
     requirement = "The correct source files shall be created when re-using the source between iterations"
     required_objects = 'OpenMCCellAverageProblem'


### PR DESCRIPTION
This PR puts a mesh generator sequence in one OpenMC test into a file so that the test can run properly with a distributed mesh. There is a bug somewhere in one of the mesh generators that just seg faults when trying to use with distributed mesh.