### PR TITLE
Allowing OpenMCCellAverageProblem.C to use a libMesh pointer or mesh file during a simulation

### DIFF
--- a/doc/content/source/problems/OpenMCCellAverageProblem.md
+++ b/doc/content/source/problems/OpenMCCellAverageProblem.md
@@ -322,8 +322,14 @@ The only requirement imposed is that:
   id=um
 
 When using unstructured mesh tallies, the `tally_blocks` parameter is unused. Instead,
-a `mesh_template` is used to provide a path to an unstructured mesh that OpenMC
-will tally on. To translate the same mesh to multiple locations in the OpenMC geometry
+there are two options for specifying an unstructured mesh tally:
+
+- Do nothing, in which case OpenMC will tally exactly on the `[Mesh]` block
+- Specify a `mesh_template`, which provides a path to a mesh file
+
+All remaining parts of this section are discussing the `mesh_template` option.
+For the `mesh_template` option, it is possible
+to translate the same mesh to multiple locations in the OpenMC geometry
 (while only taking up the memory needed to store a single mesh), or
 even simply to move a single mesh to a different location than where the mesh template
 is defined,
@@ -338,7 +344,7 @@ The `mesh_template` and the mesh translations must be in the same units as the
 
 At present, unstructured mesh tallies are copied directly to the `[Mesh]` (without
 doing any type of nearest-node lookup). Therefore, there is an important limitation
-when using unstructured mesh tallies in Cardinal that is best explained by example.
+when using unstructured *file-based* mesh tallies in Cardinal that is best explained by example.
 Suppose the mesh template consists of a mesh for a pincell with $N$ elements
 that you have translated to 3 different locations, giving a total of $3N$ tally
 bins. Because a direct copy is used to transfer the mesh tally results to the `[Mesh]`,
@@ -385,7 +391,7 @@ Then the following setup for the mesh tallies would be correct:
 This setup is correct because the first $3N$ elements in the `[Mesh]`
 exactly match the mesh template (we use the same `pincell.e` mesh and
 translate that pincell in the same order to the three positions). Using a
-mesh template other than `pincell.e` for `OpenMCCellAverageProblem`, *or*
+mesh template other than `pincell.e` *or*
 using a different order of translations to the mesh template than the element
 ordering in `[Mesh]`, will trigger an error. In practice, this design
 just requires some attention in the construction of the `[Mesh]` mesh mirror -
@@ -460,7 +466,8 @@ OpenMC always uses a length unit of centimeters, but a coupled MOOSE application
 often uses SI units (with a length unit of meters). When transferring field data
 to/from OpenMC, it is important for data transferred from OpenMC to match the length units
 of the coupled MOOSE application. This class contains a `scaling` parameter that
-is used to apply a multiplicative factor to the `[Mesh]` to get to units of
+is used to apply a multiplicative factor to the `[Mesh]` and `mesh_template`
+(if using a file-based mesh tally) to get to units of
 centimeters assumed by OpenMC. This multiplicative factor is then applied to:
 
 - Find cell routines in OpenMC in order to correctly map a centimeters-based

--- a/doc/content/tutorials/pincell1.md
+++ b/doc/content/tutorials/pincell1.md
@@ -594,8 +594,9 @@ point to a different input file.
 Then, in `openmc_um.i`, we make small modifications to the settings for the
 [OpenMCCellAverageProblem](/problems/OpenMCCellAverageProblem.md). We indicate that
 `tally_type`
-is set to `mesh` and provide the unstructured mesh that we want to tally as a file
-with the `mesh_template`.
+is set to `mesh`. By default, OpenMC will then just tally directly on the MOOSE
+`[Mesh]` (though we could have specified a different mesh by providing a
+`mesh_template` file name).
 
 !listing /tutorials/lwr_solid/openmc_um.i
   block=Problem

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -883,6 +883,9 @@ protected:
    */
   const bool _using_default_tally_blocks;
 
+  /// When using mesh tallies, whether the mesh comes from the MOOSE [Mesh] block or from a file
+  const bool _tally_mesh_from_moose;
+
   /**
    * Mesh template file to use for creating mesh tallies in OpenMC; currently, this mesh
    * must be identical to the mesh used in the [Mesh] block because a simple copy transfer

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1746,18 +1746,15 @@ OpenMCCellAverageProblem::initializeTallies()
       {
         // create a local mesh from a libMesh mesh
         local_mesh = std::make_unique<openmc::LibMesh>(_mesh.getMesh(),_scaling);
-        // by setting the ID to -1, OpenMC will automatically detect the next available ID
-        local_mesh->set_id(-1);
-        local_mesh->output_ = false;
       }
       else
       {
         // create a local mesh from the file name
         local_mesh = std::make_unique<openmc::LibMesh>(_mesh_template_filename, _scaling);
-        // by setting the ID to -1, OpenMC will automatically detect the next available ID
-        local_mesh->set_id(-1);
-        local_mesh->output_ = false;
       }
+      // by setting the ID to -1, OpenMC will automatically detect the next available ID
+      local_mesh->set_id(-1);
+      local_mesh->output_ = false;
 
       int32_t mesh_index = openmc::model::meshes.size();
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -374,18 +374,24 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     {
       checkUnusedParam(params, "tally_blocks", "using mesh tallies");
 
-      if (isParamValid("mesh_translations") && isParamValid("mesh_translations_file"))
-        mooseError("Both 'mesh_translations' and 'mesh_translations_file' cannot be specified");
+      if (isParamValid("mesh_template"))
+      {
+        _mesh_template_filename = getParam<std::string>("mesh_template");
+
+        if (isParamValid("mesh_translations") && isParamValid("mesh_translations_file"))
+          mooseError("Both 'mesh_translations' and 'mesh_translations_file' cannot be specified");
+      }
+      else
+      {
+        // if user does not provide a 'mesh_template', just use the [Mesh] block, which means these
+        // other parameters are ignored
+        checkUnusedParam(params, "mesh_translations", "reading the tally mesh from the [Mesh] block");
+        checkUnusedParam(params, "mesh_translations_file", "reading the tally mesh from the [Mesh] block");
+      }
 
       if (_check_equal_mapped_tally_volumes)
         mooseWarning(
             "The 'check_equal_mapped_tally_volumes' parameter is unused when using mesh tallies!");
-
-      // get _mesh_template_filename, if not provided, handle with MooseMesh::_mesh
-      if(params.isParamSetByUser("mesh_template"))
-      {
-        _mesh_template_filename = getParam<std::string>("mesh_template");
-      }
 
       fillMeshTranslations();
 

--- a/test/tests/neutronics/mesh_tally/one_mesh_no_input_file.i
+++ b/test/tests/neutronics/mesh_tally/one_mesh_no_input_file.i
@@ -35,11 +35,6 @@
   solid_cell_level = 0
   normalize_by_global_tally = false
 
-  # alternative OpenMC problem that was used to gold the test results
-  #type = OpenMCProblem
-  #pebble_cell_level = 0
-  #centers = '0 0 0'
-
   tally_type = mesh
   power = 100.0
   check_zero_tallies = false

--- a/test/tests/neutronics/mesh_tally/one_mesh_no_input_file.i
+++ b/test/tests/neutronics/mesh_tally/one_mesh_no_input_file.i
@@ -1,0 +1,63 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../meshes/sphere.e
+  []
+  [solid_ids]
+    type = SubdomainIDGenerator
+    input = sphere
+    subdomain_id = '100'
+  []
+
+  allow_renumbering = false
+[]
+
+# This AuxVariable and AuxKernel is only here to get the postprocessors
+# to evaluate correctly. This can be deleted after MOOSE issue #17534 is fixed.
+[AuxVariables]
+  [dummy]
+  []
+[]
+
+[AuxKernels]
+  [dummy]
+    type = ConstantAux
+    variable = dummy
+    value = 0.0
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  solid_blocks = '100'
+  initial_properties = xml
+  verbose = true
+  solid_cell_level = 0
+  normalize_by_global_tally = false
+
+  # alternative OpenMC problem that was used to gold the test results
+  #type = OpenMCProblem
+  #pebble_cell_level = 0
+  #centers = '0 0 0'
+
+  tally_type = mesh
+  power = 100.0
+  check_zero_tallies = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Postprocessors]
+  [heat_source]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+  []
+[]
+
+[Outputs]
+  exodus = true
+  hide = 'dummy temp'
+[]

--- a/test/tests/neutronics/mesh_tally/tests
+++ b/test/tests/neutronics/mesh_tally/tests
@@ -10,6 +10,20 @@
                   "a local tally when a single mesh is used."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [one_mesh_no_input_file]
+    type = Exodiff
+    input = one_mesh_no_input_file.i
+    exodiff = 'one_mesh_out.e'
+    cli_args = "Outputs/file_base=one_mesh_out"
+    # This test has very few particles, and OpenMC will error if there aren't any particles
+    # on a particular process
+    max_parallel = 32
+    requirement = "The heat source shall be tallied on an unstructured mesh and normalized against "
+                  "a local tally when a single mesh is used. "
+                  "The gold file was created with the original OpenMCProblem, showing "
+                  "that the mesh tally implementation is equivalent." #TODO add sentence explaining this new test
+    required_objects = 'OpenMCCellAverageProblem'
+  []
   [one_mesh_global]
     type = Exodiff
     input = one_mesh_global.i

--- a/test/tests/neutronics/mesh_tally/tests
+++ b/test/tests/neutronics/mesh_tally/tests
@@ -18,10 +18,9 @@
     # This test has very few particles, and OpenMC will error if there aren't any particles
     # on a particular process
     max_parallel = 32
-    requirement = "The heat source shall be tallied on an unstructured mesh and normalized against "
-                  "a local tally when a single mesh is used. "
-                  "The gold file was created with the original OpenMCProblem, showing "
-                  "that the mesh tally implementation is equivalent." #TODO add sentence explaining this new test
+    requirement = "This test is nearly identical to one_mesh. The difference lies in having no mesh_template "
+                  "in the input file. Without one, the system should be able to directly tally on a moose "
+                  "mesh instead of a file "
     required_objects = 'OpenMCCellAverageProblem'
   []
   [one_mesh_global]

--- a/tutorials/lwr_solid/openmc_um.i
+++ b/tutorials/lwr_solid/openmc_um.i
@@ -43,7 +43,6 @@
   power = ${fparse 3000e6 / 273 / (17 * 17)}
   solid_blocks = '1 2 3'
   tally_type = mesh
-  mesh_template = 'mesh_in.e'
   normalize_by_global_tally = false
   check_zero_tallies = false
   solid_cell_level = 0


### PR DESCRIPTION
This PR corresponds to [an OpenMC PR](https://github.com/openmc-dev/openmc/pull/2137) that added a constructor to OpenMC to create a mesh form a libMesh pointer. A Cardinal simulation can access the pointer of a libMesh mesh and modify it appropriately during simulations, as opposed to creating/reading a mesh input file. This will help facilitate adaptive mesh refinement simulations, as well as core thermal expansion simulations.