### PR TITLE
Simplify tally setup

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -532,10 +532,11 @@ protected:
   xt::xtensor<double, 1> normalizeLocalTally(const xt::xtensor<double, 1> & raw_tally) const;
 
   /**
-   * Add the local tally
+   * Add local tally
+   * @param[in] score score type
    * @param[in] filters tally filters
    */
-  void addLocalTally(std::vector<openmc::Filter *> & filters);
+  void addLocalTally(const std::string & score, std::vector<openmc::Filter *> & filters);
 
   /**
    * Check the sum of the fluid and solid tallies (if present) against the global

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -938,12 +938,6 @@ protected:
   /// Mean value of the local tally, across all bins; only used for fixed source mode
   Real _local_mean_tally;
 
-  /**
-   * For OpenMC geometries with a single coordinate level, we define default behavior for
-   * tally_blocks to be all of the subdomains in the MOOSE mesh.
-   */
-  const bool _using_default_tally_blocks;
-
   /// When using mesh tallies, whether the mesh comes from the MOOSE [Mesh] block or from a file
   const bool _tally_mesh_from_moose;
 

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -405,7 +405,7 @@ protected:
    * this is still inconsequential at the end of the day as long as your problem has converged
    * the relaxed heat source to the raw (unrelaxed) tally.
    */
-  void relaxAndNormalizeHeatSource(const int & t);
+  void relaxAndNormalizeTally(const int & t);
 
   /**
    * Loop over all the OpenMC cells and count the number of MOOSE elements to which the cell

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -1024,16 +1024,6 @@ protected:
   /// Helper utility to rotate [Mesh] points according to symmetry in OpenMC model
   std::unique_ptr<SymmetryPointGenerator> _symmetry;
 
-  /**
-   * \brief Whether the tally has a zero contribution in all non-fissile materials
-   *
-   * For scores involving energy from fission with entirely local deposition
-   * at the site of fission, we know that there will be zero contribution from cells
-   * not containing fissile materials. We can reduce the total number of added tally
-   * bins by ensuring we don't add tallies in non-fissile materials for these scores.
-   */
-  bool _tally_is_zero_in_nonfissile;
-
   /// Number of solid elements in each mapped OpenMC cell (global)
   std::map<cellInfo, int> _n_solid;
 

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -133,6 +133,19 @@ public:
   }
 
   /**
+   * Get the cell instance filter for tallies automatically constructed by Cardinal
+   * @return cell instance filter
+   */
+  openmc::Filter * cellInstanceFilter();
+
+  /**
+   * Get the mesh filter(s) for tallies automatically constructed by Cardinal.
+   * Multiple mesh filters are only created if the mesh template feature is used.
+   * @return mesh filters
+   */
+  std::vector<openmc::Filter *> meshFilter();
+
+  /**
    * This class uses elem->volume() in order to normalize the fission power produced
    * by OpenMC to conserve the specified power. However, as discussed on the MOOSE
    * slack channel,
@@ -971,7 +984,7 @@ protected:
   std::vector<Point> _mesh_translations;
 
   /// OpenMC mesh filters for unstructured mesh tallies
-  std::vector<const openmc::MeshFilter *> _mesh_filters;
+  std::vector<openmc::MeshFilter *> _mesh_filters;
 
   /// OpenMC solution fields to output to the mesh mirror
   const MultiMooseEnum * _outputs = nullptr;

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -245,8 +245,6 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     _has_fluid_blocks(params.isParamSetByUser("fluid_blocks")),
     _has_solid_blocks(params.isParamSetByUser("solid_blocks")),
     _needs_global_tally(_check_tally_sum || _normalize_by_global),
-    _using_default_tally_blocks(_tally_type == tally::cell && _single_coord_level &&
-                                !isParamValid("tally_blocks")),
     _tally_mesh_from_moose(!isParamValid("mesh_template")),
     _total_n_particles(0),
     _temperature_vars(nullptr),
@@ -402,16 +400,10 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
       checkUnusedParam(params, {"mesh_template", "mesh_translations", "mesh_translations_file"},
                                "using cell tallies");
 
-      // tally_blocks is optional if the OpenMC geometry has a single coordinate level
-      if (!_single_coord_level)
-        checkRequiredParam(
-            params, "tally_blocks", "OpenMC geometries have more than one coordinate level");
-
       readTallyBlocks();
 
-      // For single-level geometries, we take the default setting for tally_blocks to be all the
-      // blocks in the MOOSE domain
-      if (_using_default_tally_blocks)
+      // If not specified, add tallies to all MOOSE blocks
+      if (!isParamValid("tally_blocks"))
         for (const auto & s : _mesh.meshSubdomains())
           _tally_blocks.insert(s);
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1691,10 +1691,10 @@ OpenMCCellAverageProblem::storeTallyCells()
 }
 
 void
-OpenMCCellAverageProblem::addLocalTally(std::vector<openmc::Filter *> & filters)
+OpenMCCellAverageProblem::addLocalTally(const std::string & score, std::vector<openmc::Filter *> & filters)
 {
   auto tally = openmc::Tally::create();
-  tally->set_scores({_tally_score});
+  tally->set_scores({score});
   tally->estimator_ = _tally_estimator;
   tally->set_filters(filters);
   _local_tally.push_back(tally);
@@ -1733,14 +1733,8 @@ OpenMCCellAverageProblem::initializeTallies()
   {
     case tally::cell:
     {
-      if (_tally_cells.size() == 0)
-        _console << "Skipping cell tallies for blocks " + Moose::stringify(_tally_blocks) +
-                        " because no fissile material is present"
-                 << std::endl;
-      else
-        _console << "Adding cell tallies to blocks " + Moose::stringify(_tally_blocks) + " for " +
-                        Moose::stringify(_tally_cells.size()) + " cells..."
-                 << std::endl;
+      _console << "Adding cell tallies to blocks " + Moose::stringify(_tally_blocks) + " for " +
+                      Moose::stringify(_tally_cells.size()) + " cells..." << std::endl;
 
       _current_mean_tally.resize(1);
       _previous_mean_tally.resize(1);
@@ -1755,7 +1749,7 @@ OpenMCCellAverageProblem::initializeTallies()
 
       cell_filter->set_cell_instances(cells);
       std::vector<openmc::Filter *> tally_filters = {cell_filter};
-      addLocalTally(tally_filters);
+      addLocalTally(_tally_score, tally_filters);
 
       break;
     }
@@ -1817,7 +1811,7 @@ OpenMCCellAverageProblem::initializeTallies()
 
         _mesh_filters.push_back(meshFilter);
         std::vector<openmc::Filter *> tally_filters = {meshFilter};
-        addLocalTally(tally_filters);
+        addLocalTally(_tally_score, tally_filters);
       }
 
       if (_verbose)

--- a/test/tests/neutronics/heat_source/distrib_cell/tests
+++ b/test/tests/neutronics/heat_source/distrib_cell/tests
@@ -10,16 +10,4 @@
                   "the highest level."
     required_objects = 'OpenMCCellAverageProblem'
   []
-  [warn_zero_tallies]
-    type = RunException
-    input = warn_zero_tallies.i
-    cli_args = '--error'
-    # This test has very few particles, and OpenMC will error if there aren't enough source particles
-    # in the fission bank on a process
-    max_parallel = 4
-    expect_err = "Skipping tallies for"
-    requirement = "A warning shall be printed if a material-fill cell does not contain any fissile material "
-                  "but it was still added to the tally blocks."
-    required_objects = 'OpenMCCellAverageProblem'
-  []
 []


### PR DESCRIPTION
This PR simplifies the tally setup in Cardinal by always adding tallies where the user requests them, even if the tally would technically be zero in those regions.

This also adds a few minor helper functions that will be useful when we support multiple tally scores.

Closes #452