### PR TITLE
Enable different tally scores for heating

### DIFF
--- a/doc/content/source/problems/OpenMCCellAverageProblem.md
+++ b/doc/content/source/problems/OpenMCCellAverageProblem.md
@@ -503,6 +503,29 @@ that your problem satisfies all of the following criteria, you can set
 - Your `tallies.xml` file does not contain any other tallies that would fail
   to be spatially separate from the tallies automatically added by Cardinal.
 
+#### Tally Scores
+
+You can customize the type of score that OpenMC uses for its tally that gets
+mapped into the `heat_source` variable. Options include:
+
+- `heating`: total nuclear heating
+- `heating_local`: same as the `heating` score, except that energy from secondary photons
+   is deposited locally
+- `kappa_fission`: recoverable energy from fission, including prompt sources (fission fragments,
+   prompt neutrons, prompt gammas) and delayed sources (delayed neutrons,
+   delayed gammas, delayed betas). Neutrino energy is neglected. The energy from photons
+   is assumed to deposit locally.
+- `fission_q_prompt`: the prompt components of the `kappa_fission` score, except that the energy
+   released is a function of the incident energy by linking to optional fission energy release data.
+- `fission_q_recoverable`: same as the `kappa_fission` score, except that the score depends
+   on the incident energy by linking to optional fission energy release data
+- `damage_energy`: damage energy production
+
+All of the units for the above tallies are eV/source particle, which this class
+converts to a volumetric heat source according to the user-provided `power`.
+For more information on the specific meanings of these various scores,
+please consult the [OpenMC tally documentation](https://docs.openmc.org/en/stable/usersguide/tallies.html).
+
 #### Relaxation
 
 OpenMC is coupled to MOOSE via fixed point iteration, also referred to

--- a/doc/content/source/problems/OpenMCCellAverageProblem.md
+++ b/doc/content/source/problems/OpenMCCellAverageProblem.md
@@ -528,6 +528,11 @@ converts to a volumetric heat source according to the user-provided `power`.
 For more information on the specific meanings of these various scores,
 please consult the [OpenMC tally documentation](https://docs.openmc.org/en/stable/usersguide/tallies.html).
 
+The `damage_energy` score is unique because it doesn't really represent _heating_
+of a material - it instead represents energy for DPA calculations. For this case, the
+`heat_source` auxiliary variable should not be used in any type of volumetric heat
+source kernel.
+
 #### Relaxation
 
 OpenMC is coupled to MOOSE via fixed point iteration, also referred to

--- a/doc/content/source/problems/OpenMCCellAverageProblem.md
+++ b/doc/content/source/problems/OpenMCCellAverageProblem.md
@@ -47,7 +47,8 @@ First, `OpenMCCellAverageProblem` initializes [MooseVariables](https://moosefram
 to receive data necessary for multiphysics coupling. Depending on the settings
 for this class, the following variables will be added:
 
-- `heat_source`, the OpenMC fission heat source to be sent to MOOSE based on a `kappa-fission` tally score
+- `heat_source`, the OpenMC fission heat source to be sent to MOOSE; the particular tally score is
+   selected with the `tally_score` parameter
 - `temp`, the MOOSE temperature to be sent to OpenMC
 - `density`, the MOOSE density to be sent to OpenMC (fluid coupling)
 
@@ -282,8 +283,8 @@ locally "deepest" coordinate level.
 
 ## Adding Tallies
 
-This class automatically creates `kappa-fission` tallies (recoverable energy release
-from fission) in order to compute the fission power distribution. Cardinal includes
+This class automatically creates tallies
+in order to compute the power distribution. Cardinal includes
 two options for tallying the fission power in OpenMC:
 
 1. Cell tallies
@@ -291,7 +292,7 @@ two options for tallying the fission power in OpenMC:
 
 The tally type is specified with the `tally_type` parameter.
 The fission tally is normalized according to the specified `power`. By default,
-the normalization is done against a global `kappa-fission` tally added over the entire
+the normalization is done against a global tally added over the entire
 OpenMC domain. By setting `normalize_by_global_tally` to false, however, the fission tally is instead
 normalized by the sum of the fission tally itself. 
 
@@ -492,13 +493,13 @@ that your problem satisfies all of the following criteria, you can set
 `assume_separate_tallies = true` to greatly speed up the particle tracking rate:
 
 - `check_tally_sum = true`; when you set this parameter to true, Cardinal
-  automatically adds a **global** `kappa-fission` tally to check that your local
+  automatically adds a **global** tally to check that your local
   tally that couples to MOOSE didn't "miss" any fissile regions. However, when
   you add a global tally like this, any other tallies are no longer spatially
   separate.
 - `normalize_by_global_tally = true`; when you set this parameter to true,
-  Cardinal will again automatically add a **global** `kappa-fission` tally in order
-  to normalize the local `kappa-fission` tally that is coupled to MOOSE.
+  Cardinal will again automatically add a **global** tally in order
+  to normalize the local tally that is coupled to MOOSE.
   For the same reasons as above, your tallies will no longer be spatially separate.
 - Your `tallies.xml` file does not contain any other tallies that would fail
   to be spatially separate from the tallies automatically added by Cardinal.
@@ -521,6 +522,7 @@ mapped into the `heat_source` variable. Options include:
    on the incident energy by linking to optional fission energy release data
 - `damage_energy`: damage energy production
 
+For $k$-eigenvalue calculations, the tally score defaults to the `kappa_fission` mode.
 All of the units for the above tallies are eV/source particle, which this class
 converts to a volumetric heat source according to the user-provided `power`.
 For more information on the specific meanings of these various scores,
@@ -591,10 +593,10 @@ reaching a specified `threshold` in the following uncertainties:
 - $k$ standard deviation
 - $k$ variance
 - $k$ relative error
-- kappa-fission relative error
+- tally relative error
 
 Set the `k_trigger` parameter to activate a trigger based on $k$, and set
-`tally_trigger` to activate a trigger based on the kappa-fission tally created
+`tally_trigger` to activate a trigger based on the tally created
 automatically as part of the wrapping setup. Then, the desired convergence
 threshold is specified with the `k_trigger_threshold` and `tally_trigger_threshold`
 parameters, respectively. Both $k$ and tally triggers can be used simultaneously.

--- a/include/base/CardinalEnums.h
+++ b/include/base/CardinalEnums.h
@@ -24,6 +24,7 @@ MooseEnum getNekOrderEnum();
 MooseEnum getBinnedVelocityComponentEnum();
 MooseEnum getNekFieldEnum();
 MooseEnum getOperationEnum();
+MooseEnum getTallyScoreEnum();
 MooseEnum getTallyTypeEnum();
 MooseEnum getTallyEstimatorEnum();
 MooseEnum getEigenvalueEnum();
@@ -89,6 +90,20 @@ enum OperationEnum
   min
 };
 } // namespace operation
+
+namespace score
+{
+/// Type of score to use for OpenMC tallies coupled to MOOSE
+enum TallyScoreEnum
+{
+  heating,
+  heating_local,
+  kappa_fission,
+  fission_q_prompt,
+  fission_q_recoverable,
+  damage_energy
+};
+} // namespace score
 
 namespace tally
 {

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -963,6 +963,16 @@ protected:
   /// Helper utility to rotate [Mesh] points according to symmetry in OpenMC model
   std::unique_ptr<SymmetryPointGenerator> _symmetry;
 
+  /**
+   * \brief Whether the tally has a zero contribution in all non-fissile materials
+   *
+   * For scores involving energy from fission with entirely local deposition
+   * at the site of fission, we know that there will be zero contribution from cells
+   * not containing fissile materials. We can reduce the total number of added tally
+   * bins by ensuring we don't add tallies in non-fissile materials for these scores.
+   */
+  bool _tally_is_zero_in_nonfissile;
+
   /// Number of solid elements in each mapped OpenMC cell (global)
   std::map<cellInfo, int> _n_solid;
 

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -453,7 +453,7 @@ protected:
   void sendDensityToOpenMC();
 
   /**
-   * Extract the heat source from OpenMC and normalize by a global kappa fission tally,
+   * Extract the heat source from OpenMC and normalize by a global tally,
    * then apply as a uniform field to the corresponding MOOSE elements.
    */
   void getHeatSourceFromOpenMC();
@@ -472,30 +472,30 @@ protected:
   void getFissionTallyFromOpenMC(const unsigned int & var_num);
 
   /**
-   * Normalize the local tally by either the global kappa fission tally, or the sum
-   * of the local kappa fission tally
+   * Normalize the local tally by either the global tally, or the sum
+   * of the local tally
    * @param[in] tally_result value of tally result
    * @return normalized tally
    */
   Real normalizeLocalTally(const Real & tally_result) const;
 
   /**
-   * Normalize the local tally by either the global kappa fission tally, or the sum
-   * of the local kappa fission tally
+   * Normalize the local tally by either the global tally, or the sum
+   * of the local tally
    * @param[in] raw_tally value of tally result
    * @return normalized tally
    */
   xt::xtensor<double, 1> normalizeLocalTally(const xt::xtensor<double, 1> & raw_tally) const;
 
   /**
-   * Add the local kappa-fission tally
+   * Add the local tally
    * @param[in] filters tally filters
    */
   void addLocalTally(std::vector<openmc::Filter *> & filters);
 
   /**
    * Check the sum of the fluid and solid tallies (if present) against the global
-   * kappa fission tally.
+   * tally.
    */
   void checkTallySum() const;
 
@@ -529,7 +529,7 @@ protected:
   std::unique_ptr<NumericVector<Number>> _serialized_solution;
 
   /**
-   * Type of tally to apply to extract kappa fission score from OpenMC;
+   * Type of tally to apply to extract score from OpenMC;
    * if you want to tally in cells, use 'cell'. Otherwise, to tally on an
    * unstructured mesh, use 'mesh'. Currently, this implementation is limited
    * to a single mesh in the OpenMC geometry.
@@ -553,7 +553,7 @@ protected:
   const relaxation::RelaxationEnum _relaxation;
 
   /**
-   * Type of trigger to apply to OpenMC kappa-fission tallies to indicate when
+   * Type of trigger to apply to OpenMC tallies to indicate when
    * the simulation is complete. These can be used to on-the-fly adjust the number
    * of active batches in order to reach some desired criteria (which is specified
    * by this parameter).
@@ -641,9 +641,9 @@ protected:
   const Real & _scaling;
 
   /**
-   * How to normalize the OpenMC kappa-fission tally into units of W/volume. If 'true',
+   * How to normalize the OpenMC tally into units of W/volume. If 'true',
    * normalization is performed by dividing each local tally against a problem-global
-   * kappa-fission tally. The advantage of this approach is that some power-producing parts of the
+   * tally. The advantage of this approach is that some power-producing parts of the
    * OpenMC domain can be excluded from multiphysics feedback (without us having to guess
    * what the power of the *included* part of the domain is). This can let us do
    * "zooming" type calculations, where perhaps we only want to send T/H feedback to
@@ -655,16 +655,16 @@ protected:
    * for instance, a first-order sphere mesh will not perfectly match the volume of a
    * TRISO pebble - then not all of the power actually produced in the pebble is
    * tallies on the mesh approximation to that pebble. Therefore, if you set a core
-   * power of 1 MW and you normalized based on a global kappa fission tally, you'd always
+   * power of 1 MW and you normalized based on a global tally, you'd always
    * miss some of that power when sending to MOOSE. So, in this case, it is better to
    * normalize against the local tally itself so that the correct power is preserved.
    */
   const bool & _normalize_by_global;
 
   /**
-   * Whether to check the tallies against the global kappa fission tally;
+   * Whether to check the tallies against the global tally;
    * if set to true, and the tallies added for the 'tally_blocks' do not
-   * sum to the global kappa fission tally, an error is thrown. If you are
+   * sum to the global tally, an error is thrown. If you are
    * only performing multiphysics feedback for, say, a single assembly in a
    * full-core OpenMC model, you must set this check to false, because there
    * are known fission sources outside the domain of interest.
@@ -850,14 +850,14 @@ protected:
   /// Number of material-type cells contained within a cell
   std::map<cellInfo, int32_t> _cell_to_n_contained;
 
-  /// OpenMC cells to which a kappa fission tally is to be added
+  /// OpenMC cells to which a tally is to be added
   std::vector<cellInfo> _tally_cells;
 
-  /// Global kappa fission tally
+  /// Global tally
   openmc::Tally * _global_tally{nullptr};
 
   /**
-   * Local kappa fission tallies; multiple tallies will only exist when
+   * Local tallies; multiple tallies will only exist when
    * translating multiple unstructured meshes throughout the geometry
    */
   std::vector<openmc::Tally *> _local_tally;
@@ -874,11 +874,11 @@ protected:
   /// Density variable, which must be in units of kg/m3 based on internal conversions
   unsigned int _density_var;
 
-  /// Mean value of the global kappa fission tally
-  Real _global_kappa_fission;
+  /// Mean value of the global tally
+  Real _global_mean_tally;
 
-  /// Mean value of the local kappa fission tally
-  Real _local_kappa_fission;
+  /// Mean value of the local tally
+  Real _local_mean_tally;
 
   /**
    * For OpenMC geometries with a single coordinate level, we define default behavior for

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -775,6 +775,9 @@ protected:
   /// Tally estimator to use for the OpenMC tallies created for multiphysics
   openmc::TallyEstimator _tally_estimator;
 
+  /// Score to use for evaluating the tally that gets mapped to the 'heat_source' variable
+  std::string _tally_score;
+
   /// Blocks in MOOSE mesh that correspond to the fluid phase
   std::unordered_set<SubdomainID> _fluid_blocks;
 

--- a/include/postprocessors/FissionTallyRelativeError.h
+++ b/include/postprocessors/FissionTallyRelativeError.h
@@ -22,7 +22,7 @@
 #include "CardinalEnums.h"
 
 /**
- * Compute the max/min relative error of the kappa fission tally
+ * Compute the max/min relative error of the tally
  * added to extract the heat source from OpenMC.
  */
 class FissionTallyRelativeError : public OpenMCPostprocessor

--- a/src/base/CardinalEnums.C
+++ b/src/base/CardinalEnums.C
@@ -44,6 +44,12 @@ getOperationEnum()
 }
 
 MooseEnum
+getTallyScoreEnum()
+{
+  return MooseEnum("heating heating_local kappa_fission fission_q_prompt fission_q_recoverable damage_energy");
+}
+
+MooseEnum
 getTallyTypeEnum()
 {
   return MooseEnum("cell mesh");

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -2112,18 +2112,18 @@ Real
 OpenMCCellAverageProblem::normalizeLocalTally(const Real & tally_result) const
 {
   if (_normalize_by_global)
-    return tally_result / _global_kappa_fission;
+    return tally_result / _global_mean_tally;
   else
-    return tally_result / _local_kappa_fission;
+    return tally_result / _local_mean_tally;
 }
 
 xt::xtensor<double, 1>
 OpenMCCellAverageProblem::normalizeLocalTally(const xt::xtensor<double, 1> & raw_tally) const
 {
   if (_normalize_by_global)
-    return raw_tally / _global_kappa_fission;
+    return raw_tally / _global_mean_tally;
   else
-    return raw_tally / _local_kappa_fission;
+    return raw_tally / _local_mean_tally;
 }
 
 void
@@ -2312,13 +2312,13 @@ OpenMCCellAverageProblem::dufekGudowskiParticleUpdate()
 void
 OpenMCCellAverageProblem::getHeatSourceFromOpenMC()
 {
-  _console << "Extracting OpenMC fission heat source... " << printNewline();
+  _console << "Extracting OpenMC heat source... " << printNewline();
 
-  // get the total kappa fission sources for normalization
+  // get the total tallies for normalization
   if (_global_tally)
-    _global_kappa_fission = tallySum({_global_tally});
+    _global_mean_tally = tallySum({_global_tally});
 
-  _local_kappa_fission = tallySum(_local_tally);
+  _local_mean_tally = tallySum(_local_tally);
 
   if (_check_tally_sum)
     checkTallySum();
@@ -2481,13 +2481,13 @@ OpenMCCellAverageProblem::syncSolutions(ExternalProblem::Direction direction)
 void
 OpenMCCellAverageProblem::checkTallySum() const
 {
-  if (std::abs(_global_kappa_fission - _local_kappa_fission) / _global_kappa_fission >
+  if (std::abs(_global_mean_tally - _local_mean_tally) / _global_mean_tally >
       openmc::FP_REL_PRECISION)
   {
     std::stringstream msg;
     msg << "Heating tallies do not match the global " << _tally_score << " tally:\n"
-        << " Global value: " << Moose::stringify(_global_kappa_fission)
-        << "\n Tally sum: " << Moose::stringify(_local_kappa_fission)
+        << " Global value: " << Moose::stringify(_global_mean_tally)
+        << "\n Tally sum: " << Moose::stringify(_local_mean_tally)
         << "\n\nYou can turn off this check by setting 'check_tally_sum' to false.";
 
     // Add on extra helpful messages if the domain has a single coordinate level
@@ -2529,7 +2529,7 @@ OpenMCCellAverageProblem::checkTallySum() const
           missing_tallies = "solid";
 
         msg << "\n\nYour problem didn't add tallies for the " << missing_tallies
-            << "; this warning might be caused by\nfission sources in these regions that "
+            << "; this warning might be caused by\nheat sources in these regions that "
                "contribute to the global " << _tally_score << " tally, without being\npart of the "
                "multiphysics setup.";
       }

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -240,7 +240,8 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     _total_n_particles(0),
     _temperature_vars(nullptr),
     _temperature_blocks(nullptr),
-    _symmetry(nullptr)
+    _symmetry(nullptr),
+    _tally_is_zero_in_nonfissile(false)
 {
   if (isParamValid("tally_estimator"))
   {
@@ -298,12 +299,15 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
       break;
     case score::kappa_fission:
       _tally_score = "kappa-fission";
+      _tally_is_zero_in_nonfissile = true;
       break;
     case score::fission_q_prompt:
       _tally_score = "fission-q-prompt";
+      _tally_is_zero_in_nonfissile = true;
       break;
     case score::fission_q_recoverable:
       _tally_score = "fission-q-recoverable";
+      _tally_is_zero_in_nonfissile = true;
       break;
     case score::damage_energy:
       _tally_score = "damage-energy";
@@ -1609,8 +1613,9 @@ OpenMCCellAverageProblem::storeTallyCells()
 
     if (_cell_has_tally[cell_info])
     {
-      // if the cell doesn't have fissile material, don't add a tally to save some evaluation
-      if (!cellHasFissileMaterials(cell_info))
+      // if the cell doesn't have fissile material AND the tally has nonzero contributions in non-fissile materials,
+      //  don't add a tally to save some evaluation
+      if (!cellHasFissileMaterials(cell_info) && _tally_is_zero_in_nonfissile)
       {
         // for the special case of a single coordinate level, just silently skip adding the tallies
         if (_using_default_tally_blocks)

--- a/src/postprocessors/FissionTallyRelativeError.C
+++ b/src/postprocessors/FissionTallyRelativeError.C
@@ -30,7 +30,7 @@ FissionTallyRelativeError::validParams()
   params.addParam<MooseEnum>("value_type",
                              getOperationEnum(),
                              "Whether to give the maximum or minimum tally relative error");
-  params.addClassDescription("Extract the maximum/minimum fission tally relative error");
+  params.addClassDescription("Extract the maximum/minimum tally relative error");
   return params;
 }
 

--- a/test/tests/neutronics/feedback/lattice/gold/damage_energy_out.csv
+++ b/test/tests/neutronics/feedback/lattice/gold/damage_energy_out.csv
@@ -1,0 +1,3 @@
+time,clad_heat_source,fluid_heat_source,fuel_heat_source,heat_source
+0,0,0,0,0
+1,73.894512075628,134.37810298077,291.7273849436,500

--- a/test/tests/neutronics/feedback/lattice/gold/fission_q_prompt_out.csv
+++ b/test/tests/neutronics/feedback/lattice/gold/fission_q_prompt_out.csv
@@ -1,0 +1,3 @@
+time,clad_heat_source,fluid_heat_source,fuel_heat_source,heat_source
+0,0,0,0,0
+1,0,0,500,500

--- a/test/tests/neutronics/feedback/lattice/gold/fission_q_recoverable_out.csv
+++ b/test/tests/neutronics/feedback/lattice/gold/fission_q_recoverable_out.csv
@@ -1,0 +1,3 @@
+time,clad_heat_source,fluid_heat_source,fuel_heat_source,heat_source
+0,0,0,0,0
+1,0,0,500,500

--- a/test/tests/neutronics/feedback/lattice/gold/heating_local_out.csv
+++ b/test/tests/neutronics/feedback/lattice/gold/heating_local_out.csv
@@ -1,0 +1,3 @@
+time,clad_heat_source,fluid_heat_source,fuel_heat_source,heat_source
+0,0,0,0,0
+1,1.1246590812502,5.3313004042218,493.54404051453,500

--- a/test/tests/neutronics/feedback/lattice/gold/heating_out.csv
+++ b/test/tests/neutronics/feedback/lattice/gold/heating_out.csv
@@ -1,0 +1,3 @@
+time,clad_heat_source,fluid_heat_source,fuel_heat_source,heat_source
+0,0,0,0,0
+1,0.072120222231302,5.7437056533484,494.18417412442,499.99999999999

--- a/test/tests/neutronics/feedback/lattice/openmc_scores.i
+++ b/test/tests/neutronics/feedback/lattice/openmc_scores.i
@@ -1,0 +1,66 @@
+[Mesh]
+  type = FileMesh
+  file = ../../meshes/pincell.e
+[]
+
+[AuxVariables]
+  [cell_id]
+    family = MONOMIAL
+    order = CONSTANT
+  []
+[]
+
+[AuxKernels]
+  [cell_id]
+    type = CellIDAux
+    variable = cell_id
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 500.0
+  solid_blocks = '1 3'
+  fluid_blocks = '2'
+  tally_blocks = '1 2 3'
+  tally_type = cell
+  solid_cell_level = 1
+  fluid_cell_level = 1
+  initial_properties = xml
+  check_tally_sum = false
+  check_zero_tallies = false
+
+  tally_score = heating
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Postprocessors]
+  [heat_source]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+  []
+  [fluid_heat_source]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+    block = '2'
+  []
+  [fuel_heat_source]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+    block = '1'
+  []
+  [clad_heat_source]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+    block = '3'
+  []
+[]
+
+[Outputs]
+  exodus = true
+  csv = true
+[]

--- a/test/tests/neutronics/feedback/lattice/tests
+++ b/test/tests/neutronics/feedback/lattice/tests
@@ -9,4 +9,44 @@
                   "a case built without distributed cells in ../single_level."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [heating]
+    type = CSVDiff
+    input = openmc_scores.i
+    csvdiff = heating_out.csv
+    cli_args = 'Outputs/file_base=heating_out'
+    requirement = "The system shall allow the user to specify a 'heating' score in the OpenMC tally."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+  [heating_local]
+    type = CSVDiff
+    input = openmc_scores.i
+    csvdiff = heating_local_out.csv
+    cli_args = 'Problem/tally_score=heating_local Outputs/file_base=heating_local_out'
+    requirement = "The system shall allow the user to specify a 'heating-local' score in the OpenMC tally."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+  [damage_energy]
+    type = CSVDiff
+    input = openmc_scores.i
+    csvdiff = damage_energy_out.csv
+    cli_args = 'Problem/tally_score=damage_energy Outputs/file_base=damage_energy_out'
+    requirement = "The system shall allow the user to specify a 'damage-energy' score in the OpenMC tally."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+  [fission_q_prompt]
+    type = CSVDiff
+    input = openmc_scores.i
+    csvdiff = fission_q_prompt_out.csv
+    cli_args = 'Problem/tally_score=fission_q_prompt Outputs/file_base=fission_q_prompt_out'
+    requirement = "The system shall allow the user to specify a 'fission-q-prompt' score in the OpenMC tally."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+  [fission_q_recoverable]
+    type = CSVDiff
+    input = openmc_scores.i
+    csvdiff = fission_q_recoverable_out.csv
+    cli_args = 'Problem/tally_score=fission_q_recoverable Outputs/file_base=fission_q_recoverable_out'
+    requirement = "The system shall allow the user to specify a 'fission-q-recoverable' score in the OpenMC tally."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
 []


### PR DESCRIPTION
To support fixed source mode, we will want Cardinal to support other tally scores to couple to MOOSE. This adds an enumeration for the available tally scores:

- `heating`
- `heating-local`
- `kappa-fission` (default)
- `fission-q-prompt`
- `fission-q-recoverable`
- `damage-energy`

I just added all the scores that have units of eV/particle. Most of the changes in this PR are just removing specific code comments/changing member variables names to not be so specific to a kappa fission score. The only notable changes are:

- adding the new scores, plus tests
- being sure to only use the "does the cell have fissionable material?" check for the `kappa-fission`, `fission-q-prompt` and `fission-q-recoverable` scores