### PR TITLE
Add error if NEKRS_HOME is not set to the correct location.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ ifeq ($(ENABLE_OPENMC), yes)
   $(info Cardinal is using HDF5 from $(HDF5_ROOT))
 endif
 
+# Check that NEKRS_HOME is set to the correct location
+ifeq ($(ENABLE_NEK), yes)
+  include config/check_nekrs.mk
+endif
+
 ALL_MODULES         := no
 
 FLUID_PROPERTIES    := yes

--- a/config/check_nekrs.mk
+++ b/config/check_nekrs.mk
@@ -1,0 +1,8 @@
+define n
+
+
+endef
+
+ifneq ($(NEKRS_HOME), $(CONTRIB_INSTALL_DIR))
+  $(error $n$n"Environment variable NEKRS_HOME needs to be set to $(CONTRIB_INSTALL_DIR)!")
+endif


### PR DESCRIPTION
Many NekRS users get tripped up on having to set NEKRS_HOME to a different location than they use for running standalone NekRS cases in order to build + run Cardinal.

This adds an error message to the Makefile to eliminate this error from happening at the build stage.