### PR TITLE
Reset mapping of cells-to-elems between solves

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -86,6 +86,8 @@ public:
    */
   void setupProblem();
 
+  virtual void initialSetup() override;
+
   /**
    * Add 'heat_source', 'temp', and, if any fluid blocks are specified, a
    * 'density' variable. These are used to communicate OpenMC's solution with MOOSE,

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -76,6 +76,17 @@ public:
   static InputParameters validParams();
 
   /**
+   * \brief Initialize the mapping of OpenMC to the MooseMesh and perform any additional setup actions.
+   *
+   * When 'fixed_mesh' is false, this function is called at the start of _each_ OpenMC
+   * run to establish the mapping from the OpenMC cells to the [Mesh].
+   * TODO: this function currently does not re-initialize tallies based on the updated mapping
+   *       (which will certainly need to be updated for any mesh tallies on the [Mesh], and might
+   *       need updating for cell tallies if the identities of the coupled OpenMC cells changes).
+   */
+  void setupProblem();
+
+  /**
    * Add 'heat_source', 'temp', and, if any fluid blocks are specified, a
    * 'density' variable. These are used to communicate OpenMC's solution with MOOSE,
    * and for MOOSE to communicate its solution with OpenMC.
@@ -694,6 +705,14 @@ protected:
    * normalize against the local tally itself so that the correct power is preserved.
    */
   const bool _normalize_by_global;
+
+  /**
+   * Whether the [Mesh] is fixed and unchanging during the simulation, or whether
+   * the mesh moves spatially and/or is adaptively refine. When the mesh changes
+   * during the simulation, the mapping from OpenMC cells to the [Mesh] must be
+   * re-established after each OpenMC run.
+   */
+  const bool & _fixed_mesh;
 
   /**
    * Whether to check the tallies against the global tally;

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -619,17 +619,12 @@ OpenMCCellAverageProblem::checkMeshTemplateAndTranslations()
   // other words, you might have two meshes that represent the same geometry, but if you created
   // the solid phase _first_ in Cubit for one mesh, but the fluid phase _first_ in Cubit for the
   // other mesh, even though the geometry is the same, the element ordering would be different.
-  //
-  // If the first two elements of each mesh translation match the [Mesh], we assume that the meshes
-  // are the same (otherwise, print an error). We need to check two elements per mesh translation
-  // because this ensures that both the position and angular rotation match.
   unsigned int offset = 0;
   for (unsigned int i = 0; i < _mesh_filters.size(); ++i)
   {
     const auto & filter = _mesh_filters[i];
 
-    // just compare the first two elements
-    for (unsigned int e = 0; e < 2; ++e)
+    for (unsigned int e = 0; e < filter->n_bins(); ++e)
     {
       auto elem_ptr = _mesh.queryElemPtr(offset + e);
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -485,6 +485,15 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
 }
 
 void
+OpenMCCellAverageProblem::initialSetup()
+{
+  OpenMCProblemBase::initialSetup();
+
+  if (_adaptivity.isOn() && _fixed_mesh)
+    mooseError("When using mesh adaptivity, 'fixed_mesh' must be false!");
+}
+
+void
 OpenMCCellAverageProblem::setupProblem()
 {
   initializeElementToCellMapping();

--- a/test/tests/neutronics/feedback/different_units/tests
+++ b/test/tests/neutronics/feedback/different_units/tests
@@ -10,4 +10,13 @@
                   "scale of meters (openmc_master.i)."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [different_units_null_fixed_mesh]
+    type = Exodiff
+    input = openmc_master.i
+    exodiff = 'openmc_master_out.e openmc_master_out_openmc0.e'
+    cli_args = 'MultiApps/openmc/cli_args="Problem/fixed_mesh=false"'
+    requirement = "The system shall correctly re-initialize the same mapping when the MooseMesh does not change "
+                  "during a simulation."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
 []

--- a/test/tests/neutronics/feedback/lattice/tests
+++ b/test/tests/neutronics/feedback/lattice/tests
@@ -9,6 +9,14 @@
                   "a case built without distributed cells in ../single_level."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [pincell_null_fixed_mesh]
+    type = Exodiff
+    input = openmc_master.i
+    exodiff = 'openmc_master_out.e openmc_master_out_openmc0.e'
+    requirement = "The system shall correctly re-initialize the same mapping when the MooseMesh does not change "
+                  "during a simulation."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
   [heating]
     type = CSVDiff
     input = openmc_scores.i

--- a/test/tests/neutronics/feedback/single_level/tests
+++ b/test/tests/neutronics/feedback/single_level/tests
@@ -7,4 +7,13 @@
                   "and MOOSE and a solid pincell model."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [pincell_null_fixed_mesh]
+    type = Exodiff
+    input = openmc_master.i
+    exodiff = 'openmc_master_out.e openmc_master_out_openmc0.e'
+    cli_args = 'MultiApps/openmc/cli_args="Problem/fixed_mesh=false"'
+    requirement = "The system shall correctly re-initialize the same mapping when the MooseMesh does not change "
+                  "during a simulation."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
 []

--- a/test/tests/neutronics/relaxation/cell_tallies/tests
+++ b/test/tests/neutronics/relaxation/cell_tallies/tests
@@ -107,6 +107,16 @@
                   "openmc_nonaligned.i case with normalize_by_global_tally=false"
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [local_without_alignment_relax_null_fixed_mesh]
+    type = Exodiff
+    input = openmc_nonaligned.i
+    exodiff = nonalignment_relaxation_out.e
+    cli_args = "Problem/normalize_by_global_tally=false Problem/relaxation=constant Problem/relaxation_factor=0.5 Outputs/file_base=nonalignment_relaxation_out Problem/fixed_mesh=false"
+    min_parallel = 2
+    requirement = "The system shall correctly re-initialize the same mapping when the MooseMesh does not change "
+                  "during a simulation."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
   [output_fission_tally_cell]
     type = Exodiff
     input = output_fission_tally.i

--- a/test/tests/neutronics/relaxation/mesh_tallies/tests
+++ b/test/tests/neutronics/relaxation/mesh_tallies/tests
@@ -19,6 +19,15 @@
                   "additional command line parameters)."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [global_without_alignment_relax_null_fixed_mesh]
+    type = Exodiff
+    input = openmc.i
+    exodiff = relaxed_out.e
+    cli_args = "Problem/relaxation=constant Problem/relaxation_factor=0.5 Outputs/file_base=relaxed_out Problem/fixed_mesh=false"
+    requirement = "The system shall correctly re-initialize the same mapping when the MooseMesh does not change "
+                  "during a simulation."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
 
   [local_without_alignment_unity_relax]
     type = Exodiff

--- a/test/tests/openmc_errors/adaptivity/fixed_mesh.i
+++ b/test/tests/openmc_errors/adaptivity/fixed_mesh.i
@@ -1,0 +1,46 @@
+[Mesh]
+  [sphere]
+    # Mesh of a single pebble with outer radius of 1.5 (cm)
+    type = FileMeshGenerator
+    file = ../../neutronics/meshes/sphere.e
+  []
+  [solid]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 0'
+  []
+  [solid_ids]
+    type = SubdomainIDGenerator
+    input = solid
+    subdomain_id = '100'
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 70.0
+  solid_blocks = '100'
+  tally_blocks = '100'
+  tally_type = cell
+  solid_cell_level = 0
+  fluid_cell_level = 0
+  fixed_mesh = true
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Adaptivity]
+  [Markers]
+    [error_tol_marker]
+      type = UniformMarker
+      mark = refine
+    []
+  []
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/openmc_errors/adaptivity/geometry.xml
+++ b/test/tests/openmc_errors/adaptivity/geometry.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<geometry>
+  <cell id="1" material="1" region="-1" universe="1" />
+  <cell id="2" material="2" region="-2" universe="1" />
+  <cell id="3" material="3" region="-3" universe="1" />
+  <cell id="4" material="4" region="1 2 3 4 -5 6 -7 8 -9" universe="1" />
+  <surface coeffs="0.0 0.0 0.0 1.5" id="1" type="sphere" />
+  <surface coeffs="0.0 0.0 4.0 1.5" id="2" type="sphere" />
+  <surface coeffs="0.0 0.0 8.0 1.5" id="3" type="sphere" />
+  <surface boundary="reflective" coeffs="-2.5" id="4" name="minimum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="5" name="maximum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="-2.5" id="6" name="minimum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="7" name="maximum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="-2.0" id="8" type="z-plane" />
+  <surface boundary="reflective" coeffs="10.0" id="9" type="z-plane" />
+</geometry>

--- a/test/tests/openmc_errors/adaptivity/materials.xml
+++ b/test/tests/openmc_errors/adaptivity/materials.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material depletable="true" id="1">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="9.051308944870946e-05" name="U234" />
+    <nuclide ao="0.010126612654073502" name="U235" />
+    <nuclide ao="0.9897364895065476" name="U238" />
+    <nuclide ao="4.63847499302226e-05" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="2">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="0.0004523305496680539" name="U234" />
+    <nuclide ao="0.05060678290832386" name="U235" />
+    <nuclide ao="0.948709083169038" name="U238" />
+    <nuclide ao="0.00023180337297007338" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="3">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="0.0009040745407538578" name="U234" />
+    <nuclide ao="0.10114794158928406" name="U235" />
+    <nuclide ao="0.8974846777145036" name="U238" />
+    <nuclide ao="0.00046330615545845175" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="4">
+    <density units="g/cc" value="1.0" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <nuclide ao="5.4e-05" name="U234" />
+    <nuclide ao="0.007204" name="U235" />
+    <nuclide ao="0.992742" name="U238" />
+  </material>
+</materials>

--- a/test/tests/openmc_errors/adaptivity/settings.xml
+++ b/test/tests/openmc_errors/adaptivity/settings.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<settings>
+  <run_mode>eigenvalue</run_mode>
+  <particles>100</particles>
+  <batches>50</batches>
+  <inactive>10</inactive>
+  <source strength="1.0">
+    <space type="fission">
+      <parameters>-5.0 -5.0 0 5.0 5.0 12.0</parameters>
+    </space>
+  </source>
+  <temperature_default>294.0</temperature_default>
+  <temperature_method>interpolation</temperature_method>
+  <temperature_multipole>false</temperature_multipole>
+  <temperature_range>294.0 1600.0</temperature_range>
+</settings>

--- a/test/tests/openmc_errors/adaptivity/tests
+++ b/test/tests/openmc_errors/adaptivity/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [fixed_mesh]
+    type = RunException
+    input = fixed_mesh.i
+    expect_err = "When using mesh adaptivity, 'fixed_mesh' must be false!"
+    requirement = "The system shall error if user incorrectly specifies a fixed mesh when adaptivity is turned on."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+[]


### PR DESCRIPTION
For adaptive mesh refinement, we will need to re-establish the mapping from OpenMC cells to the [Mesh] between each solve. This provides some of the machinery to do this (while still missing the ability to delete tallies + re-add them; see [this issue](https://github.com/openmc-dev/openmc/issues/2155) for the relevant changes in OpenMC). 

This PR checks correctness by setting `fixed_mesh = false` to a few representative tests to make sure that re-evaluating the mapping doesn't change the results when the [Mesh] isn't changing (which it should not).

Refs #449 