### PR TITLE
Allow power to be provided by a postprocessor

### DIFF
--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -21,12 +21,13 @@
 #define LIBMESH
 
 #include "ExternalProblem.h"
+#include "PostprocessorInterface.h"
 #include "openmc/tallies/tally.h"
 
 /**
  * Base class for all MOOSE wrappings of OpenMC
  */
-class OpenMCProblemBase : public ExternalProblem
+class OpenMCProblemBase : public ExternalProblem, public PostprocessorInterface
 {
 public:
   OpenMCProblemBase(const InputParameters & params);

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -37,8 +37,8 @@ InputParameters
 OpenMCProblemBase::validParams()
 {
   InputParameters params = ExternalProblem::validParams();
-  params.addRequiredRangeCheckedParam<Real>(
-      "power", "power >= 0.0", "Power (Watts) to normalize the OpenMC tallies");
+  params.addRequiredParam<PostprocessorName>(
+      "power", "Power (Watts) to normalize the OpenMC tallies");
   params.addParam<bool>("verbose", false, "Whether to print diagnostic information");
 
   // interfaces to directly set some OpenMC parameters
@@ -68,7 +68,8 @@ OpenMCProblemBase::validParams()
 
 OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
   : ExternalProblem(params),
-    _power(getParam<Real>("power")),
+    PostprocessorInterface(this),
+    _power(getPostprocessorValue("power")),
     _verbose(getParam<bool>("verbose")),
     _reuse_source(getParam<bool>("reuse_source")),
     _single_coord_level(openmc::model::n_coord_levels == 1),

--- a/test/tests/neutronics/heat_source/from_postprocessor.i
+++ b/test/tests/neutronics/heat_source/from_postprocessor.i
@@ -1,0 +1,96 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../meshes/sphere.e
+  []
+  [solid]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 0
+                 0 0 4
+                 0 0 8'
+  []
+  [solid_ids]
+    type = SubdomainIDGenerator
+    input = solid
+    subdomain_id = '100'
+  []
+  [fluid]
+    type = FileMeshGenerator
+    file = stoplight.exo
+  []
+  [fluid_ids]
+    type = SubdomainIDGenerator
+    input = fluid
+    subdomain_id = '200'
+  []
+  [combine]
+    type = CombinerGenerator
+    inputs = 'solid_ids fluid_ids'
+  []
+[]
+
+# This AuxVariable and AuxKernel is only here to get the postprocessors
+# to evaluate correctly. This can be deleted after MOOSE issue #17534 is fixed.
+[AuxVariables]
+  [dummy]
+  []
+[]
+
+[AuxKernels]
+  [dummy]
+    type = ConstantAux
+    variable = dummy
+    value = 0.0
+  []
+[]
+
+[Postprocessors]
+  [p]
+    type = Receiver
+    default = 100.0
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = p
+  solid_blocks = '100'
+  fluid_blocks = '200'
+  tally_blocks = '100 200'
+  verbose = true
+  solid_cell_level = 0
+  fluid_cell_level = 0
+  tally_type = cell
+
+  # This turns off the density and temperature update on the first syncSolutions;
+  # this uses whatever temperature and densities are set in OpenMCs XML files for first step
+  initial_properties = xml
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Postprocessors]
+  [heat_source]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+  []
+  [fluid_heat_source]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+    block = '200'
+  []
+  [solid_heat_source]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+    block = '100'
+  []
+[]
+
+[Outputs]
+  exodus = true
+  hide = 'dummy density'
+[]

--- a/test/tests/neutronics/heat_source/from_postprocessor.i
+++ b/test/tests/neutronics/heat_source/from_postprocessor.i
@@ -92,5 +92,5 @@
 
 [Outputs]
   exodus = true
-  hide = 'dummy density'
+  hide = 'dummy density p'
 []

--- a/test/tests/neutronics/heat_source/tests
+++ b/test/tests/neutronics/heat_source/tests
@@ -10,6 +10,21 @@
                   "for perfect model overlap with fissile fluid and solid phases."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [from_postprocessor]
+    type = Exodiff
+    input = from_postprocessor.i
+
+    # use the same gold file from the overlap_all test; this test is exactly the same except
+    # that the power comes from a postprocessor
+    cli_args = 'Outputs/file_base=overlap_all_out'
+    exodiff = 'overlap_all_out.e'
+
+    # This test has very few particles, and OpenMC will error if there aren't enough source particles
+    # in the fission bank on a process
+    max_parallel = 8
+    requirement = "The power shall be provided by a postprocessor"
+    required_objects = 'OpenMCCellAverageProblem'
+  []
   [overlap_solid]
     type = Exodiff
     input = overlap_solid.i


### PR DESCRIPTION
For time-dependent simulations, the power used to normalize the OpenMC tallies should vary with time. This PR allows a postprocessor to be provided for `power`. No syntax changes are needed if you still want to set power with a Real value, like `power = 100.0`. 

Closes #384