### PR TITLE
Simplify hdf5 detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,14 @@
 #
 # * CARDINAL_DIR : Top-level Cardinal src dir (default: this Makefile's dir)
 # * CONTRIB_DIR : Dir with third-party src (default: $(CARDINAL_DIR)/contrib)
+# * HYPRE_DIR: Top-level HYPRE dir (default: $(PETSC_DIR)/$(PETSC_ARCH))
+
+# HDF5_ROOT: Top-level HDF5 directory (default: $(HYPRE_DIR), meaning that the default
+#            is to use HDF5 downloaded by PETSc. This makefile will then get the header
+#            files from $(HDF5_ROOT)/include and the libraries from $(HDF5_ROOT)/lib.
+
 # * HDF5_INCLUDE_DIR: Top-level HDF5 header dir (default: $(HDF5_ROOT)/include)
 # * HDF5_LIBDIR: Top-level HDF5 lib dir (default: $(HDF5_ROOT)/lib)
-# * HYPRE_DIR: Top-level HYPRE dir (default: $(PETSC_DIR)/$(PETSC_ARCH))
 # * MOOSE_SUBMODULE : Top-level MOOSE src dir (default: $(CONTRIB_DIR)/moose)
 # * NEKRS_DIR: Top-level NekRS src dir (default: $(CONTRIB_DIR)/nekRS)
 # * OPENMC_DIR: Top-level OpenMC src dir (default: $(CONTRIB_DIR)/openmc)
@@ -30,8 +35,6 @@ ENABLE_OPENMC       ?= yes
 
 CARDINAL_DIR        := $(abspath $(dir $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))))
 CONTRIB_DIR         := $(CARDINAL_DIR)/contrib
-HDF5_INCLUDE_DIR    ?= $(HDF5_ROOT)/include
-HDF5_LIBDIR         ?= $(HDF5_ROOT)/lib
 MOOSE_SUBMODULE     ?= $(CONTRIB_DIR)/moose
 NEKRS_DIR           ?= $(CONTRIB_DIR)/nekRS
 OPENMC_DIR          ?= $(CONTRIB_DIR)/openmc
@@ -45,6 +48,21 @@ SOCKEYE_DIR         ?= $(CONTRIB_DIR)/sockeye
 SODIUM_DIR          ?= $(CONTRIB_DIR)/sodium
 POTASSIUM_DIR       ?= $(CONTRIB_DIR)/potassium
 IAPWS95_DIR         ?= $(CONTRIB_DIR)/iapws95
+
+# If HDF5_ROOT is set, use those settings to link HDF5 to OpenMC.
+# Otherwise, use HYPRE_DIR, which is where PETSc will put HDF5 if downloading it.
+ifeq ($(HDF5_ROOT),)
+  HDF5_ROOT          := $(HYPRE_DIR)
+  export HDF5_ROOT
+endif
+
+HDF5_INCLUDE_DIR    ?= $(HDF5_ROOT)/include
+HDF5_LIBDIR         ?= $(HDF5_ROOT)/lib
+
+# HDF5 is only needed to be linked if using OpenMC
+ifeq ($(ENABLE_OPENMC), yes)
+  $(info Cardinal is using HDF5 from $(HDF5_ROOT))
+endif
 
 ALL_MODULES         := no
 

--- a/doc/content/start.md
+++ b/doc/content/start.md
@@ -76,17 +76,15 @@ automatically. To fetch the MOOSE, OpenMC, and NekRS dependencies, run:
 $ ./scripts/get-dependencies.sh
 ```
 
+
+!alert! note title=Optional dependencies
+
 Cardinal supports *optional* coupling to the following codes:
 
 - *SAM*, a tool for systems analysis of advanced non-light water reactors
-  safety analysis
-- *Sockeye*, a tool for modeling of heat pipe systems
-
-!alert! note title=Building with an optional dependency?
-
-- *SAM*: Follow [these instructions](sam_instructions.md) to obtain the required dependencies for adding the
+  safety analysis. Follow [these instructions](sam_instructions.md) to obtain the required dependencies for adding the
   SAM submodule.
-- *Sockeye*: Follow [these instructions](sockeye_instructions.md) to obtain the required dependencies for adding the
+- *Sockeye*, a tool for modeling of heat pipe systems. Follow [these instructions](sockeye_instructions.md) to obtain the required dependencies for adding the
   Sockeye submodule.
 !alert-end!
 

--- a/doc/content/start.md
+++ b/doc/content/start.md
@@ -130,8 +130,9 @@ export OPENMC_CROSS_SECTIONS=${HOME}/cross_sections/endfb71_hdf5/cross_sections.
 Additional *optional* environment variables that you may need/want to set when building
 Cardinal:
 
-- `HDF5_INCLUDE_DIR`: location of HDF5 headers
-- `HDF5_LIBDIR`: location of HDF5 libraries
+- `HDF5_ROOT`: top-level directory containing HDF5 (this directory should contain
+   an `include` and a `lib` directory). If not set, this will default to the HDF5 downloaded
+   by PETSc and placed into `$PETSC_DIR/$PETSC_ARCH`.
 - `METHODS`: optimization method(s) to use for building Cardinal's libMesh dependency.
    Multiple libMesh libraries with different settings will be built if specifying more than one method, such as wth
   `METHODS='opt dbg'`. Options are:


### PR DESCRIPTION
These changes will now not *require* you to set `HDF5_ROOT` - instead, we will try and use the HDF5 that PETSc downloads, and otherwise use whatever is set in `HDF5_ROOT`.