### PR TITLE
Check OpenMC run mode for compatibility with other systems

### DIFF
--- a/include/actions/OpenMCInitAction.h
+++ b/include/actions/OpenMCInitAction.h
@@ -22,8 +22,6 @@
 
 /**
  * Initialize OpenMC application by calling openmc_init.
- * This action detects whether OpenMC should be initialized based on whether
- * OpenMCCellAverageProblem or OpenMCProblem are used as the Problem.
  */
 class OpenMCInitAction : public MooseObjectAction
 {

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -43,7 +43,7 @@ OpenMCInitAction::act()
 {
   TIME_SECTION("initOpenMC", 1, "Initializing OpenMC", false);
 
-  if (_type == "OpenMCCellAverageProblem" || _type == "OpenMCProblem")
+  if (_type == "OpenMCCellAverageProblem")
   {
     int argc = 1;
     char openmc[] = "openmc";

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -276,6 +276,9 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     }
   }
 
+  if (openmc::settings::run_mode != openmc::RunMode::EIGENVALUE && _k_trigger != tally::none)
+    mooseError("Cannot specify a 'k_trigger' for OpenMC runs that are not eigenvalue mode!");
+
   if (_tally_type == tally::mesh)
     if (_mesh.getMesh().allow_renumbering() && !_mesh.getMesh().is_replicated())
       mooseError("Mesh tallies currently require 'allow_renumbering = false' to be set in the [Mesh]!");

--- a/src/postprocessors/KEigenvalue.C
+++ b/src/postprocessors/KEigenvalue.C
@@ -38,6 +38,8 @@ KEigenvalue::KEigenvalue(const InputParameters & parameters)
   : OpenMCPostprocessor(parameters),
     _type(getParam<MooseEnum>("value_type").getEnum<eigenvalue::EigenvalueEnum>())
 {
+  if (openmc::settings::run_mode != openmc::RunMode::EIGENVALUE)
+    mooseError("Eigenvalues are only computed when running OpenMC in eigenvalue mode!");
 }
 
 Real

--- a/src/postprocessors/KStandardDeviation.C
+++ b/src/postprocessors/KStandardDeviation.C
@@ -40,6 +40,8 @@ KStandardDeviation::KStandardDeviation(const InputParameters & parameters)
   : OpenMCPostprocessor(parameters),
     _type(getParam<MooseEnum>("value_type").getEnum<eigenvalue::EigenvalueEnum>())
 {
+  if (openmc::settings::run_mode != openmc::RunMode::EIGENVALUE)
+    mooseError("Eigenvalues are only computed when running OpenMC in eigenvalue mode!");
 }
 
 Real

--- a/test/tests/neutronics/fixed_source/geometry.xml
+++ b/test/tests/neutronics/fixed_source/geometry.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<geometry>
+  <cell id="1" material="1" region="-1" universe="1" />
+  <cell id="2" material="2" region="-2" universe="1" />
+  <cell id="3" material="3" region="-3" universe="1" />
+  <cell id="4" material="4" region="1 2 3 4 -5 6 -7 8 -9" universe="1" />
+  <surface coeffs="0.0 0.0 0.0 1.5" id="1" type="sphere" />
+  <surface coeffs="0.0 0.0 4.0 1.5" id="2" type="sphere" />
+  <surface coeffs="0.0 0.0 8.0 1.5" id="3" type="sphere" />
+  <surface boundary="reflective" coeffs="-2.5" id="4" name="minimum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="5" name="maximum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="-2.5" id="6" name="minimum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="7" name="maximum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="-2.0" id="8" type="z-plane" />
+  <surface boundary="reflective" coeffs="10.0" id="9" type="z-plane" />
+</geometry>

--- a/test/tests/neutronics/fixed_source/materials.xml
+++ b/test/tests/neutronics/fixed_source/materials.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material depletable="true" id="1">
+    <density units="g/cc" value="5.0" />
+    <nuclide ao="9.051308944870946e-05" name="U234" />
+    <nuclide ao="0.010126612654073502" name="U235" />
+    <nuclide ao="0.9897364895065476" name="U238" />
+    <nuclide ao="4.63847499302226e-05" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="2">
+    <density units="g/cc" value="5.0" />
+    <nuclide ao="0.0004523305496680539" name="U234" />
+    <nuclide ao="0.05060678290832386" name="U235" />
+    <nuclide ao="0.948709083169038" name="U238" />
+    <nuclide ao="0.00023180337297007338" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="3">
+    <density units="g/cc" value="5.0" />
+    <nuclide ao="0.0009040745407538578" name="U234" />
+    <nuclide ao="0.10114794158928406" name="U235" />
+    <nuclide ao="0.8974846777145036" name="U238" />
+    <nuclide ao="0.00046330615545845175" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="4">
+    <density units="g/cc" value="0.1" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <nuclide ao="5.4e-05" name="U234" />
+    <nuclide ao="0.007204" name="U235" />
+    <nuclide ao="0.992742" name="U238" />
+  </material>
+</materials>

--- a/test/tests/neutronics/fixed_source/settings.xml
+++ b/test/tests/neutronics/fixed_source/settings.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<settings>
+  <run_mode>fixed source</run_mode>
+  <particles>100</particles>
+  <batches>50</batches>
+  <inactive>10</inactive>
+  <source strength="1.0">
+    <space type="fission">
+      <parameters>-5.0 -5.0 0 5.0 5.0 12.0</parameters>
+    </space>
+  </source>
+  <temperature_default>600.0</temperature_default>
+  <temperature_method>nearest</temperature_method>
+  <temperature_multipole>false</temperature_multipole>
+  <temperature_range>294.0 1600.0</temperature_range>
+</settings>

--- a/test/tests/openmc_errors/fixed_source/geometry.xml
+++ b/test/tests/openmc_errors/fixed_source/geometry.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<geometry>
+  <cell id="1" material="1" region="-1" universe="1" />
+  <cell id="2" material="2" region="-2" universe="1" />
+  <cell id="3" material="3" region="-3" universe="1" />
+  <cell id="4" material="4" region="1 2 3 4 -5 6 -7 8 -9" universe="1" />
+  <surface coeffs="0.0 0.0 0.0 1.5" id="1" type="sphere" />
+  <surface coeffs="0.0 0.0 4.0 1.5" id="2" type="sphere" />
+  <surface coeffs="0.0 0.0 8.0 1.5" id="3" type="sphere" />
+  <surface boundary="reflective" coeffs="-2.5" id="4" name="minimum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="5" name="maximum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="-2.5" id="6" name="minimum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="7" name="maximum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="-2.0" id="8" type="z-plane" />
+  <surface boundary="reflective" coeffs="10.0" id="9" type="z-plane" />
+</geometry>

--- a/test/tests/openmc_errors/fixed_source/k.i
+++ b/test/tests/openmc_errors/fixed_source/k.i
@@ -1,0 +1,38 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../../neutronics/meshes/sphere.e
+  []
+  [solid]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 0
+                 0 0 4
+                 0 0 8'
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 100.0
+  solid_blocks = '1'
+  tally_blocks = '1'
+  solid_cell_level = 0
+  tally_type = cell
+  initial_properties = xml
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Postprocessors]
+  [k]
+    type = KEigenvalue
+  []
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/openmc_errors/fixed_source/k_trigger.i
+++ b/test/tests/openmc_errors/fixed_source/k_trigger.i
@@ -1,0 +1,36 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../../neutronics/meshes/sphere.e
+  []
+  [solid]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 0
+                 0 0 4
+                 0 0 8'
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 100.0
+  solid_blocks = '1'
+  tally_blocks = '1'
+  solid_cell_level = 0
+  tally_type = cell
+  initial_properties = xml
+
+  k_trigger = std_dev
+  k_trigger_threshold = 1e-4
+  max_batches = 100
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/openmc_errors/fixed_source/materials.xml
+++ b/test/tests/openmc_errors/fixed_source/materials.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material depletable="true" id="1">
+    <density units="g/cc" value="5.0" />
+    <nuclide ao="9.051308944870946e-05" name="U234" />
+    <nuclide ao="0.010126612654073502" name="U235" />
+    <nuclide ao="0.9897364895065476" name="U238" />
+    <nuclide ao="4.63847499302226e-05" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="2">
+    <density units="g/cc" value="5.0" />
+    <nuclide ao="0.0004523305496680539" name="U234" />
+    <nuclide ao="0.05060678290832386" name="U235" />
+    <nuclide ao="0.948709083169038" name="U238" />
+    <nuclide ao="0.00023180337297007338" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="3">
+    <density units="g/cc" value="5.0" />
+    <nuclide ao="0.0009040745407538578" name="U234" />
+    <nuclide ao="0.10114794158928406" name="U235" />
+    <nuclide ao="0.8974846777145036" name="U238" />
+    <nuclide ao="0.00046330615545845175" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="4">
+    <density units="g/cc" value="0.1" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <nuclide ao="5.4e-05" name="U234" />
+    <nuclide ao="0.007204" name="U235" />
+    <nuclide ao="0.992742" name="U238" />
+  </material>
+</materials>

--- a/test/tests/openmc_errors/fixed_source/settings.xml
+++ b/test/tests/openmc_errors/fixed_source/settings.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<settings>
+  <run_mode>fixed source</run_mode>
+  <particles>100</particles>
+  <batches>50</batches>
+  <inactive>10</inactive>
+  <source strength="1.0">
+    <space type="fission">
+      <parameters>-5.0 -5.0 0 5.0 5.0 12.0</parameters>
+    </space>
+  </source>
+  <temperature_default>600.0</temperature_default>
+  <temperature_method>nearest</temperature_method>
+  <temperature_multipole>false</temperature_multipole>
+  <temperature_range>294.0 1600.0</temperature_range>
+</settings>

--- a/test/tests/openmc_errors/fixed_source/tests
+++ b/test/tests/openmc_errors/fixed_source/tests
@@ -16,4 +16,12 @@
                   "OpenMC run that is not run with eigenvalue mode."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [k_trigger]
+    type = RunException
+    input = k_trigger.i
+    expect_err = "Cannot specify a 'k_trigger' for OpenMC runs that are not eigenvalue mode!"
+    requirement = "The system shall error if attempting to set a k trigger for an OpenMC mode that doesn't "
+                  "have a notion of eigenvalues"
+    required_objects = 'OpenMCCellAverageProblem'
+  []
 []

--- a/test/tests/openmc_errors/fixed_source/tests
+++ b/test/tests/openmc_errors/fixed_source/tests
@@ -1,0 +1,19 @@
+[Tests]
+  [k]
+    type = RunException
+    input = k.i
+    expect_err = "Eigenvalues are only computed when running OpenMC in eigenvalue mode!"
+    requirement = "The system shall error if attempting to extract the eigenvalue from an OpenMC run that is "
+                  "not run with eigenvalue mode."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+  [k_std_dev]
+    type = RunException
+    input = k.i
+    cli_args = 'Postprocessors/k/type=KStandardDeviation'
+    expect_err = "Eigenvalues are only computed when running OpenMC in eigenvalue mode!"
+    requirement = "The system shall error if attempting to extract the eigenvalue standard deviation from an "
+                  "OpenMC run that is not run with eigenvalue mode."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+[]

--- a/test/tests/openmc_errors/mode/particle/geometry.xml
+++ b/test/tests/openmc_errors/mode/particle/geometry.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<geometry>
+  <cell id="1" material="1" region="-1" universe="1" />
+  <cell id="2" material="2" region="-2" universe="1" />
+  <cell id="3" material="3" region="-3" universe="1" />
+  <cell id="4" material="4" region="1 2 3 4 -5 6 -7 8 -9" universe="1" />
+  <surface coeffs="0.0 0.0 0.0 1.5" id="1" type="sphere" />
+  <surface coeffs="0.0 0.0 4.0 1.5" id="2" type="sphere" />
+  <surface coeffs="0.0 0.0 8.0 1.5" id="3" type="sphere" />
+  <surface boundary="reflective" coeffs="-2.5" id="4" name="minimum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="5" name="maximum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="-2.5" id="6" name="minimum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="7" name="maximum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="-2.0" id="8" type="z-plane" />
+  <surface boundary="reflective" coeffs="10.0" id="9" type="z-plane" />
+</geometry>

--- a/test/tests/openmc_errors/mode/particle/materials.xml
+++ b/test/tests/openmc_errors/mode/particle/materials.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material depletable="true" id="1">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="9.051308944870946e-05" name="U234" />
+    <nuclide ao="0.010126612654073502" name="U235" />
+    <nuclide ao="0.9897364895065476" name="U238" />
+    <nuclide ao="4.63847499302226e-05" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="2">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="0.0004523305496680539" name="U234" />
+    <nuclide ao="0.05060678290832386" name="U235" />
+    <nuclide ao="0.948709083169038" name="U238" />
+    <nuclide ao="0.00023180337297007338" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="3">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="0.0009040745407538578" name="U234" />
+    <nuclide ao="0.10114794158928406" name="U235" />
+    <nuclide ao="0.8974846777145036" name="U238" />
+    <nuclide ao="0.00046330615545845175" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="4">
+    <density units="g/cc" value="1.0" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <nuclide ao="5.4e-05" name="U234" />
+    <nuclide ao="0.007204" name="U235" />
+    <nuclide ao="0.992742" name="U238" />
+  </material>
+</materials>

--- a/test/tests/openmc_errors/mode/particle/particle.i
+++ b/test/tests/openmc_errors/mode/particle/particle.i
@@ -1,0 +1,39 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../../../neutronics/meshes/sphere.e
+  []
+  [combine]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 0
+                 0 0 4
+                 0 0 8'
+  []
+  [block]
+    type = SubdomainIDGenerator
+    input = combine
+    subdomain_id = '0'
+  []
+
+  allow_renumbering = false
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  solid_blocks = '0'
+  initial_properties = xml
+  solid_cell_level = 0
+  tally_type = cell
+  power = 100.0
+  check_tally_sum = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/openmc_errors/mode/particle/plots.xml
+++ b/test/tests/openmc_errors/mode/particle/plots.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<plots>
+  <plot basis="xz" color_by="cell" filename="plot1" id="1" type="slice">
+    <origin>0.0 0.0 6.0</origin>
+    <width>4.0 12.0</width>
+    <pixels>100 300</pixels>
+  </plot>
+  <plot basis="xy" color_by="cell" filename="plot2" id="2" type="slice">
+    <origin>0.0 0.0 2.0</origin>
+    <width>4.0 4.0</width>
+    <pixels>100 100</pixels>
+  </plot>
+</plots>

--- a/test/tests/openmc_errors/mode/particle/settings.xml
+++ b/test/tests/openmc_errors/mode/particle/settings.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<settings>
+  <run_mode>particle restart</run_mode>
+  <particles>1000</particles>
+  <batches>50</batches>
+  <inactive>10</inactive>
+  <source strength="1.0">
+    <space type="fission">
+      <parameters>-5.0 -5.0 0 5.0 5.0 12.0</parameters>
+    </space>
+  </source>
+  <temperature_default>600.0</temperature_default>
+  <temperature_method>nearest</temperature_method>
+  <temperature_multipole>false</temperature_multipole>
+  <temperature_range>294.0 1600.0</temperature_range>
+</settings>

--- a/test/tests/openmc_errors/mode/particle/tests
+++ b/test/tests/openmc_errors/mode/particle/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [volume]
+    type = RunException
+    input = particle.i
+    expect_err = "Running OpenMC in particle restart mode is not supported through Cardinal!"
+    requirement = "The system shall error if attempting to run OpenMC in particle restart mode through Cardinal."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+[]

--- a/test/tests/openmc_errors/mode/plot/geometry.xml
+++ b/test/tests/openmc_errors/mode/plot/geometry.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<geometry>
+  <cell id="1" material="1" region="-1" universe="1" />
+  <cell id="2" material="2" region="-2" universe="1" />
+  <cell id="3" material="3" region="-3" universe="1" />
+  <cell id="4" material="4" region="1 2 3 4 -5 6 -7 8 -9" universe="1" />
+  <surface coeffs="0.0 0.0 0.0 1.5" id="1" type="sphere" />
+  <surface coeffs="0.0 0.0 4.0 1.5" id="2" type="sphere" />
+  <surface coeffs="0.0 0.0 8.0 1.5" id="3" type="sphere" />
+  <surface boundary="reflective" coeffs="-2.5" id="4" name="minimum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="5" name="maximum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="-2.5" id="6" name="minimum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="7" name="maximum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="-2.0" id="8" type="z-plane" />
+  <surface boundary="reflective" coeffs="10.0" id="9" type="z-plane" />
+</geometry>

--- a/test/tests/openmc_errors/mode/plot/materials.xml
+++ b/test/tests/openmc_errors/mode/plot/materials.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material depletable="true" id="1">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="9.051308944870946e-05" name="U234" />
+    <nuclide ao="0.010126612654073502" name="U235" />
+    <nuclide ao="0.9897364895065476" name="U238" />
+    <nuclide ao="4.63847499302226e-05" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="2">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="0.0004523305496680539" name="U234" />
+    <nuclide ao="0.05060678290832386" name="U235" />
+    <nuclide ao="0.948709083169038" name="U238" />
+    <nuclide ao="0.00023180337297007338" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="3">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="0.0009040745407538578" name="U234" />
+    <nuclide ao="0.10114794158928406" name="U235" />
+    <nuclide ao="0.8974846777145036" name="U238" />
+    <nuclide ao="0.00046330615545845175" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="4">
+    <density units="g/cc" value="1.0" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <nuclide ao="5.4e-05" name="U234" />
+    <nuclide ao="0.007204" name="U235" />
+    <nuclide ao="0.992742" name="U238" />
+  </material>
+</materials>

--- a/test/tests/openmc_errors/mode/plot/plot.i
+++ b/test/tests/openmc_errors/mode/plot/plot.i
@@ -1,0 +1,39 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../../../neutronics/meshes/sphere.e
+  []
+  [combine]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 0
+                 0 0 4
+                 0 0 8'
+  []
+  [block]
+    type = SubdomainIDGenerator
+    input = combine
+    subdomain_id = '0'
+  []
+
+  allow_renumbering = false
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  solid_blocks = '0'
+  initial_properties = xml
+  solid_cell_level = 0
+  tally_type = cell
+  power = 100.0
+  check_tally_sum = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/openmc_errors/mode/plot/plots.xml
+++ b/test/tests/openmc_errors/mode/plot/plots.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<plots>
+  <plot basis="xz" color_by="cell" filename="plot1" id="1" type="slice">
+    <origin>0.0 0.0 6.0</origin>
+    <width>4.0 12.0</width>
+    <pixels>100 300</pixels>
+  </plot>
+  <plot basis="xy" color_by="cell" filename="plot2" id="2" type="slice">
+    <origin>0.0 0.0 2.0</origin>
+    <width>4.0 4.0</width>
+    <pixels>100 100</pixels>
+  </plot>
+</plots>

--- a/test/tests/openmc_errors/mode/plot/settings.xml
+++ b/test/tests/openmc_errors/mode/plot/settings.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<settings>
+  <run_mode>plot</run_mode>
+  <particles>1000</particles>
+  <batches>50</batches>
+  <inactive>10</inactive>
+  <source strength="1.0">
+    <space type="fission">
+      <parameters>-5.0 -5.0 0 5.0 5.0 12.0</parameters>
+    </space>
+  </source>
+  <temperature_default>600.0</temperature_default>
+  <temperature_method>nearest</temperature_method>
+  <temperature_multipole>false</temperature_multipole>
+  <temperature_range>294.0 1600.0</temperature_range>
+</settings>

--- a/test/tests/openmc_errors/mode/plot/tests
+++ b/test/tests/openmc_errors/mode/plot/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [plot]
+    type = RunException
+    input = plot.i
+    expect_err = "Running OpenMC in plotting mode is not supported through Cardinal!"
+    requirement = "The system shall error if attempting to run OpenMC in plotting mode through Cardinal."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+[]

--- a/test/tests/openmc_errors/mode/volume/geometry.xml
+++ b/test/tests/openmc_errors/mode/volume/geometry.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<geometry>
+  <cell id="1" material="1" region="-1" universe="1" />
+  <cell id="2" material="2" region="-2" universe="1" />
+  <cell id="3" material="3" region="-3" universe="1" />
+  <cell id="4" material="4" region="1 2 3 4 -5 6 -7 8 -9" universe="1" />
+  <surface coeffs="0.0 0.0 0.0 1.5" id="1" type="sphere" />
+  <surface coeffs="0.0 0.0 4.0 1.5" id="2" type="sphere" />
+  <surface coeffs="0.0 0.0 8.0 1.5" id="3" type="sphere" />
+  <surface boundary="reflective" coeffs="-2.5" id="4" name="minimum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="5" name="maximum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="-2.5" id="6" name="minimum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="7" name="maximum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="-2.0" id="8" type="z-plane" />
+  <surface boundary="reflective" coeffs="10.0" id="9" type="z-plane" />
+</geometry>

--- a/test/tests/openmc_errors/mode/volume/materials.xml
+++ b/test/tests/openmc_errors/mode/volume/materials.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material depletable="true" id="1">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="9.051308944870946e-05" name="U234" />
+    <nuclide ao="0.010126612654073502" name="U235" />
+    <nuclide ao="0.9897364895065476" name="U238" />
+    <nuclide ao="4.63847499302226e-05" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="2">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="0.0004523305496680539" name="U234" />
+    <nuclide ao="0.05060678290832386" name="U235" />
+    <nuclide ao="0.948709083169038" name="U238" />
+    <nuclide ao="0.00023180337297007338" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="3">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="0.0009040745407538578" name="U234" />
+    <nuclide ao="0.10114794158928406" name="U235" />
+    <nuclide ao="0.8974846777145036" name="U238" />
+    <nuclide ao="0.00046330615545845175" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="4">
+    <density units="g/cc" value="1.0" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <nuclide ao="5.4e-05" name="U234" />
+    <nuclide ao="0.007204" name="U235" />
+    <nuclide ao="0.992742" name="U238" />
+  </material>
+</materials>

--- a/test/tests/openmc_errors/mode/volume/plots.xml
+++ b/test/tests/openmc_errors/mode/volume/plots.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<plots>
+  <plot basis="xz" color_by="cell" filename="plot1" id="1" type="slice">
+    <origin>0.0 0.0 6.0</origin>
+    <width>4.0 12.0</width>
+    <pixels>100 300</pixels>
+  </plot>
+  <plot basis="xy" color_by="cell" filename="plot2" id="2" type="slice">
+    <origin>0.0 0.0 2.0</origin>
+    <width>4.0 4.0</width>
+    <pixels>100 100</pixels>
+  </plot>
+</plots>

--- a/test/tests/openmc_errors/mode/volume/settings.xml
+++ b/test/tests/openmc_errors/mode/volume/settings.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='utf-8'?>
+<settings>
+  <run_mode>volume</run_mode>
+  <particles>1000</particles>
+  <batches>50</batches>
+  <inactive>10</inactive>
+  <source strength="1.0">
+    <space type="fission">
+      <parameters>-5.0 -5.0 0 5.0 5.0 12.0</parameters>
+    </space>
+  </source>
+  <temperature_default>600.0</temperature_default>
+  <temperature_method>nearest</temperature_method>
+  <temperature_multipole>false</temperature_multipole>
+  <temperature_range>294.0 1600.0</temperature_range>
+  <volume_calc>
+    <domain_type>cell</domain_type>
+    <domain_ids>1</domain_ids>
+    <samples>100000000</samples>
+    <lower_left>0 -11.20059522227874 0.0</lower_left>
+    <upper_right>11.20059522227874 11.20059522227874 25.0</upper_right>
+  </volume_calc>
+</settings>

--- a/test/tests/openmc_errors/mode/volume/tests
+++ b/test/tests/openmc_errors/mode/volume/tests
@@ -2,7 +2,7 @@
   [volume]
     type = RunException
     input = volume.i
-    expect_err = "Running OpenMC in volume mode is not supported through Cardinal!"
+    expect_err = "Running OpenMC in volume calculation mode is not supported through Cardinal!"
     requirement = "The system shall error if attempting to run OpenMC in volume mode through Cardinal."
     required_objects = 'OpenMCCellAverageProblem'
   []

--- a/test/tests/openmc_errors/mode/volume/tests
+++ b/test/tests/openmc_errors/mode/volume/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [volume]
+    type = RunException
+    input = volume.i
+    expect_err = "Running OpenMC in volume mode is not supported through Cardinal!"
+    requirement = "The system shall error if attempting to run OpenMC in volume mode through Cardinal."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+[]

--- a/test/tests/openmc_errors/mode/volume/volume.i
+++ b/test/tests/openmc_errors/mode/volume/volume.i
@@ -1,0 +1,39 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../../../neutronics/meshes/sphere.e
+  []
+  [combine]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 0
+                 0 0 4
+                 0 0 8'
+  []
+  [block]
+    type = SubdomainIDGenerator
+    input = combine
+    subdomain_id = '0'
+  []
+
+  allow_renumbering = false
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  solid_blocks = '0'
+  initial_properties = xml
+  solid_cell_level = 0
+  tally_type = cell
+  power = 100.0
+  check_tally_sum = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Outputs]
+  exodus = true
+[]


### PR DESCRIPTION
In preparation for a fixed source implementation, this PR adds some extra error checking for the OpenMC `RunMode` against other systems in Cardinal. Cardinal will now error if:

- You try to run an OpenMC input file in `plot`, `particle`, or `volume` mode. We would just need to modify the `externalSolve()` function to support these, but this would also require us to add logic to just run a single "time step" and kick out all the way through the multi-app hierarchy. I just don't think that's worth it when you can do exactly the same run with the `openmc` executable. So I added helpful error messages if a user encounters this.
- You try to use a k trigger or extract k or its standard deviation in a non-eigenvalue mode.