### PR TITLE
Fixed source mode

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -374,7 +374,7 @@ protected:
    * for k-eigenvalue simulations), we are basically relaxing the distribution of the heat
    * source, but then multiplying it by the _current_ mean tally magnitude.
    *
-   * There will be very small errors in these approximations unless power/the source strength
+   * There will be very small errors in these approximations unless the power/source strength
    * change dramatically with iteration. But because relaxation is itself a numerical approximation,
    * this is still inconsequential at the end of the day as long as your problem has converged
    * the relaxed heat source to the raw (unrelaxed) tally.

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -361,7 +361,7 @@ protected:
 
   /**
    * Relax the heat source and normalize it so that it has units of power fraction (i.e. an
-   * integral of unity, where that "integral" is over the entire OpenMC domain if you set
+   * integral of unity, where that "integral" is over the entire OpenMC domain) if you set
    * 'normalize_by_global_tally = true', but only over the Cardinal-created tallies if you
    * instead set 'normalize_by_global_tally = false'.
    *

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -674,7 +674,7 @@ protected:
    * to normalize by the local tally, we're probably using mesh tallies). But you can
    * of course still set a value for this parameter to override the default.
    */
-  const bool & _check_tally_sum;
+  const bool _check_tally_sum;
 
   /**
    * Whether to check that the [Mesh] volume each cell tally maps to is identical.

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -359,6 +359,26 @@ protected:
    */
   void storeElementPhase();
 
+  /**
+   * Relax the heat source and normalize it so that it has units of power fraction (i.e. an
+   * integral of unity, where that "integral" is over the entire OpenMC domain if you set
+   * 'normalize_by_global_tally = true', but only over the Cardinal-created tallies if you
+   * instead set 'normalize_by_global_tally = false'.
+   *
+   * NOTE: This function relaxes the power _distribution_, and not the actual magnitude of the
+   * power. That is, we relax the power distribution and then multiply it by the power
+   * (for k-eigenvalue) or source strength (for fixed source) of _the current step_ before
+   * applying it to MOOSE. If the magnitude of the power is constant in time, there is zero
+   * error in this. But for fixed source simulations where the actual magnitude of the tally
+   * can vary based on simulation (b/c we don't renormalize it in the sense that we do
+   * for k-eigenvalue simulations), we are basically relaxing the distribution of the heat
+   * source, but then multiplying it by the _current_ mean tally magnitude.
+   *
+   * There will be very small errors in these approximations unless power/the source strength
+   * change dramatically with iteration. But because relaxation is itself a numerical approximation,
+   * this is still inconsequential at the end of the day as long as your problem has converged
+   * the relaxed heat source to the raw (unrelaxed) tally.
+   */
   void relaxAndNormalizeHeatSource(const int & t);
 
   /**

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -43,11 +43,18 @@ public:
   void importProperties() const;
 
   /**
-   * Compute the mean value of a tally
+   * Compute the sum of a tally
    * @param[in] tally OpenMC tallies (multiple if repeated mesh tallies)
-   * @return mean value
+   * @return tally sum
    */
   double tallySum(std::vector<openmc::Tally *> tally) const;
+
+  /**
+   * Compute the mean of a tally
+   * @param[in] tally OpenMC tallies (multiple if repeated mesh tallies)
+   * @return tally mean
+   */
+  double tallyMean(std::vector<openmc::Tally *> tally) const;
 
   /**
    * Type definition for storing the relevant aspects of the OpenMC geometry; the first
@@ -198,11 +205,14 @@ protected:
     return _path_output + "initial_source_" + std::to_string(_fixed_point_iteration) + ".h5";
   }
 
-  /// Power by which to normalize the OpenMC results
-  const Real & _power;
-
   /// Whether to print diagnostic information about model setup and the transfers
   const bool & _verbose;
+
+  /// Power by which to normalize the OpenMC results, for k-eigenvalue mode
+  const Real * _power;
+
+  /// Source strength by which to normalize the OpenMC results, for fixed source mode
+  const Real * _source_strength;
 
   /**
    * Whether to take the starting fission source from iteration \f$n\f$ as the

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -211,7 +211,7 @@ protected:
    * progress because you don't "start from scratch" each iteration and do the same
    * identical (within a random number seed) converging of the fission source.
    */
-  const bool & _reuse_source;
+  bool _reuse_source;
 
   /**
    * Whether the OpenMC model consists of a single coordinate level; this can

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -43,18 +43,31 @@ public:
   void importProperties() const;
 
   /**
-   * Compute the sum of a tally
+   * \brief Compute the sum of a tally within each bin
+   *
+   * For example, suppose we have a cell tally with 4 bins, one for each of 4
+   * different cells. This function will return the sum of the tally in each of
+   * those bins, so the return xtensor will have a length of 4, with each value
+   * representing the sum for that bin.
+   *
+   * @param[in] tally OpenMC tally
+   * @return tally sum within each bin
+   */
+  xt::xtensor<double, 1> tallySum(openmc::Tally * tally) const;
+
+  /**
+   * Compute the sum of a tally across all of its bins
    * @param[in] tally OpenMC tallies (multiple if repeated mesh tallies)
    * @return tally sum
    */
-  double tallySum(std::vector<openmc::Tally *> tally) const;
+  double tallySumAcrossBins(std::vector<openmc::Tally *> tally) const;
 
   /**
-   * Compute the mean of a tally
+   * Compute the mean of a tally across all of its bins
    * @param[in] tally OpenMC tallies (multiple if repeated mesh tallies)
    * @return tally mean
    */
-  double tallyMean(std::vector<openmc::Tally *> tally) const;
+  double tallyMeanAcrossBins(std::vector<openmc::Tally *> tally) const;
 
   /**
    * Type definition for storing the relevant aspects of the OpenMC geometry; the first

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -226,7 +226,8 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     _scaling(getParam<Real>("scaling")),
     _normalize_by_global(getParam<bool>("normalize_by_global_tally")),
     _check_tally_sum(isParamValid("check_tally_sum") ? getParam<bool>("check_tally_sum")
-                                                     : _normalize_by_global),
+                                                     : (openmc::settings::run_mode == openmc::RunMode::FIXED_SOURCE ?
+                                                        true : _normalize_by_global)),
     _check_equal_mapped_tally_volumes(getParam<bool>("check_equal_mapped_tally_volumes")),
     _relaxation_factor(getParam<Real>("relaxation_factor")),
     _identical_tally_cell_fills(getParam<bool>("identical_tally_cell_fills")),
@@ -244,6 +245,9 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     _symmetry(nullptr),
     _tally_is_zero_in_nonfissile(false)
 {
+  if (openmc::settings::run_mode == openmc::RunMode::FIXED_SOURCE)
+    checkUnusedParam(params, "normalize_by_global_tally", "running OpenMC in fixed source mode");
+
   if (isParamValid("tally_estimator"))
   {
     auto estimator = getParam<MooseEnum>("tally_estimator").getEnum<tally::TallyEstimatorEnum>();

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -2175,8 +2175,7 @@ OpenMCCellAverageProblem::getFissionTallyFromOpenMC(const unsigned int & var_num
   {
     case tally::cell:
     {
-      auto tally = _local_tally.at(0);
-      auto sum = xt::view(tally->results_, xt::all(), 0, static_cast<int>(openmc::TallyResult::SUM));
+      auto sum = tallySum(_local_tally.at(0));
 
       int i = 0;
       for (const auto & c : _cell_to_elem)
@@ -2202,9 +2201,7 @@ OpenMCCellAverageProblem::getFissionTallyFromOpenMC(const unsigned int & var_num
     for (unsigned int i = 0; i < _mesh_filters.size(); ++i)
     {
       const auto * filter = _mesh_filters[i];
-
-      auto tally = _local_tally.at(i);
-      auto sum = xt::view(tally->results_, xt::all(), 0, static_cast<int>(openmc::TallyResult::SUM));
+      auto sum = tallySum(_local_tally.at(i));
 
       for (decltype(filter->n_bins()) e = 0; e < filter->n_bins(); ++e)
       {
@@ -2233,8 +2230,7 @@ OpenMCCellAverageProblem::getFissionTallyStandardDeviationFromOpenMC(const unsig
     case tally::cell:
     {
       auto tally = _local_tally.at(0);
-      auto sum =
-          xt::view(tally->results_, xt::all(), 0, static_cast<int>(openmc::TallyResult::SUM));
+      auto sum = tallySum(_local_tally.at(0));
       auto sum_sq =
           xt::view(tally->results_, xt::all(), 0, static_cast<int>(openmc::TallyResult::SUM_SQ));
 
@@ -2267,8 +2263,7 @@ OpenMCCellAverageProblem::getFissionTallyStandardDeviationFromOpenMC(const unsig
         const auto * filter = _mesh_filters[i];
 
         auto tally = _local_tally.at(i);
-        auto sum =
-            xt::view(tally->results_, xt::all(), 0, static_cast<int>(openmc::TallyResult::SUM));
+        auto sum = tallySum(_local_tally.at(i));
         auto sum_sq =
             xt::view(tally->results_, xt::all(), 0, static_cast<int>(openmc::TallyResult::SUM_SQ));
 
@@ -2301,8 +2296,7 @@ OpenMCCellAverageProblem::relaxAndNormalizeHeatSource(const int & t)
   // return
   if (_fixed_point_iteration == 0 || _relaxation == relaxation::none)
   {
-    auto mean_tally = xt::view(
-        _local_tally.at(t)->results_, xt::all(), 0, static_cast<int>(openmc::TallyResult::SUM));
+    auto mean_tally = tallySum(_local_tally.at(t));
     _current_mean_tally[t] = normalizeLocalTally(mean_tally);
     _previous_mean_tally[t] = normalizeLocalTally(mean_tally);
     return;
@@ -2312,8 +2306,7 @@ OpenMCCellAverageProblem::relaxAndNormalizeHeatSource(const int & t)
   std::copy(_current_mean_tally[t].cbegin(),
             _current_mean_tally[t].cend(),
             _previous_mean_tally[t].begin());
-  auto mean_tally = xt::view(
-      _local_tally.at(t)->results_, xt::all(), 0, static_cast<int>(openmc::TallyResult::SUM));
+  auto mean_tally = tallySum(_local_tally.at(t));
 
   double alpha;
   switch (_relaxation)
@@ -2358,9 +2351,9 @@ OpenMCCellAverageProblem::getHeatSourceFromOpenMC()
 
   // get the total tallies for normalization
   if (_global_tally)
-    _global_mean_tally = tallySum({_global_tally});
+    _global_mean_tally = tallySumAcrossBins({_global_tally});
 
-  _local_mean_tally = tallySum(_local_tally);
+  _local_mean_tally = tallySumAcrossBins(_local_tally);
 
   if (_check_tally_sum)
     checkTallySum();

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -224,9 +224,11 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     _export_properties(getParam<bool>("export_properties")),
     _specified_scaling(params.isParamSetByUser("scaling")),
     _scaling(getParam<Real>("scaling")),
-    _normalize_by_global(getParam<bool>("normalize_by_global_tally")),
-    _check_tally_sum(isParamValid("check_tally_sum") ? getParam<bool>("check_tally_sum")
-                                                     : (openmc::settings::run_mode == openmc::RunMode::FIXED_SOURCE ?
+    _run_mode(openmc::settings::run_mode),
+    _normalize_by_global(_run_mode == openmc::RunMode::FIXED_SOURCE ? false :
+                                      getParam<bool>("normalize_by_global_tally")),
+    _check_tally_sum(isParamValid("check_tally_sum") ? getParam<bool>("check_tally_sum") :
+                                                       (_run_mode == openmc::RunMode::FIXED_SOURCE ?
                                                         true : _normalize_by_global)),
     _check_equal_mapped_tally_volumes(getParam<bool>("check_equal_mapped_tally_volumes")),
     _relaxation_factor(getParam<Real>("relaxation_factor")),
@@ -245,7 +247,7 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     _symmetry(nullptr),
     _tally_is_zero_in_nonfissile(false)
 {
-  if (openmc::settings::run_mode == openmc::RunMode::FIXED_SOURCE)
+  if (_run_mode == openmc::RunMode::FIXED_SOURCE)
     checkUnusedParam(params, "normalize_by_global_tally", "running OpenMC in fixed source mode");
 
   if (isParamValid("tally_estimator"))
@@ -285,7 +287,7 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     }
   }
 
-  if (openmc::settings::run_mode != openmc::RunMode::EIGENVALUE && _k_trigger != tally::none)
+  if (_run_mode != openmc::RunMode::EIGENVALUE && _k_trigger != tally::none)
     mooseError("Cannot specify a 'k_trigger' for OpenMC runs that are not eigenvalue mode!");
 
   score::TallyScoreEnum score;
@@ -2130,42 +2132,28 @@ OpenMCCellAverageProblem::checkZeroTally(const Real & power_fraction,
 Real
 OpenMCCellAverageProblem::tallyMultiplier() const
 {
-  if (openmc::settings::run_mode == openmc::RunMode::EIGENVALUE)
+  if (_run_mode == openmc::RunMode::EIGENVALUE)
     return *_power;
   else
-    return *_source_strength * EV_TO_JOULE;
+    return *_source_strength * EV_TO_JOULE * _local_mean_tally;
 }
 
 Real
 OpenMCCellAverageProblem::normalizeLocalTally(const Real & tally_result) const
 {
-  if (openmc::settings::run_mode == openmc::RunMode::EIGENVALUE)
-  {
-    if (_normalize_by_global)
-      return tally_result / _global_mean_tally;
-    else
-      return tally_result / _local_mean_tally;
-  }
+  if (_normalize_by_global)
+    return tally_result / _global_sum_tally;
   else
-  {
-    return tally_result;
-  }
+    return tally_result / _local_sum_tally;
 }
 
 xt::xtensor<double, 1>
 OpenMCCellAverageProblem::normalizeLocalTally(const xt::xtensor<double, 1> & raw_tally) const
 {
-  if (openmc::settings::run_mode == openmc::RunMode::EIGENVALUE)
-  {
-    if (_normalize_by_global)
-      return raw_tally / _global_mean_tally;
-    else
-      return raw_tally / _local_mean_tally;
-  }
+  if (_normalize_by_global)
+    return raw_tally / _global_sum_tally;
   else
-  {
-    return raw_tally;
-  }
+    return raw_tally / _local_sum_tally;
 }
 
 void
@@ -2351,9 +2339,10 @@ OpenMCCellAverageProblem::getHeatSourceFromOpenMC()
 
   // get the total tallies for normalization
   if (_global_tally)
-    _global_mean_tally = tallySumAcrossBins({_global_tally});
+    _global_sum_tally = tallySumAcrossBins({_global_tally});
 
-  _local_mean_tally = tallySumAcrossBins(_local_tally);
+  _local_sum_tally = tallySumAcrossBins(_local_tally);
+  _local_mean_tally = tallyMeanAcrossBins(_local_tally);
 
   if (_check_tally_sum)
     checkTallySum();
@@ -2379,7 +2368,7 @@ OpenMCCellAverageProblem::getHeatSourceFromOpenMC()
 
         // divide each tally value by the volume that it corresponds to in MOOSE
         // because we will apply it as a volumetric heat source (W/volume).
-        Real volumetric_power = power_fraction * _power / _cell_to_elem_volume[cell_info];
+        Real volumetric_power = power_fraction * tallyMultiplier() / _cell_to_elem_volume[cell_info];
         power_fraction_sum += power_fraction;
 
         if (_verbose)
@@ -2412,7 +2401,7 @@ OpenMCCellAverageProblem::getHeatSourceFromOpenMC()
           // Because we require that the mesh template has units of cm based on the
           // mesh constructors in OpenMC, we need to adjust the division
           Real volumetric_power =
-              power_fraction * _power / _mesh_template->volume(e) * _scaling * _scaling * _scaling;
+              power_fraction * tallyMultiplier() / _mesh_template->volume(e) * _scaling * _scaling * _scaling;
           power_fraction_sum += power_fraction;
           template_power_fraction += power_fraction;
 
@@ -2516,13 +2505,13 @@ OpenMCCellAverageProblem::syncSolutions(ExternalProblem::Direction direction)
 void
 OpenMCCellAverageProblem::checkTallySum() const
 {
-  if (std::abs(_global_mean_tally - _local_mean_tally) / _global_mean_tally >
+  if (std::abs(_global_sum_tally - _local_sum_tally) / _global_sum_tally >
       openmc::FP_REL_PRECISION)
   {
     std::stringstream msg;
     msg << "Heating tallies do not match the global " << _tally_score << " tally:\n"
-        << " Global value: " << Moose::stringify(_global_mean_tally)
-        << "\n Tally sum: " << Moose::stringify(_local_mean_tally)
+        << " Global value: " << Moose::stringify(_global_sum_tally)
+        << "\n Tally sum: " << Moose::stringify(_local_sum_tally)
         << "\n\nYou can turn off this check by setting 'check_tally_sum' to false.";
 
     // Add on extra helpful messages if the domain has a single coordinate level

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -454,4 +454,14 @@ OpenMCProblemBase::tallySum(std::vector<openmc::Tally *> tally) const
   return sum;
 }
 
+double
+OpenMCProblemBase::tallyMean(std::vector<openmc::Tally *> tally) const
+{
+  int n = 0;
+  for (const auto & t : tally)
+    n += t->n_realizations_;
+
+  return tallySum(tally) / n;
+}
+
 #endif

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -86,12 +86,15 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
 
     checkUnusedParam(params, "inactive_batches", "running in fixed source mode");
     checkUnusedParam(params, "reuse_source", "running in fixed source mode");
+    checkUnusedParam(params, "power", "running in fixed source mode");
     _reuse_source = false;
   }
   else
   {
     checkRequiredParam(params, "power", "running in k-eigenvalue mode");
     _power = &getPostprocessorValue("power");
+
+    checkUnusedParam(params, "source_strength", "running in k-eigenvalue mode");
   }
 
   if (openmc::settings::libmesh_comm)

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -440,14 +440,20 @@ OpenMCProblemBase::relativeError(const Real & sum,
   return mean != 0.0 ? std_dev / std::abs(mean) : 0.0;
 }
 
+xt::xtensor<double, 1>
+OpenMCProblemBase::tallySum(openmc::Tally * tally) const
+{
+  return xt::view(tally->results_, xt::all(), 0, static_cast<int>(openmc::TallyResult::SUM));
+}
+
 double
-OpenMCProblemBase::tallySum(std::vector<openmc::Tally *> tally) const
+OpenMCProblemBase::tallySumAcrossBins(std::vector<openmc::Tally *> tally) const
 {
   double sum = 0.0;
 
   for (const auto & t : tally)
   {
-    auto mean = xt::view(t->results_, xt::all(), 0, static_cast<int>(openmc::TallyResult::SUM));
+    auto mean = tallySum(t);
     sum += xt::sum(mean)();
   }
 
@@ -455,13 +461,13 @@ OpenMCProblemBase::tallySum(std::vector<openmc::Tally *> tally) const
 }
 
 double
-OpenMCProblemBase::tallyMean(std::vector<openmc::Tally *> tally) const
+OpenMCProblemBase::tallyMeanAcrossBins(std::vector<openmc::Tally *> tally) const
 {
   int n = 0;
   for (const auto & t : tally)
     n += t->n_realizations_;
 
-  return tallySum(tally) / n;
+  return tallySumAcrossBins(tally) / n;
 }
 
 #endif

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -20,6 +20,7 @@
 
 #include "OpenMCProblemBase.h"
 #include "AuxiliarySystem.h"
+#include "UserErrorChecking.h"
 
 #include "mpi.h"
 #include "openmc/capi.h"
@@ -77,6 +78,9 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
     _path_output(openmc::settings::path_output),
     _n_cell_digits(std::to_string(openmc::model::cells.size()).length())
 {
+  if (openmc::settings::run_mode != openmc::RunMode::EIGENVALUE)
+    checkUnusedParam(params, "inactive_batches", "not running in k-eigenvalue mode");
+
   if (openmc::settings::libmesh_comm)
     mooseWarning("libMesh communicator already set in OpenMC.");
 

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -79,7 +79,11 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
     _n_cell_digits(std::to_string(openmc::model::cells.size()).length())
 {
   if (openmc::settings::run_mode != openmc::RunMode::EIGENVALUE)
+  {
     checkUnusedParam(params, "inactive_batches", "not running in k-eigenvalue mode");
+    checkUnusedParam(params, "reuse_source", "not running in k-eigenvalue mode");
+    _reuse_source = false;
+  }
 
   if (openmc::settings::libmesh_comm)
     mooseWarning("libMesh communicator already set in OpenMC.");

--- a/test/tests/neutronics/fixed_source/gold/overlap_all_out.csv
+++ b/test/tests/neutronics/fixed_source/gold/overlap_all_out.csv
@@ -1,0 +1,3 @@
+time,heat_source,heat_source_fluid,heat_source_solid
+0,0,0,0
+1,140.78396879781,5.7359472826065,135.0480215152

--- a/test/tests/neutronics/fixed_source/gold/overlap_solid_out.csv
+++ b/test/tests/neutronics/fixed_source/gold/overlap_solid_out.csv
@@ -1,0 +1,3 @@
+time,heat_source,heat_source_fluid,heat_source_solid
+0,0,0,0
+1,135.0480215152,0,135.0480215152

--- a/test/tests/neutronics/fixed_source/overlap_all.i
+++ b/test/tests/neutronics/fixed_source/overlap_all.i
@@ -1,0 +1,100 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../meshes/sphere.e
+  []
+  [solid]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 0
+                 0 0 4
+                 0 0 8'
+  []
+  [solid_ids]
+    type = SubdomainIDGenerator
+    input = solid
+    subdomain_id = '100'
+  []
+  [fluid]
+    type = FileMeshGenerator
+    file = ../heat_source/stoplight.exo
+  []
+  [fluid_ids]
+    type = SubdomainIDGenerator
+    input = fluid
+    subdomain_id = '200'
+  []
+  [combine]
+    type = CombinerGenerator
+    inputs = 'solid_ids fluid_ids'
+  []
+[]
+
+# This AuxVariable and AuxKernel is only here to get the postprocessors
+# to evaluate correctly. This can be deleted after MOOSE issue #17534 is fixed.
+[AuxVariables]
+  [dummy]
+  []
+[]
+
+[AuxKernels]
+  [dummy]
+    type = ConstantAux
+    variable = dummy
+    value = 0.0
+  []
+[]
+
+[ICs]
+  [temp]
+    type = ConstantIC
+    variable = temp
+    value = 600.0
+  []
+  [rho]
+    type = ConstantIC
+    variable = density
+    value = 100.0
+    block = '200'
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  verbose = true
+  source_strength = 1e12
+  solid_blocks = '100'
+  fluid_blocks = '200'
+  tally_blocks = '100 200'
+  solid_cell_level = 0
+  fluid_cell_level = 0
+  tally_type = cell
+  initial_properties = xml
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Postprocessors]
+  [heat_source]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+  []
+  [heat_source_fluid]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+    block = '200'
+  []
+  [heat_source_solid]
+    type = ElementIntegralVariablePostprocessor
+    variable = heat_source
+    block = '100'
+  []
+[]
+
+[Outputs]
+  exodus = true
+  csv = true
+[]

--- a/test/tests/neutronics/fixed_source/overlap_solid.i
+++ b/test/tests/neutronics/fixed_source/overlap_solid.i
@@ -50,12 +50,14 @@
   verbose = true
   source_strength = 1e12
   solid_blocks = '100'
-  fluid_blocks = '200'
-  tally_blocks = '100 200'
+  tally_blocks = '100'
   solid_cell_level = 0
-  fluid_cell_level = 0
   tally_type = cell
   initial_properties = xml
+
+  # we are omitting the fluid regions from feedback (which have some fissile material),
+  # so we need to explicitly skip the tally check
+  check_tally_sum = false
 []
 
 [Executioner]

--- a/test/tests/neutronics/fixed_source/settings.xml
+++ b/test/tests/neutronics/fixed_source/settings.xml
@@ -3,7 +3,6 @@
   <run_mode>fixed source</run_mode>
   <particles>100</particles>
   <batches>50</batches>
-  <inactive>10</inactive>
   <source strength="1.0">
     <space type="fission">
       <parameters>-5.0 -5.0 0 5.0 5.0 12.0</parameters>

--- a/test/tests/neutronics/fixed_source/tests
+++ b/test/tests/neutronics/fixed_source/tests
@@ -1,0 +1,11 @@
+[Tests]
+  [reuse_source]
+    type = RunException
+    input = openmc.i
+    cli_args = Problem/reuse_source=true
+    expected_err = "When running in fixed source mode, the particle source is given by the user"
+    requirement = "The system shall error if the user tries to reuse a source from a previous Picard "
+                  "iteration when running in fixed source mode."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+[]

--- a/test/tests/neutronics/fixed_source/tests
+++ b/test/tests/neutronics/fixed_source/tests
@@ -1,11 +1,10 @@
 [Tests]
-  [reuse_source]
-    type = RunException
-    input = openmc.i
-    cli_args = Problem/reuse_source=true
-    expected_err = "When running in fixed source mode, the particle source is given by the user"
-    requirement = "The system shall error if the user tries to reuse a source from a previous Picard "
-                  "iteration when running in fixed source mode."
+  [overlap_all]
+    type = CSVDiff
+    input = overlap_all.i
+    csvdiff = overlap_all_out.csv
+    requirement = "The system shall correctly normalize tallies from a fixed source simulation when there "
+                  "is perfect overlap between the OpenMC model and the MOOSE mesh."
     required_objects = 'OpenMCCellAverageProblem'
   []
 []

--- a/test/tests/neutronics/fixed_source/tests
+++ b/test/tests/neutronics/fixed_source/tests
@@ -7,4 +7,30 @@
                   "is perfect overlap between the OpenMC model and the MOOSE mesh."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [normalize_unused]
+    type = RunException
+    input = overlap_solid.i
+    cli_args = "Problem/normalize_by_global_tally=true --error"
+    expect_err = "When running OpenMC in fixed source mode, the 'normalize_by_global_tally' parameter is unused"
+    requirement = "The system shall notify the user that the settings related to normalizing by global "
+                  "or local tallies are inconsequential for fixed source mode."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+  [missing_power]
+    type = RunException
+    input = overlap_solid.i
+    cli_args = 'Problem/check_tally_sum=true'
+    expect_err = "Heating tallies do not match the global kappa-fission tally"
+    requirement = "The system shall error if the total tally sum does not match the system-wide value for "
+                  "fixed source simulations."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+  [overlap_solid]
+    type = CSVDiff
+    input = overlap_solid.i
+    csvdiff = overlap_solid_out.csv
+    requirement = "The system shall correctly normalize tallies from a fixed source simulation when there "
+                  "is only partial overlap between the OpenMC model and MOOSE domain."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
 []

--- a/test/tests/openmc_errors/fixed_source/k.i
+++ b/test/tests/openmc_errors/fixed_source/k.i
@@ -20,6 +20,7 @@
   solid_cell_level = 0
   tally_type = cell
   initial_properties = xml
+  source_strength = 1e6
 []
 
 [Executioner]

--- a/test/tests/openmc_errors/fixed_source/k_trigger.i
+++ b/test/tests/openmc_errors/fixed_source/k_trigger.i
@@ -24,6 +24,7 @@
   k_trigger = std_dev
   k_trigger_threshold = 1e-4
   max_batches = 100
+  source_strength = 1e6
 []
 
 [Executioner]


### PR DESCRIPTION
This PR adds a fixed source mode to Cardinal (this PR is rebased off of #439, and will be updated once that is merged). The only major difference is how the tallies are normalized. Instead of preserving a user-specified power level, the tally results are converted to power by:

tally (eV / particle) * source_strength (particles / s) * Joule / eV