### PR TITLE
Spell out verification steps

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -21,6 +21,7 @@ Extensions:
             Documentation: documentation.menu.md
             Publications: publications.md
             Contact: contact.md
+            Help: faq.md
             News: news.md
     MooseDocs.extensions.appsyntax:
         executable: ${ROOT_DIR}

--- a/doc/content/faq.md
+++ b/doc/content/faq.md
@@ -1,0 +1,41 @@
+# FAQ
+
+On this page we collect a number of commonly-asked questions with
+possible solutions. If you have a question that isn't covered here,
+please post to our [Discussions page](https://github.com/neams-th-coe/cardinal/discussions)
+or reach our to a developer on our Slack channels
+on the MOOSE Developers Slack workspace
+(`moosedevelopers.slack.com`) or on the NekRS Developers Slack workspace
+(`nekrsdev-team.slack.com`).
+
+## Errors with Test Suite
+
+This section addresses errors commonly encountered when running the regression
+test suite, with `./run_tests`.
+
+!alert! note
+```
+Traceback (most recent call last):
+  File "/Users/anovak/projects/cardinal/./run_tests", line 11, in <module>
+    from TestHarness import TestHarness
+ModuleNotFoundError: No module named 'TestHarness'
+```
+
+This means that you need to:
+
+- Be sure that your Python is version 3 (`python --version` will show you the version)
+- Add `cardinal/contrib/moose/python` to your `PYTHONPATH` to be sure Python can find `TestHarness`
+
+!alert-end!
+
+!alert! note
+```
+Error! Could not find 'libmesh-config' in any of the usual libmesh's locations!
+```
+
+This means that you need to explicitly set `LIBMESH_DIR` to point
+to where you have `moose/libmesh`. If you're using MOOSE's conda environment, this
+means setting `LIBMESH_DIR` to `$CONDA_PREFIX/libmesh`. If not using the conda
+environment, set to `cardinal/contrib/moose/libmesh`.
+
+!alert-end!

--- a/doc/content/start.md
+++ b/doc/content/start.md
@@ -252,12 +252,39 @@ you need to provide the full path to `cardinal-opt` in the above command.
 Note that while MOOSE and OpenMC use hybrid parallelism with both MPI and OpenMP,
 NekRS does not use shared memory parallelism.
 
-For the special case of running SAM as the master application, you also need to pass
+Finally, for the special case of running SAM as the master application, you also need to pass
 `--app SamApp` on the command line to instruct Cardinal to build a `SamApp`.
 
-## Testing
+## Checking the Install
 
-Cardinal uses MOOSE's CIVET system for regression testing [!cite](slaughter).
+If you would like to check that Cardinal was built correctly and that you
+have all the basic requirements in place, you can try running a few input files.
+
+1. If you are using OpenMC, try:
+
+```
+cd tutorials/lwr_solid
+mpiexec -np 2 ../../cardinal-opt -i solid.i --n-threads=2
+```
+
+2. If you are using OpenMC and also want to leverage OpenMC's
+   [Python API](https://docs.openmc.org/en/stable/usersguide/install.html#installing-python-api)
+   to make OpenMC models, try:
+
+```
+cd tutorials/lwr_solid
+python make_openmc_model.py
+```
+
+3. If you are using NekRS, try:
+
+```
+cd test/tests/cht/sfr_pincell
+mpiexec -np 4 ../../../../cardinal-opt -i nek_master.i
+```
+
+For developers, you will also find it useful to be able to run Cardinal's
+test suite, which consists of unit and regression tests.
 You can run Cardinal's test suite with the following:
 
 ```
@@ -271,43 +298,3 @@ Depending on the availability of various dependencies, some tests may be skipped
 The first time
 you run the test suite, the runtime will be very long due to the just-in-time compilation of
 NekRS. Subsequent runs will be much faster due to the use of cached build files.
-
-!alert! note
-Do you get an error like the following when running the test suite?
-
-```
-Traceback (most recent call last):
-  File "/Users/anovak/projects/cardinal/./run_tests", line 11, in <module>
-    from TestHarness import TestHarness
-ModuleNotFoundError: No module named 'TestHarness'
-```
-
-This means that you need to:
-
-- Be sure that your Python is version 3 (`python --version` will show you the version)
-- Add `cardinal/contrib/moose/python` to your `PYTHONPATH` to be sure Python can find `TestHarness`
-
-!alert-end!
-
-!alert! note
-Do you get an error like the following when running the test suite?
-
-```
-Error! Could not find 'libmesh-config' in any of the usual libmesh's locations!
-```
-
-This means that you need to explicitly set `LIBMESH_DIR` to point
-to where you have `moose/libmesh`. If you're using MOOSE's conda environment, this
-means setting `LIBMESH_DIR` to `$CONDA_PREFIX/libmesh`. If not using the conda
-environment, set to `cardinal/contrib/moose/libmesh`.
-
-!alert-end!
-
-You can also try running the various test input files directly (i.e. outside
-the testing framework). For example, you can try to run a [!ac](CHT) for a
-[!ac](SFR) pincell with:
-
-```
-$ cd test/tests/cht/sfr_pincell
-$ mpiexec -np 4 cardinal-opt -i nek_master.i
-```


### PR DESCRIPTION
Inspired by discussion with @lewisgross1296, this PR adds a few steps the user can try in order to verify that all the basic parts of Cardinal have been installed correctly.

Also moved the common test suite errors to a separate page to try and slim down the getting started page to just the essentials.