### PR TITLE
Remove leading $ in copy commands

### DIFF
--- a/doc/content/contributing.md
+++ b/doc/content/contributing.md
@@ -24,7 +24,7 @@ create branches and commit your set of changes.
   the account where you forked the repository to
 
 ```
-$ git clone https://github.com/username/cardinal.git
+git clone https://github.com/username/cardinal.git
 ```
 
 ### 2. Add the `upstream` Remote:
@@ -32,8 +32,8 @@ $ git clone https://github.com/username/cardinal.git
 Add the real Cardinal repository as a remote named "upstream":
 
 ```
-$ cd cardinal
-$ git remote add upstream https://github.com/neams-th-coe/cardinal.git
+cd cardinal
+git remote add upstream https://github.com/neams-th-coe/cardinal.git
 ```
 
 You should now have at least two remotes when you run `git remote -vv`:
@@ -51,22 +51,22 @@ To make modifications to Cardinal, first create a branch where you will commit y
 work.
 
 ```
-$ git checkout -b branch_name upstream/devel
+git checkout -b branch_name upstream/devel
 ```
 
 Then, add your contributions to the branch.
 
 ```
-$ git add new_file.C
-$ git commit -m "An informative message about the commit."
+git add new_file.C
+git commit -m "An informative message about the commit."
 ```
 
 Before contributing your changes, you should rebase them on top of the latest
 upstream "devel" branch in the real Cardinal repository:
 
 ```
-$ git fetch upstream
-$ git rebase upstream/devel
+git fetch upstream
+git rebase upstream/devel
 ```
 
 ### 4. Add Documentation
@@ -79,7 +79,7 @@ for documentation. Please be sure to document your changes and commit it to your
 Push your branch to your fork:
 
 ```
-$ git push origin branch_name
+git push origin branch_name
 ```
 
 ### 6. Create a Pull Request

--- a/doc/content/developers.md
+++ b/doc/content/developers.md
@@ -66,7 +66,7 @@ Next, generate the static HTML by running the following
 from within the `doc` directory:
 
 ```
-$ ./moosedocs.py build
+./moosedocs.py build
 ```
 
 This should print to the screen a summary of the steps taken when compiling
@@ -90,7 +90,7 @@ this directory, and then copy all content to the `cardinal` public HTML director
 in the [!ac](GCE) computing environment.
 
 ```
-$ scp -r * <user>@homes.cels.anl.gov:/nfs/pub_html/gce/projects/cardinal
+scp -r * <user>@homes.cels.anl.gov:/nfs/pub_html/gce/projects/cardinal
 ```
 
 

--- a/doc/content/hpc.md
+++ b/doc/content/hpc.md
@@ -157,8 +157,8 @@ you use Nek5k:
 - The first time you log in, run from the command line:
 
 ```
-$ module load openmpi/4.0.1/gcc/8.3.1 cmake openmpi/4.0.1/gcc/8.3.1-hdf5-1.10.6 anaconda3/anaconda3
-$ conda init
+module load openmpi/4.0.1/gcc/8.3.1 cmake openmpi/4.0.1/gcc/8.3.1-hdf5-1.10.6 anaconda3/anaconda3
+conda init
 ```
 
 - Log out, then log back in

--- a/doc/content/tutorials/cht1.md
+++ b/doc/content/tutorials/cht1.md
@@ -402,7 +402,7 @@ the `exo2nek` program are available [here](https://nekrsdoc.readthedocs.io/en/la
 After this script has been compiled, you simply need to run
 
 ```
-$ exo2nek
+exo2nek
 ```
 
 and then follow the prompts for the information that must be added about the mesh
@@ -791,7 +791,7 @@ To run the pseudo-steady conduction model, run the following from a command line
 through a job submission script on a [!ac](HPC) system.
 
 ```
-$ mpiexec -np 48 cardinal-opt -i solid.i
+mpiexec -np 48 cardinal-opt -i solid.i
 ```
 
 where `mpiexec` is an [!ac](MPI) compiler wrapper, `-np 48` indicates that the input

--- a/doc/content/tutorials/cht2.md
+++ b/doc/content/tutorials/cht2.md
@@ -149,7 +149,7 @@ on which the results are displayed), or simply by running the solid input file i
 mesh generation mode:
 
 !listing
-$ cardinal-opt -i solid.i --mesh-only
+cardinal-opt -i solid.i --mesh-only
 
 The boundary names are illustrated towards
 the right by showing only the highlighted surface to which each boundary corresponds. Names
@@ -432,7 +432,7 @@ parameters in a single place and use them multiple places (these functions are
 To run the pseudo-steady model, run the following from a command line:
 
 ```
-$ mpiexec -np 12 cardinal-opt -i solid.i
+mpiexec -np 12 cardinal-opt -i solid.i
 ```
 
 By using the `synchronization_interval = parent_app` feature, you will see in the screen output

--- a/doc/content/tutorials/cht3.md
+++ b/doc/content/tutorials/cht3.md
@@ -504,7 +504,7 @@ steady state relative tolerance of $10^{-8}$.
 To run the coupled NekRS-MOOSE calculation, run the following:
 
 ```
-$ mpiexec -np 500 cardinal-opt -i common_input.i solid_nek.i
+mpiexec -np 500 cardinal-opt -i common_input.i solid_nek.i
 ```
 
 This will run with 500 [!ac](MPI) processes (you may run with other parallel
@@ -513,7 +513,7 @@ HPC resources due to the large mesh). To run the coupled THM-MOOSE calculation,
 run the following:
 
 ```
-$ cardinal-opt -i common_input.i solid_thm.i --n-threads=8
+cardinal-opt -i common_input.i solid_thm.i --n-threads=8
 ```
 
 which will run with 8 OpenMP threads; greater computational resources are not needed

--- a/doc/content/tutorials/convergence.md
+++ b/doc/content/tutorials/convergence.md
@@ -58,8 +58,8 @@ for [Tutorial 6C](https://cardinal.cels.anl.gov/tutorials/gas_compact.html),
 we would run:
 
 ```
-$ cd tutorials/gas_compact
-$ python ../../scripts/inactive_study.py -i unit_cell -input openmc.i
+cd tutorials/gas_compact
+python ../../scripts/inactive_study.py -i unit_cell -input openmc.i
 ```
 
 since the Python script used to generate the OpenMC model is named
@@ -172,8 +172,8 @@ for [Tutorial 6C](https://cardinal.cels.anl.gov/tutorials/gas_compact.html),
 we would run:
 
 ```
-$ cd tutorials/gas_compact
-$ python ../../scripts/layers_study.py -i unit_cell -input openmc.i
+cd tutorials/gas_compact
+python ../../scripts/layers_study.py -i unit_cell -input openmc.i
 ```
 
 since the Python script used to generate the OpenMC model is named

--- a/doc/content/tutorials/gas_compact.md
+++ b/doc/content/tutorials/gas_compact.md
@@ -157,7 +157,7 @@ of 7.1 MPa [!cite](petersen) given the imposed temperature, i.e. $\rho_f(P, T)$.
 To create the XML files required to run OpenMC, run the script:
 
 ```
-$ python unit_cell.py
+python unit_cell.py
 ```
 
 You can also use the XML files checked in to the `tutorials/gas_compact` directory.
@@ -359,7 +359,7 @@ executioner. Finally, we specify Exodus and CSV output formats.
 To run the coupled calculation, run the following from the command line.
 
 ```
-$ mpiexec -np 2 cardinal-opt -i openmc.i --n-threads=24
+mpiexec -np 2 cardinal-opt -i openmc.i --n-threads=24
 ```
 
 This will run both MOOSE and OpenMC with 2 [!ac](MPI) processes and 24 OpenMP threads

--- a/doc/content/tutorials/nekrs_outputs.md
+++ b/doc/content/tutorials/nekrs_outputs.md
@@ -39,7 +39,7 @@ and [NekTimeStepper](/timesteppers/NekTimeStepper.md) to run the NekRS CFD
 calculation through the Cardinal wrapper. You can run this example with
 
 ```
-$ mpiexec -np 4 cardinal-opt -i nek.i
+mpiexec -np 4 cardinal-opt -i nek.i
 ```
 
 which will create an output file named `nek_out.e`, which contains the time
@@ -243,7 +243,7 @@ no physics solve occurs in this sub-application.
 This input can be run with
 
 ```
-$ mpiexec -np 8 cardinal-opt -i nek.i
+mpiexec -np 8 cardinal-opt -i nek.i
 ```
 
 which will run with 8 [!ac](MPI) ranks. Because we don't specify any output

--- a/doc/content/tutorials/nekrs_standalone.md
+++ b/doc/content/tutorials/nekrs_standalone.md
@@ -31,7 +31,7 @@ To use these scripts to run standalone NekRS cases,
 we recommend adding this location to your path:
 
 ```
-$ export PATH=$NEKRS_HOME/bin:$PATH
+export PATH=$NEKRS_HOME/bin:$PATH
 ```
 
 Then, you can run any standalone NekRS case simply by having built Cardinal -
@@ -39,8 +39,8 @@ no need to separately build and compile NekRS. For instance, try running the
 `ethier` example that ships with NekRS:
 
 ```
-$ cd contrib/nekRS/examples/ethier
-$ nrsmpi ethier 4
+cd contrib/nekRS/examples/ethier
+nrsmpi ethier 4
 ```
 
 ## Thinly-Wrapped Simulations
@@ -117,7 +117,7 @@ projected onto the [NekRSMesh](/mesh/NekRSMesh.md) to the specified format.
 This input file is run with:
 
 ```
-$ mpiexec -np 8 cardinal-opt -i nek.i
+mpiexec -np 8 cardinal-opt -i nek.i
 ```
 
 which will run with 8 [!ac](MPI) ranks.

--- a/doc/content/tutorials/openmc_fluid.md
+++ b/doc/content/tutorials/openmc_fluid.md
@@ -220,7 +220,7 @@ of 7.1 MPa given the imposed temperature, i.e. $\rho_f(P,T_f)$.
 To create the XML files required to run OpenMC, run the script:
 
 ```
-$ python assembly.py
+python assembly.py
 ```
 
 You can also use the XML files checked in to the `tutorials/gas_assembly` directory;
@@ -595,7 +595,7 @@ inconsequential in this case, but instead represents the Picard iteration. We wi
 To run the coupled calculation, run the following:
 
 ```
-$ mpiexec -np 6 cardinal-opt -i common_input.i openmc.i --n-threads=12
+mpiexec -np 6 cardinal-opt -i common_input.i openmc.i --n-threads=12
 ```
 
 This will run with 6 [!ac](MPI) processes and 12 OpenMP threads (you may use other
@@ -698,7 +698,7 @@ cell temperatures and densities for the fluid cells.
 [fluid_temp] shows the solid temperature computed by MOOSE on several $x-y$ planes
 with the fluid temperature computed by [!ac](THM) shown as tubes. An inset shows the fluid temperature
 on the outlet plane. The absence of compacts in the center region results in the lowest
-fluid temperatures in this region, while the highest fluid temperatures are observed for channels surrounded by 6 compacts 
+fluid temperatures in this region, while the highest fluid temperatures are observed for channels surrounded by 6 compacts
 that are sufficiently close to the periphery to be affected by the lateral insulated boundary conditions.
 
 !media assembly_fluid_temp.png
@@ -710,7 +710,7 @@ and velocity and pressure (right) as a function of axial position. The negative
 temperature feedback results in a top-peaked power distribution. The fuel temperature
 peaks near the mid-plane due to the combined effects of the relatively high power
 density and the continually-increasing fluid temperature with distance from the inlet. The pressure gradient is nearly
-constant with axial position. 
+constant with axial position.
 Due to mass conservation, the heating of the fluid results in the velocity
 increasing with distance from the inlet.
 

--- a/doc/content/tutorials/other_apps.md
+++ b/doc/content/tutorials/other_apps.md
@@ -13,7 +13,7 @@ use dynamic linking in order to couple Cardinal to a generic MOOSE application
 named Chickadee - please first clone this repository with
 
 ```
-$ git clone https://github.com/aprilnovak/Chickadee.git
+git clone https://github.com/aprilnovak/Chickadee.git
 ```
 
 Chickadee doesn't solve any interesting physics - it only contains one
@@ -25,15 +25,15 @@ MOOSE version that you are using in Cardinal; unless you specified something
 special when building Cardinal, this will be `cardinal/contrib/moose`:
 
 ```
-$ export MOOSE_DIR=$HOME/cardinal/contrib/moose
+export MOOSE_DIR=$HOME/cardinal/contrib/moose
 ```
 
 Adjust the above according to wherever you have the Cardinal repository cloned.
 Then, you must compile Chickadee just as you would for any other MOOSE application:
 
 ```
-$ cd chickadee
-$ make -j8
+cd chickadee
+make -j8
 ```
 
 All input files for this tutorial are available in the `tutorials/other_apps`
@@ -69,7 +69,7 @@ To run this input file, use the Cardinal executable (since the master applicatio
 is a Cardinal application):
 
 ```
-$ cardinal-opt -i cardinal_master.i
+cardinal-opt -i cardinal_master.i
 ```
 
 ## Running Cardinal as the Sub App
@@ -90,6 +90,6 @@ otherwise, `CardinalApp` will try to find a `SoluteDiffusion` object, which
 only exists in `ChickadeeApp`, not `CardinalApp`.
 
 ```
-$ chickadee-opt -i chickadee_master.i
+chickadee-opt -i chickadee_master.i
 ```
 

--- a/doc/content/tutorials/triso.md
+++ b/doc/content/tutorials/triso.md
@@ -118,7 +118,7 @@ model remain fixed at the values set in the OpenMC input files.
 To create the XML files required to run OpenMC, run the script:
 
 ```
-$ python make_openmc_model.py
+python make_openmc_model.py
 ```
 
 You can also use the XML files checked in to the `tutorials/pebbles` directory.
@@ -219,7 +219,7 @@ define several postprocessors.
 To run the coupled calculation, run the following from the command line.
 
 ```
-$ mpiexec -np 8 cardinal-opt -i solid.i --n-threads=2
+mpiexec -np 8 cardinal-opt -i solid.i --n-threads=2
 ```
 
 This will run both MOOSE and OpenMC with 8 [!ac](MPI) processes and 2 OpenMP threads.
@@ -304,7 +304,7 @@ within the [!ac](CSG) spheres, but slightly outside the faceted surface of the s
 To run this input, enter the following in a command line.
 
 ```
-$ mpiexec -np 8 cardinal-opt -i solid_um.i --n-threads=2
+mpiexec -np 8 cardinal-opt -i solid_um.i --n-threads=2
 ```
 
 [mesh3] shows the heat source computed by OpenMC, the heat source applied in MOOSE,

--- a/doc/content/tutorials/triso_multiphysics.md
+++ b/doc/content/tutorials/triso_multiphysics.md
@@ -162,7 +162,7 @@ same initial conditions as for the "single-stack" case.
 To create the XML files required to run OpenMC, run the script:
 
 ```
-$ python unit_cell.py
+python unit_cell.py
 ```
 
 You can also use the XML files checked in to the `tutorials/gas_compact_multiphysics` directory.


### PR DESCRIPTION
Closes #462. Remove the extra symbol to increase user friendliness of tutorials.