### PR TITLE
Use lowercase name for default names

### DIFF
--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -482,7 +482,12 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     {
       // default names are simply matched to the output enum string
       for (const auto & o : *_outputs)
-        _output_name.push_back(o);
+      {
+        std::string name = o;
+        std::transform(name.begin(), name.end(), name.begin(),
+            [](unsigned char c){ return std::tolower(c); });
+        _output_name.push_back(name);
+      }
     }
   }
   else


### PR DESCRIPTION
We recently added the ability to automatically select the name for additional outputs specified for `OpenMCCellAverageProblem` (such as for writing the tally standard deviation). However, the names are printed in uppercase because that's how the enum is converted to a string, and I think lowercase looks better and is more in line with all the other lowercase variables within `OpenMCCellAverageProblem`.