### PR TITLE
Add check install step for the NekRS scripts.

### DIFF
--- a/doc/content/nek_tools.md
+++ b/doc/content/nek_tools.md
@@ -1,0 +1,19 @@
+# Getting NekRS Tools
+
+The Nek development team provides many useful tools for streamlining
+the use of NekRS. The binaries you can build, as well as their purpose, include:
+
+- `exo2nek`: Convert between Exodus and Gmsh meshes to the custom NekRS `.re2` mesh format
+- `visnek`: Generate metadata files to view the custom NekRS output file format in Paraview or Visit
+
+To build these tools, separately clone the Nek5000 repository and then
+navigate to the `tools` directory and run the makefile to compile all the programs.
+
+```
+git clone https://github.com/Nek5000/Nek5000.git
+cd Nek5000/tools
+./maketools all
+```
+
+This will create executables in the `Nek5000/bin` directory. You may want to add
+this to your path in order to quickly access these programs.

--- a/doc/content/nek_tools.md
+++ b/doc/content/nek_tools.md
@@ -3,7 +3,8 @@
 The Nek development team provides many useful tools for streamlining
 the use of NekRS. The binaries you can build, as well as their purpose, include:
 
-- `exo2nek`: Convert between Exodus and Gmsh meshes to the custom NekRS `.re2` mesh format
+- `exo2nek`: Convert between Exodus meshes to the custom NekRS `.re2` mesh format
+- `gmsh2nek`: Convert between Gmsh meshes to the custom NekRS `.re2` mesh format
 - `visnek`: Generate metadata files to view the custom NekRS output file format in Paraview or Visit
 
 To build these tools, separately clone the Nek5000 repository and then

--- a/doc/content/start.md
+++ b/doc/content/start.md
@@ -100,6 +100,15 @@ Cardinal supports *optional* coupling to the following codes:
 
 !alert-end!
 
+!alert! note title=Running with NekRS?
+
+Follow [these instructions](nek_tools.md) to obtain binary executables to use for common NekRS-related operations, such as:
+
+- Converting between an Exodus mesh and NekRS's custom `.re2` mesh format
+- Generating metadata files for visualizing NekRS's custom field fiel output in Paraview
+
+!alert-end!
+
 #### Set Environment Variables
   id=env
 
@@ -284,6 +293,14 @@ python make_openmc_model.py
 ```
 cd test/tests/cht/sfr_pincell
 mpiexec -np 4 ../../../../cardinal-opt -i nek_master.i
+```
+
+4. If you are using NekRS and also want to leverage [NekRS's tools](nek_tools.md)
+   to make meshes, view output files in Paraview, etc., try:
+
+```
+cd test/tests/conduction/boundary_and_volume/prism
+exo2nek
 ```
 
 For developers, you will also find it useful to be able to run Cardinal's


### PR DESCRIPTION
Users of the NekRS wrapping will often want to use the Nek5000 tool scripts (`exo2nek`, `visnek`, etc.). This adds instructions to the Cardinal website to help streamline the process.