### PR TITLE
Replace flux interpolation with generic boundary interpolation.

### DIFF
--- a/include/base/NekRSProblem.h
+++ b/include/base/NekRSProblem.h
@@ -111,13 +111,6 @@ public:
 protected:
   virtual void addTemperatureVariable() override { return; }
 
-  /**
-   * Interpolate the MOOSE flux onto the nekRS mesh
-   * @param[in] elem_id global element ID
-   * @param[in] flux_face flux at the libMesh nodes
-   */
-  void flux(const int elem_id, double * flux_face);
-
   std::unique_ptr<NumericVector<Number>> _serialized_solution;
 
   /// Whether the problem is a moving mesh problem i.e. with on-the-fly mesh deformation enabled

--- a/include/base/NekRSProblemBase.h
+++ b/include/base/NekRSProblemBase.h
@@ -132,7 +132,7 @@ protected:
                                       double * outgoing_nek_value, int & gll_offset);
 
   /**
-   * Write into the NekRS solution space; for setting a mesh position in terms of a
+   * Write into the NekRS solution space for coupling volumes; for setting a mesh position in terms of a
    * displacement, we need to add the displacement to the initial mesh coordinates. For
    * this, the 'add' parameter lets you pass in a vector of values (in NekRS's mesh order,
    * i.e. the re2 order) to add.
@@ -145,6 +145,19 @@ protected:
                            const field::NekWriteEnum & field,
                            double * T,
                            const std::vector<double> * add = nullptr);
+
+  /**
+   * Write into the NekRS solution space for coupling boundaries; for setting a mesh position in terms of a
+   * displacement, we need to add the displacement to the initial mesh coordinates. For
+   * this, the 'add' parameter lets you pass in a vector of values (in NekRS's mesh order,
+   * i.e. the re2 order) to add.
+   * @param[in] elem_id element ID
+   * @param[in] field field to write
+   * @param[in] T solution values to write for the field for the given element
+   * @param[in] add optional vector of values to add to each value set on the NekRS en
+   */
+  void writeBoundarySolution(const int elem_id, const field::NekWriteEnum & field, double * T,
+    const std::vector<double> * add = nullptr);
 
   /**
    * Interpolate the NekRS volume solution onto the volume MOOSE mesh mirror (re2 -> mirror)

--- a/src/base/NekRSProblemBase.C
+++ b/src/base/NekRSProblemBase.C
@@ -886,6 +886,34 @@ NekRSProblemBase::writeVolumeSolution(const int elem_id,
 }
 
 void
+NekRSProblemBase::writeBoundarySolution(const int elem_id, const field::NekWriteEnum & field,
+  double * T, const std::vector<double> * add)
+{
+  const auto & bc = _nek_mesh->boundaryCoupling();
+
+  // We can only write into the nekRS scratch space if that face is "owned" by the current process
+  if (nekrs::commRank() == bc.processor_id(elem_id))
+  {
+    mesh_t * mesh = nekrs::temperatureMesh();
+    void (*write_solution)(int, dfloat);
+    write_solution = nekrs::solution::solutionPointer(field);
+
+    int offset;
+    double * tmp = (double *)calloc(mesh->Nfp, sizeof(double));
+    interpolateBoundarySolutionToNek(elem_id, T, tmp, offset);
+
+    for (int i = 0; i < mesh->Nfp; ++i)
+    {
+      int id = mesh->vmapM[offset + i];
+      double extra = (add == nullptr) ? 0.0 : (*add)[id];
+      write_solution(id, tmp[i]);
+    }
+
+    freePointer(tmp);
+  }
+}
+
+void
 NekRSProblemBase::interpolateVolumeSolutionToNek(const int elem_id, double * incoming_moose_value,
   double * outgoing_nek_value, int & gll_offset)
 {


### PR DESCRIPTION
This replaces the flux-specific usrwrk writing function with a generic function that applies to any boundary quantity. This will be useful when adding the mesh elasticity solver implementation.