### PR TITLE
Allow custom variable names for tally outputs

### DIFF
--- a/doc/content/news/mar2022.md
+++ b/doc/content/news/mar2022.md
@@ -1,4 +1,4 @@
 # March 2022 News
 
 - Added the option to output the unrelaxed fission heat source from OpenMC, using
-  `output = fission_tally`
+  `output = unrelaxed_tally`

--- a/doc/content/source/problems/OpenMCCellAverageProblem.md
+++ b/doc/content/source/problems/OpenMCCellAverageProblem.md
@@ -652,8 +652,8 @@ minimal capabilities to extract other aspects of the OpenMC solution directly
 onto the mesh mirror for postprocessing or visualization. A list of parameters to
 output is provided to the `output` parameter; available options are:
 
-- `fission_tally`: unrelaxed tally
-- `fission_tally_std_dev`: unrelaxed tally standard deviation
+- `unrelaxed_tally`: unrelaxed tally
+- `unrelaxed_tally_std_dev`: unrelaxed tally standard deviation
 
 #### Collating Temperatures from Multiple Apps
 

--- a/doc/content/tutorials/convergence.md
+++ b/doc/content/tutorials/convergence.md
@@ -100,7 +100,7 @@ To determine an appropriate cell discretization, you can use the
 In addition, your Cardinal input file must contain a number of postprocessors,
 user objects, and vector postprocessors to process the solution to extract
 the various scalar and averaged quantities used in the convergence study.
-In the `[Problem]` block, you must set `outputs = 'fission_tally_std_dev'`.
+In the `[Problem]` block, you must set `outputs = 'unrelaxed_tally_std_dev'`.
 You will also need to copy and paste the following into your input file:
 
 ```
@@ -130,14 +130,14 @@ You will also need to copy and paste the following into your input file:
 
   [proxy_max_power_std_dev]
     type = ElementExtremeValue
-    variable = fission_tally_std_dev
+    variable = unrelaxed_tally_std_dev
     proxy_variable = heat_source
     value_type = max
     block = 2
   []
   [proxy_min_power_std_dev]
     type = ElementExtremeValue
-    variable = fission_tally_std_dev
+    variable = unrelaxed_tally_std_dev
     proxy_variable = heat_source
     value_type = min
     block = 2

--- a/doc/content/tutorials/openmc_fluid.md
+++ b/doc/content/tutorials/openmc_fluid.md
@@ -467,7 +467,7 @@ we specify a `scaling` of 100, i.e. a multiplicative factor to apply to the
   block=Problem
 
 Other features we use include an output of the fission tally standard deviation
-in units of W/m$^3$ to the `[Mesh]` by setting `output = 'fission_tally_std_dev'`.
+in units of W/m$^3$ to the `[Mesh]` by setting `output = 'unrelaxed_tally_std_dev'`.
 This is used to obtain uncertainty estimates of the heat source distribution from OpenMC
 in the same units as the heat source. We also leverage a helper utility
 in Cardinal by setting `check_equal_mapped_tally_volumes = true`. This parameter will

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -490,17 +490,16 @@ protected:
   void getTallyFromOpenMC();
 
   /**
-   * Get the fission tally standard deviation as a function of space and store into variable
+   * Get the (unrelaxed) tally standard deviation as a function of space and store into variable
    * @param[in] var_num variable number to store the standard deviation in
    */
-  void getFissionTallyStandardDeviationFromOpenMC(const unsigned int & var_num);
+  void getUnrelaxedTallyStandardDeviationFromOpenMC(const unsigned int & var_num);
 
   /**
-   * Get the fission tally (i.e. raw, unrelaxed output from OpenMC)
-   *  as a function of space and store into variable
+   * Get the (unrelaxed) tally from OpenMC as a function of space and store into variable
    * @param[in] var_num variable number to store the tally in
    */
-  void getFissionTallyFromOpenMC(const unsigned int & var_num);
+  void getUnrelaxedTallyFromOpenMC(const unsigned int & var_num);
 
   /**
    * Multiplier on the normalized tally results; for fixed source runs,
@@ -972,6 +971,12 @@ protected:
 
   /// OpenMC solution fields to output to the mesh mirror
   const MultiMooseEnum * _outputs = nullptr;
+
+  /**
+   * Auxiliary variable names to apply to each quantity in 'output'; if not specified,
+   * the names default to the string-conversion of the enum in 'output'
+   */
+  std::vector<std::string> _output_name;
 
   /// Numeric identifiers for the external variables
   std::vector<unsigned int> _external_vars;

--- a/test/tests/neutronics/mesh_tally/fission_tally_std_dev.i
+++ b/test/tests/neutronics/mesh_tally/fission_tally_std_dev.i
@@ -41,7 +41,8 @@
   check_tally_sum = false
   check_zero_tallies = false
 
-  output = 'fission_tally_std_dev'
+  output = 'unrelaxed_tally_std_dev'
+  output_name = 'fission_tally_std_dev'
 []
 
 [Executioner]

--- a/test/tests/neutronics/relaxation/cell_tallies/output_fission_tally.i
+++ b/test/tests/neutronics/relaxation/cell_tallies/output_fission_tally.i
@@ -54,7 +54,8 @@
   solid_cell_level = 1
   scaling = 100.0
 
-  output = 'fission_tally'
+  output = 'unrelaxed_tally'
+  output_name = 'fission_tally'
   relaxation = constant
 []
 

--- a/test/tests/neutronics/relaxation/mesh_tallies/output_fission_tally.i
+++ b/test/tests/neutronics/relaxation/mesh_tallies/output_fission_tally.i
@@ -61,7 +61,8 @@
   solid_cell_level = 1
   scaling = 100.0
 
-  output = 'fission_tally'
+  output = 'unrelaxed_tally'
+  output_name = 'fission_tally'
   relaxation = constant
 
   check_tally_sum = false

--- a/test/tests/openmc_errors/tallies/output_name_length.i
+++ b/test/tests/openmc_errors/tallies/output_name_length.i
@@ -1,0 +1,45 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../../neutronics/meshes/sphere.e
+  []
+  [solid]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 0
+                 0 0 4
+                 0 0 8'
+  []
+  [solid_ids]
+    type = SubdomainIDGenerator
+    input = solid
+    subdomain_id = '100'
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 100.0
+  solid_blocks = '100'
+  tally_type = cell
+  tally_blocks = '100'
+  verbose = true
+  solid_cell_level = 0
+  fluid_cell_level = 0
+
+  # This turns off the density and temperature update on the first syncSolutions;
+  # this uses whatever temperature and densities are set in OpenMCs XML files for first step
+  initial_properties = xml
+
+  output = 'unrelaxed_tally'
+  output_name = 'tally1 tally2'
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/openmc_errors/tallies/tests
+++ b/test/tests/openmc_errors/tallies/tests
@@ -14,4 +14,11 @@
     requirement = "The system shall error if attempting to use separate tallies when a global tally exists"
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [custom_name]
+    type = RunException
+    input = output_name_length.i
+    expect_err = "When specifying custom variable names for OpenMC outputs, the 'output_name' must be the same length as 'output'!"
+    requirement = "The system shall error if custom names for additional tally output is not the correct length."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
 []

--- a/test/tests/postprocessors/fission_tally_relative_error/openmc.i
+++ b/test/tests/postprocessors/fission_tally_relative_error/openmc.i
@@ -42,7 +42,8 @@
   check_tally_sum = false
 
   # this outputs the fission tally standard deviation in space
-  output = 'fission_tally_std_dev'
+  output = 'unrelaxed_tally_std_dev'
+  output_name = 'fission_tally_std_dev'
 
   # This turns off the density and temperature update on the first syncSolutions;
   # this uses whatever temperature and densities are set in OpenMCs XML files for first step

--- a/tutorials/gas_assembly/openmc.i
+++ b/tutorials/gas_assembly/openmc.i
@@ -164,7 +164,7 @@ num_layers_for_THM = 50      # number of elements in the THM model; for the conv
 
 [Problem]
   type = OpenMCCellAverageProblem
-  output = 'fission_tally_std_dev'
+  output = 'unrelaxed_tally_std_dev'
   check_equal_mapped_tally_volumes = true
 
   identical_tally_cell_fills = true

--- a/tutorials/gas_compact/openmc.i
+++ b/tutorials/gas_compact/openmc.i
@@ -43,7 +43,7 @@ mdot = 0.011                             # fluid mass flowrate (kg/s)
 [Problem]
   type = OpenMCCellAverageProblem
   verbose = true
-  output = 'fission_tally_std_dev'
+  output = 'unrelaxed_tally_std_dev'
   check_equal_mapped_tally_volumes = true
 
   power = ${power}
@@ -115,7 +115,7 @@ mdot = 0.011                             # fluid mass flowrate (kg/s)
   []
   [avg_std_dev]
     type = NearestPointLayeredAverage
-    variable = fission_tally_std_dev
+    variable = unrelaxed_tally_std_dev
     points = '0.0 0.0 0.0'
     num_layers = 30
     direction = z

--- a/tutorials/gas_compact_multiphysics/openmc_nek.i
+++ b/tutorials/gas_compact_multiphysics/openmc_nek.i
@@ -114,7 +114,7 @@ N = 1000
 
 [Problem]
   type = OpenMCCellAverageProblem
-  output = 'fission_tally_std_dev'
+  output = 'unrelaxed_tally_std_dev'
   check_equal_mapped_tally_volumes = true
 
   power = ${unit_cell_power}

--- a/tutorials/gas_compact_multiphysics/openmc_thm.i
+++ b/tutorials/gas_compact_multiphysics/openmc_thm.i
@@ -123,7 +123,7 @@ unit_cell_power = ${fparse power / (n_bundles * n_coolant_channels_per_block) * 
 
 [Problem]
   type = OpenMCCellAverageProblem
-  output = 'fission_tally_std_dev'
+  output = 'unrelaxed_tally_std_dev'
   check_equal_mapped_tally_volumes = true
 
   power = ${unit_cell_power}

--- a/tutorials/pincell_multiphysics/openmc.i
+++ b/tutorials/pincell_multiphysics/openmc.i
@@ -124,7 +124,7 @@ dT = ${fparse power / mdot / Cp}
 
 [Problem]
   type = OpenMCCellAverageProblem
-  output = 'fission_tally_std_dev'
+  output = 'unrelaxed_tally_std_dev'
   check_equal_mapped_tally_volumes = true
 
   power = ${power}


### PR DESCRIPTION
This PR adds a parameter `output_name` that lets the user select the auxiliary variable name to use for any additional OpenMC tally outputs, such as the standard deviation and value of the _unrelaxed_ tally. I also changed the names of the enum flags to be more descriptive and agnostic of whether the tally represents a fission heat source, in preparation for upcoming PRs that will allow us to tally quantities that don't have a conventional notion of "power density," such as flux.