### PR TITLE
Update faq.md for running tests without conda.

### DIFF
--- a/doc/content/faq.md
+++ b/doc/content/faq.md
@@ -59,6 +59,6 @@ Error! Could not find 'libmesh-config' in any of the usual libmesh's locations!
 This means that you need to explicitly set `LIBMESH_DIR` to point
 to where you have `moose/libmesh`. If you're using MOOSE's conda environment, this
 means setting `LIBMESH_DIR` to `$CONDA_PREFIX/libmesh`. If not using the conda
-environment, set to `cardinal/contrib/moose/libmesh`.
+environment, set to `cardinal/contrib/moose/libmesh/installed`.
 
 !alert-end!


### PR DESCRIPTION
When trying to run tests without the conda environment, libmesh's default installation is `cardinal/contrib/moose/libmesh/installed`, not `cardinal/contrib/moose/libmesh`. 

Using the LIBMESH_DIR in FAQ results in same libmesh-config error message as without the env variable declared.

Correcting LIBMESH_DIR to the '.../installed' directory removes the error and allows for the tests to build and run.

- Tested on Nek5k cluster