### PR TITLE
Add warning for user if they do not set temperature_range.

### DIFF
--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -82,6 +82,15 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
 
   openmc::settings::libmesh_comm = &_mesh.comm();
 
+  if (openmc::settings::temperature_range[1] == 0.0)
+    mooseWarning(
+      "For multiphysics simulations, we recommend setting the 'temperature_range' in OpenMC's\n"
+      "settings.xml file. This will pre-load nuclear data over a range of temperatures, instead\n"
+      "of only the temperatures defined in the XML file.\n\n"
+      "For efficiency purposes, OpenMC only checks that cell temperatures are within the global\n"
+      "min/max of loaded data, which can be different from data loaded for each nuclide. Run may\n"
+      "abort suddenly if requested nuclear data is not available.");
+
   if (isParamValid("openmc_verbosity"))
     openmc::settings::verbosity = getParam<unsigned int>("openmc_verbosity");
 

--- a/test/tests/openmc_errors/no_range/geometry.xml
+++ b/test/tests/openmc_errors/no_range/geometry.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<geometry>
+  <cell id="1" material="1" region="-1" universe="1" />
+  <cell id="2" material="2" region="-2" universe="1" />
+  <cell id="3" material="3" region="-3" universe="1" />
+  <cell id="4" material="4" region="1 2 3 4 -5 6 -7 8 -9" universe="1" />
+  <surface coeffs="0.0 0.0 0.0 1.5" id="1" type="sphere" />
+  <surface coeffs="0.0 0.0 4.0 1.5" id="2" type="sphere" />
+  <surface coeffs="0.0 0.0 8.0 1.5" id="3" type="sphere" />
+  <surface boundary="reflective" coeffs="-2.5" id="4" name="minimum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="5" name="maximum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="-2.5" id="6" name="minimum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="7" name="maximum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="-2.0" id="8" type="z-plane" />
+  <surface boundary="reflective" coeffs="10.0" id="9" type="z-plane" />
+</geometry>

--- a/test/tests/openmc_errors/no_range/make_openmc_model.py
+++ b/test/tests/openmc_errors/no_range/make_openmc_model.py
@@ -1,0 +1,87 @@
+#********************************************************************/
+#*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+#*                             Cardinal                             */
+#*                                                                  */
+#*                  (c) 2021 UChicago Argonne, LLC                  */
+#*                        ALL RIGHTS RESERVED                       */
+#*                                                                  */
+#*                 Prepared by UChicago Argonne, LLC                */
+#*               Under Contract No. DE-AC02-06CH11357               */
+#*                With the U. S. Department of Energy               */
+#*                                                                  */
+#*             Prepared by Battelle Energy Alliance, LLC            */
+#*               Under Contract No. DE-AC07-05ID14517               */
+#*                With the U. S. Department of Energy               */
+#*                                                                  */
+#*                 See LICENSE for full restrictions                */
+#********************************************************************/
+
+import openmc
+
+# This is a model of three pebbles with varying enrichments in water
+# (with uranium in it to cover the possibility of a fissile fluid phase).
+# We are going to compare the tallies computed by OpenMC and how they are
+# extracted and written into MOOSE auxiliary variables.
+
+uo2_a = openmc.Material()
+uo2_a.set_density('g/cc', 10.0)
+uo2_a.add_element('U', 1.0, enrichment = 1.0)
+uo2_a.add_element('O', 2.0)
+
+uo2_b = openmc.Material()
+uo2_b.set_density('g/cc', 10.0)
+uo2_b.add_element('U', 1.0, enrichment = 5.0)
+uo2_b.add_element('O', 2.0)
+
+uo2_c = openmc.Material()
+uo2_c.set_density('g/cc', 10.0)
+uo2_c.add_element('U', 1.0, enrichment = 10.0)
+uo2_c.add_element('O', 2.0)
+
+water = openmc.Material()
+water.set_density('g/cc', 1.0)
+water.add_element('H', 2.0)
+water.add_element('O', 1.0)
+water.add_element('U', 1.0)
+
+mats = openmc.Materials([uo2_a, uo2_b, uo2_c, water])
+mats.export_to_xml()
+
+# Create three pebbles
+R = 1.5
+zmin = 0.0
+zmax = 8.0
+sphere1 = openmc.Sphere(x0 = 0.0, y0 = 0.0, z0 = zmin, r = R)
+sphere2 = openmc.Sphere(x0 = 0.0, y0 = 0.0, z0 = 4.0, r = R)
+sphere3 = openmc.Sphere(x0 = 0.0, y0 = 0.0, z0 = zmax, r = R)
+
+# create a box surrounding them
+L = 5.0
+l = 0.5
+prism = openmc.model.rectangular_prism(L, L, boundary_type = 'reflective')
+bot = openmc.ZPlane(z0 = zmin - R - l, boundary_type = 'reflective')
+top = openmc.ZPlane(z0 = zmax + R + l, boundary_type = 'reflective')
+box = prism & +bot & -top
+
+solid_cell1 = openmc.Cell(fill = uo2_a, region = -sphere1)
+solid_cell2 = openmc.Cell(fill = uo2_b, region = -sphere2)
+solid_cell3 = openmc.Cell(fill = uo2_c, region = -sphere3)
+fluid_cell = openmc.Cell(fill = water, region = +sphere1 & +sphere2 & +sphere3 & box)
+geom = openmc.Geometry([solid_cell1, solid_cell2, solid_cell3, fluid_cell])
+geom.export_to_xml()
+
+# Finally, define some run settings
+settings = openmc.Settings()
+settings.batches = 50
+settings.inactive = 10
+settings.particles = 100
+
+height = 8.0 + 2 * R + 2 * l
+lower_left = (-L, -L, 0)
+upper_right = (L, L, height)
+uniform_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
+settings.source = openmc.source.Source(space=uniform_dist)
+settings.temperature = {'default': 294.0,
+                        'method': 'interpolation',
+                        'multipole': False}
+settings.export_to_xml()

--- a/test/tests/openmc_errors/no_range/materials.xml
+++ b/test/tests/openmc_errors/no_range/materials.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material depletable="true" id="1">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="9.051308944870946e-05" name="U234" />
+    <nuclide ao="0.010126612654073502" name="U235" />
+    <nuclide ao="0.9897364895065476" name="U238" />
+    <nuclide ao="4.63847499302226e-05" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="2">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="0.0004523305496680539" name="U234" />
+    <nuclide ao="0.05060678290832386" name="U235" />
+    <nuclide ao="0.948709083169038" name="U238" />
+    <nuclide ao="0.00023180337297007338" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="3">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="0.0009040745407538578" name="U234" />
+    <nuclide ao="0.10114794158928406" name="U235" />
+    <nuclide ao="0.8974846777145036" name="U238" />
+    <nuclide ao="0.00046330615545845175" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="4">
+    <density units="g/cc" value="1.0" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <nuclide ao="5.4e-05" name="U234" />
+    <nuclide ao="0.007204" name="U235" />
+    <nuclide ao="0.992742" name="U238" />
+  </material>
+</materials>

--- a/test/tests/openmc_errors/no_range/openmc.i
+++ b/test/tests/openmc_errors/no_range/openmc.i
@@ -1,0 +1,32 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  xmin = -2
+  xmax = 2
+  ymin = -2
+  ymax = 2
+  zmin = -2
+  zmax = 10
+  nx = 5
+  ny = 5
+  nz = 5
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 100.0
+  solid_blocks = '0'
+  tally_type = cell
+  tally_blocks = '0'
+  solid_cell_level = 0
+  initial_properties = xml
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/openmc_errors/no_range/settings.xml
+++ b/test/tests/openmc_errors/no_range/settings.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='utf-8'?>
+<settings>
+  <run_mode>eigenvalue</run_mode>
+  <particles>100</particles>
+  <batches>50</batches>
+  <inactive>10</inactive>
+  <source strength="1.0">
+    <space type="fission">
+      <parameters>-5.0 -5.0 0 5.0 5.0 12.0</parameters>
+    </space>
+  </source>
+  <temperature_default>294.0</temperature_default>
+  <temperature_method>interpolation</temperature_method>
+  <temperature_multipole>false</temperature_multipole>
+</settings>

--- a/test/tests/openmc_errors/no_range/tests
+++ b/test/tests/openmc_errors/no_range/tests
@@ -7,5 +7,6 @@
     requirement = "The system shall warn the user if they did not set the temperature range, protecting against "
                   "seg faults within the tracking loop when trying to access nuclear data at temperatures that "
                   "Cardinal wants to apply, but that weren't actually loaded at initialization."
+    required_objects = 'OpenMCCellAverageProblem'
   []
 []

--- a/test/tests/openmc_errors/no_range/tests
+++ b/test/tests/openmc_errors/no_range/tests
@@ -1,0 +1,11 @@
+[Tests]
+  [no_range]
+    type = RunException
+    input = openmc.i
+    cli_args = '--error'
+    expect_err = "For multiphysics simulations, we recommend setting the 'temperature_range'"
+    requirement = "The system shall warn the user if they did not set the temperature range, protecting against "
+                  "seg faults within the tracking loop when trying to access nuclear data at temperatures that "
+                  "Cardinal wants to apply, but that weren't actually loaded at initialization."
+  []
+[]


### PR DESCRIPTION
This adds a warning message if the user does not set the `settings.temperature.range` in an OpenMC model. If the user sets the temperature of some cells in their `geometry.xml` file, OpenMC is going to load a set of nuclear data files according to those temperatures. During the course of the multiphysics simulation, Cardinal likely could set a temperature outside that already-loaded range. 

For efficiency purposes, the only check that OpenMC makes when setting a cell temperature is to check that the temperature is within the global min/max of the loaded data (`openmc::settings::temperature_min/max`), which could be different from precisely what was loaded for a particular nuclide. 

Disclaimer: I was NOT able to reproduce this with just the C-API. I can't explain that, but I'm happy with just printing this warning in the meantime.

Thank you @folkthom for reporting this issue!