### PR TITLE
Move `_moving_mesh` from NekRSProblem to NekRSMesh

### DIFF
--- a/include/base/NekRSProblem.h
+++ b/include/base/NekRSProblem.h
@@ -106,7 +106,7 @@ public:
    */
   virtual double minInterpolatedTemperature() const;
 
-  virtual bool movingMesh() const override { return _moving_mesh; }
+  virtual const bool hasMovingNekMesh() const override { return _nek_mesh->movingMesh(); }
 
 protected:
   virtual void addTemperatureVariable() override { return; }
@@ -119,9 +119,6 @@ protected:
   void flux(const int elem_id, double * flux_face);
 
   std::unique_ptr<NumericVector<Number>> _serialized_solution;
-
-  /// Whether the problem is a moving mesh problem i.e. with on-the-fly mesh deformation enabled
-  const bool & _moving_mesh;
 
   /// Whether a heat source will be applied to NekRS from MOOSE
   const bool & _has_heat_source;

--- a/include/base/NekRSProblemBase.h
+++ b/include/base/NekRSProblemBase.h
@@ -81,10 +81,10 @@ public:
   virtual bool nondimensional() const { return _nondimensional; }
 
   /**
-   * Whether the mesh is moving
-   * @return whether the mesh is moving
-   */
-  virtual bool movingMesh() const { return false; }
+  * Whether the mesh is moving
+  * @return whether the mesh is moving
+  */
+  virtual const bool hasMovingNekMesh() const { return false; }
 
   /**
    * Whether data should be synchronized in to nekRS

--- a/include/base/NekRSStandaloneProblem.h
+++ b/include/base/NekRSStandaloneProblem.h
@@ -31,5 +31,5 @@ public:
 
   static InputParameters validParams();
 
-  virtual bool movingMesh() const override;
+  virtual bool movingMesh() const;
 };

--- a/include/mesh/NekRSMesh.h
+++ b/include/mesh/NekRSMesh.h
@@ -252,6 +252,12 @@ public:
    */
   int facesOnBoundary(const int elem_id) const;
 
+  /**
+   * Get the value of the _moving_mesh parameter
+   * @return whether the problem is "moving mesh" type or not
+   */
+  const bool & movingMesh() const { return _moving_mesh; }
+
 protected:
   /// Store the rank-local element and rank ownership for volume coupling
   void storeVolumeCoupling();
@@ -284,6 +290,9 @@ protected:
 
   /// Initialize members for the mesh and determine the GLL-to-node mapping
   void initializeMeshParams();
+
+  /// Whether the problem is a moving mesh problem i.e. with on-the-fly mesh deformation enabled
+  const bool & _moving_mesh;
 
   /**
    * \brief Whether nekRS is coupled through volumes to MOOSE

--- a/include/userobjects/NekUserObject.h
+++ b/include/userobjects/NekUserObject.h
@@ -40,6 +40,12 @@ protected:
   /// Underlying problem object
   const NekRSProblemBase * _nek_problem;
 
+  /// Base mesh this postprocessor acts on
+  const MooseMesh & _mesh;
+
+  /// Underlying NekRSMesh, if present
+  const NekRSMesh * _nek_mesh;
+
   /// Whether the mesh this userobject operates on is fixed, allowing caching of volumes and areas
   bool _fixed_mesh;
 };

--- a/src/mesh/NekRSMesh.C
+++ b/src/mesh/NekRSMesh.C
@@ -36,6 +36,7 @@ NekRSMesh::validParams()
   params.addParam<std::vector<int>>("boundary",
                                     "Boundary ID(s) through which nekRS will be coupled to MOOSE");
   params.addParam<bool>("volume", false, "Whether the nekRS volume will be coupled to MOOSE");
+  params.addParam<bool>("moving_mesh", false, "Whether we have a moving mesh problem or not");
   params.addParam<MooseEnum>(
       "order", getNekOrderEnum(), "Order of the mesh interpolation between nekRS and MOOSE");
   params.addRangeCheckedParam<Real>(
@@ -47,6 +48,7 @@ NekRSMesh::validParams()
 
 NekRSMesh::NekRSMesh(const InputParameters & parameters)
   : MooseMesh(parameters),
+    _moving_mesh(getParam<bool>("moving_mesh")),
     _volume(getParam<bool>("volume")),
     _boundary(isParamValid("boundary") ? &getParam<std::vector<int>>("boundary") : nullptr),
     _order(getParam<MooseEnum>("order").getEnum<order::NekOrderEnum>()),
@@ -98,6 +100,7 @@ NekRSMesh::NekRSMesh(const InputParameters & parameters)
 
   // save the initial mesh structure in case we are applying displacements
   // (which are additive to the initial mesh structure)
+
   for (int k = 0; k < _nek_internal_mesh->Nelements; ++k)
   {
     int offset = k * _nek_internal_mesh->Np;

--- a/src/postprocessors/NekPostprocessor.C
+++ b/src/postprocessors/NekPostprocessor.C
@@ -41,11 +41,12 @@ NekPostprocessor::NekPostprocessor(const InputParameters & parameters)
                "options: 'NekRSProblem', 'NekRSSeparateDomainProblem', 'NekRSStandaloneProblem'");
   }
 
-  _fixed_mesh = !(_nek_problem->movingMesh());
 
   // NekRSProblem enforces that we then use NekRSMesh, so we don't need to check that
   // this pointer isn't NULL
   _nek_mesh = dynamic_cast<const NekRSMesh *>(&_mesh);
+
+  _fixed_mesh = !(_nek_mesh->movingMesh());
 }
 
 #endif

--- a/src/userobjects/NekUserObject.C
+++ b/src/userobjects/NekUserObject.C
@@ -28,7 +28,7 @@ NekUserObject::validParams()
 }
 
 NekUserObject::NekUserObject(const InputParameters & parameters)
-  : ThreadedGeneralUserObject(parameters)
+  : ThreadedGeneralUserObject(parameters), _mesh(_subproblem.mesh())
 {
   _nek_problem = dynamic_cast<const NekRSProblemBase *>(&_fe_problem);
   if (!_nek_problem)
@@ -41,7 +41,9 @@ NekUserObject::NekUserObject(const InputParameters & parameters)
                "options: 'NekRSProblem', 'NekRSSeparateDomainProblem', 'NekRSStandaloneProblem'");
   }
 
-  _fixed_mesh = !(_nek_problem->movingMesh());
+  _nek_mesh = dynamic_cast<const NekRSMesh *>(&_mesh);
+
+  _fixed_mesh = !(_nek_mesh->movingMesh());
 }
 
 #endif

--- a/test/tests/deformation/simple-cube/nek.i
+++ b/test/tests/deformation/simple-cube/nek.i
@@ -4,12 +4,12 @@
   volume = true
   parallel_type = replicated
   displacements = 'disp_x disp_y disp_z'
+  moving_mesh = true
 []
 
 [Problem]
   type = NekRSProblem
   casename = 'nekbox'
-  moving_mesh = true
   minimize_transfers_in = true
 []
 

--- a/test/tests/deformation/vol-areas/nek.i
+++ b/test/tests/deformation/vol-areas/nek.i
@@ -4,12 +4,12 @@
   volume = true
   parallel_type = replicated
   displacements = 'disp_x disp_y disp_z'
+  moving_mesh = true
 []
 
 [Problem]
   type = NekRSProblem
   casename = 'nekbox'
-  moving_mesh = true
 []
 
 [AuxVariables]

--- a/test/tests/nek_errors/deformation/nek.i
+++ b/test/tests/nek_errors/deformation/nek.i
@@ -4,12 +4,12 @@
   volume = true
   parallel_type = replicated
 #  displacements = 'disp_x disp_y disp_z'
+  moving_mesh = true
 []
 
 [Problem]
   type = NekRSProblem
   casename = 'nekbox'
-  moving_mesh = true
 []
 
 [AuxVariables]

--- a/test/tests/nek_errors/no_moving_mesh/nek.i
+++ b/test/tests/nek_errors/no_moving_mesh/nek.i
@@ -1,6 +1,5 @@
 [Problem]
   type = NekRSProblem
-  moving_mesh = true
   casename = 'cube'
 []
 
@@ -9,6 +8,7 @@
   volume = true
   parallel_type = replicated
   displacements = 'disp_x disp_y disp_z'
+  moving_mesh = true
 []
 
 [Executioner]


### PR DESCRIPTION
It makes more sense for the moving mesh information to be stored on `NekRSMesh`, as opposed to `NekRSProblem`. I cherry-picked a commit from @anshchaube to set up this PR to reduce the amount of code we need to review later when the mesh elasticity solver is merged.