### PR TITLE
Clarify instructions for PETSc tests

### DIFF
--- a/doc/content/start.md
+++ b/doc/content/start.md
@@ -193,8 +193,14 @@ $ ./contrib/moose/scripts/update_and_rebuild_petsc.sh
 $ ./contrib/moose/scripts/update_and_rebuild_libmesh.sh
 ```
 
-After building PETSc, don't worry if the PETSc
-tests don't pass.
+After building PETSc, if you want to test the installation you will need to `cd`
+into the PETSc directory before running the on-screen directions that print
+when PETSc finishes, i.e. like:
+
+```
+$ cd contrib/moose/petsc
+$ make PETSC_DIR=$HOME/cardinal/contrib/moose/scripts/../petsc PETSC_ARCH=arch-moose check
+```
 
 !alert tip
 Building libMesh can be time consuming. You only need to build libMesh


### PR DESCRIPTION
Users sometimes get confused with the instructions printed to test out the PETSc installation, because it's not clear that you have to change working directories to properly run the test suite.