### PR TITLE
Enable distributed mesh testing

### DIFF
--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1817,7 +1817,16 @@ OpenMCCellAverageProblem::initializeTallies()
 
       std::unique_ptr<openmc::LibMesh> tally_mesh;
       if (_tally_mesh_from_moose)
+      {
+        // for distributed meshes, each rank only owns a portion of the mesh information, but
+        // OpenMC wants the entire mesh to be available on every rank. We might be able to add
+        // this feature in the future, but will need to investigate
+        if (!_mesh.getMesh().is_replicated())
+          mooseError("Directly tallying on the [Mesh] block by OpenMC is not yet supported "
+            "for distributed meshes!");
+
         tally_mesh = std::make_unique<openmc::LibMesh>(_mesh.getMesh(), _scaling);
+      }
       else
         tally_mesh = std::make_unique<openmc::LibMesh>(_mesh_template_filename, _scaling);
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -2168,18 +2168,38 @@ Real
 OpenMCCellAverageProblem::normalizeLocalTally(const Real & tally_result) const
 {
   if (_normalize_by_global)
+  {
+    if (std::abs(_global_sum_tally) < 1e-12)
+      mooseError("Cannot normalize tally by global sum: ", _global_sum_tally, " due to divide-by-zero.\n"
+        "This means that the ", _tally_score, " tally over the entire domain is zero.");
     return tally_result / _global_sum_tally;
+  }
   else
+  {
+    if (std::abs(_local_sum_tally) < 1e-12)
+      mooseError("Cannot normalize tally by local sum: ", _local_sum_tally, " due to divide-by-zero.\n"
+        "This means that the ", _tally_score, " tally created by Cardinal is everywhere zero.");
     return tally_result / _local_sum_tally;
+  }
 }
 
 xt::xtensor<double, 1>
 OpenMCCellAverageProblem::normalizeLocalTally(const xt::xtensor<double, 1> & raw_tally) const
 {
   if (_normalize_by_global)
+  {
+    if (std::abs(_global_sum_tally) < 1e-12)
+      mooseError("Cannot normalize tally by global sum: ", _global_sum_tally, " due to divide-by-zero.\n"
+        "This means that the ", _tally_score, " tally over the entire domain is zero.");
     return raw_tally / _global_sum_tally;
+  }
   else
+  {
+    if (std::abs(_local_sum_tally) < 1e-12)
+      mooseError("Cannot normalize tally by local sum: ", _local_sum_tally, " due to divide-by-zero.\n"
+        "This means that the ", _tally_score, " tally created by Cardinal is everywhere zero.");
     return raw_tally / _local_sum_tally;
+  }
 }
 
 void

--- a/test/tests/nek_standalone/ethier/tests
+++ b/test/tests/nek_standalone/ethier/tests
@@ -4,6 +4,7 @@
     input = nek.i
     csvdiff = nek_out.csv
     min_parallel = 2
+    mesh_mode = 'replicated'
     requirement = "Cardinal shall be able to run the ethier NekRS example with a thin wrapper. "
                   "We add postprocessors to let us compare min/max values printed to the screen by NekRS."
     required_objects = 'NekRSProblem'

--- a/test/tests/neutronics/mesh_tally/tests
+++ b/test/tests/neutronics/mesh_tally/tests
@@ -14,13 +14,23 @@
     type = Exodiff
     input = one_mesh_no_input_file.i
     exodiff = 'one_mesh_out.e'
-    cli_args = "Outputs/file_base=one_mesh_out"
+    cli_args = "Outputs/file_base=one_mesh_out Mesh/parallel_type=replicated"
     # This test has very few particles, and OpenMC will error if there aren't any particles
     # on a particular process
     max_parallel = 32
     requirement = "This test is nearly identical to one_mesh. The difference lies in having no mesh_template "
                   "in the input file. Without one, the system should be able to directly tally on a moose "
                   "mesh instead of a file "
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+  [moose_mesh_tally_distributed]
+    type = RunException
+    input = one_mesh_no_input_file.i
+    mesh_mode = 'distributed'
+    expect_err = "Directly tallying on the \[Mesh\] block by OpenMC is not yet supported "
+                 "for distributed meshes!"
+    requirement = "The system shall error if attempting to directly tally on a MOOSE mesh that is "
+                  "distributed, since all meshes are always replicated in OpenMC."
     required_objects = 'OpenMCCellAverageProblem'
   []
   [one_mesh_global]

--- a/test/tests/openmc_errors/zero_tally/geometry.xml
+++ b/test/tests/openmc_errors/zero_tally/geometry.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<geometry>
+  <cell id="1" material="1" region="-1" universe="1" />
+  <cell id="2" material="2" region="-2" universe="1" />
+  <cell id="3" material="3" region="-3" universe="1" />
+  <cell id="4" material="4" region="1 2 3 4 -5 6 -7 8 -9" universe="1" />
+  <surface coeffs="0.0 0.0 0.0 1.5" id="1" type="sphere" />
+  <surface coeffs="0.0 0.0 4.0 1.5" id="2" type="sphere" />
+  <surface coeffs="0.0 0.0 8.0 1.5" id="3" type="sphere" />
+  <surface boundary="reflective" coeffs="-2.5" id="4" name="minimum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="5" name="maximum x" type="x-plane" />
+  <surface boundary="reflective" coeffs="-2.5" id="6" name="minimum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="2.5" id="7" name="maximum y" type="y-plane" />
+  <surface boundary="reflective" coeffs="-2.0" id="8" type="z-plane" />
+  <surface boundary="reflective" coeffs="10.0" id="9" type="z-plane" />
+</geometry>

--- a/test/tests/openmc_errors/zero_tally/materials.xml
+++ b/test/tests/openmc_errors/zero_tally/materials.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material id="1" name="water0">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="2" name="water1">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="3" name="water2">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="4" name="water3">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+</materials>

--- a/test/tests/openmc_errors/zero_tally/openmc.i
+++ b/test/tests/openmc_errors/zero_tally/openmc.i
@@ -1,0 +1,33 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../../neutronics/meshes/sphere.e
+  []
+  [solid]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 0
+                 0 0 4
+                 0 0 8'
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 100.0
+  solid_blocks = '1'
+  tally_blocks = '1'
+  solid_cell_level = 0
+  tally_type = cell
+  initial_properties = xml
+  source_strength = 1e6
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/openmc_errors/zero_tally/settings.xml
+++ b/test/tests/openmc_errors/zero_tally/settings.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<settings>
+  <run_mode>fixed source</run_mode>
+  <particles>100</particles>
+  <batches>50</batches>
+  <inactive>10</inactive>
+  <source strength="1.0">
+    <space type="box">
+      <parameters>-5.0 -5.0 0 5.0 5.0 12.0</parameters>
+    </space>
+  </source>
+  <temperature_default>600.0</temperature_default>
+  <temperature_method>nearest</temperature_method>
+  <temperature_multipole>false</temperature_multipole>
+  <temperature_range>294.0 1600.0</temperature_range>
+</settings>

--- a/test/tests/openmc_errors/zero_tally/tests
+++ b/test/tests/openmc_errors/zero_tally/tests
@@ -2,7 +2,7 @@
   [local_zero]
     type = RunException
     input = openmc.i
-    expect_err = "Cannot normalize tally by local sum: 0 due to divide-by-zero.\n
+    expect_err = "Cannot normalize tally by local sum: 0 due to divide-by-zero.\n"
                  "This means that the kappa-fission tally created by Cardinal is everywhere zero."
     requirement = "The system shall error if the local tally is to be normalized by a local tally which is everywhere zero."
   []

--- a/test/tests/openmc_errors/zero_tally/tests
+++ b/test/tests/openmc_errors/zero_tally/tests
@@ -5,5 +5,6 @@
     expect_err = "Cannot normalize tally by local sum: 0 due to divide-by-zero.\n"
                  "This means that the kappa-fission tally created by Cardinal is everywhere zero."
     requirement = "The system shall error if the local tally is to be normalized by a local tally which is everywhere zero."
+    required_objects = 'OpenMCCellAverageProblem'
   []
 []

--- a/test/tests/openmc_errors/zero_tally/tests
+++ b/test/tests/openmc_errors/zero_tally/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [local_zero]
+    type = RunException
+    input = openmc.i
+    expect_err = "Cannot normalize tally by local sum: 0 due to divide-by-zero.\n
+                 "This means that the kappa-fission tally created by Cardinal is everywhere zero."
+    requirement = "The system shall error if the local tally is to be normalized by a local tally which is everywhere zero."
+  []
+[]

--- a/test/tests/userobjects/hexagonal_gap_layered/tests
+++ b/test/tests/userobjects/hexagonal_gap_layered/tests
@@ -10,6 +10,7 @@
     type = Exodiff
     input = nek.i
     exodiff = 'nek_out_subchannel0.e'
+    rel_err = 5e-5
     requirement = "A hexagonal gap and 1-D layered bin shall be combined to give a multi-dimensional "
                   "binning and demonstrate correct results for side integrals and averages."
     required_objects = 'NekRSProblem'

--- a/test/tests/userobjects/sideset_layered/tests
+++ b/test/tests/userobjects/sideset_layered/tests
@@ -10,6 +10,7 @@
     type = Exodiff
     input = z_bins.i
     exodiff = z_bins_out.e
+    mesh_mode = 'replicated'
     requirement = "The system shall correctly integrate over a sideset in the NekRS domain when mapping space by the quadrature point"
     required_objects = 'NekRSProblem'
   []

--- a/test/tests/userobjects/subchannel_layered/tests
+++ b/test/tests/userobjects/subchannel_layered/tests
@@ -73,6 +73,7 @@
     type = CSVDiff
     input = pin_1d.i
     csvdiff = pin_1d_out_from_uo_0002.csv
+    mesh_mode = 'replicated'
     requirement = "A pin-centered subchannel bin shall give correct results for side averages of temperature."
     required_objects = 'NekRSProblem'
   []

--- a/tutorials/lwr_solid/tests
+++ b/tutorials/lwr_solid/tests
@@ -20,6 +20,7 @@
     input = solid_um.i
     min_parallel = 4
     prereq = make_mesh
+    mesh_mode = 'replicated'
     cli_args = "Executioner/num_steps=1 openmc:Problem/particles=1000 openmc:Problem/inactive_batches=5 openmc:Problem/batches=10"
     requirement = "The OpenMC wrapping shall provide heat source and temperature coupling "
                   "to MOOSE with an unstructured mesh tally."

--- a/tutorials/pincell_multiphysics/tests
+++ b/tutorials/pincell_multiphysics/tests
@@ -14,6 +14,7 @@
   [fluid_mesh_to_hex20]
     type = RunApp
     input = convert.i
+    mesh_mode = 'replicated'
     cli_args = '--mesh-only'
     requirement = "The system shall be able to convert a HEX27 fluid mesh into a HEX20 mesh suitable for Nek."
     prereq = fluid_mesh

--- a/tutorials/transfers/tests
+++ b/tutorials/transfers/tests
@@ -14,6 +14,7 @@
   [volume]
     type = RunApp
     input = main.i
+    mesh_mode = 'replicated'
     requirement = "The system shall be able to transfer fields between two volume meshes in several different ways."
     prereq = 'mesh1 mesh2'
   []


### PR DESCRIPTION
Distributed mesh testing is now enabled on CIVET; this PR makes a few minor fix-ups to tests that can only run in replicated meshes that we previously weren't explicitly restricting so.

Also adds a check that tallying OpenMC on a MooseMesh cannot work with distributed meshes, since OpenMC always replicates the mesh on each MPI rank internally.