### PR TITLE
Support user-defined Nek tolerances

### DIFF
--- a/include/base/NekInterface.h
+++ b/include/base/NekInterface.h
@@ -45,6 +45,18 @@ namespace nekrs
 static int build_only;
 
 /**
+ * Set the absolute tolerance for checking energy conservation in data transfers to Nek
+ * @param[in] tol tolerance
+ */
+void setAbsoluteTol(double tol);
+
+/**
+ * Set the relative tolerance for checking energy conservation in data transfers to Nek
+ * @param[in] tol tolerance
+ */
+void setRelativeTol(double tol);
+
+/**
  * Set the start time used by NekRS
  * @param[in] start start time
  */

--- a/src/base/NekInterface.C
+++ b/src/base/NekInterface.C
@@ -28,8 +28,20 @@ namespace nekrs
 {
 
 // various constants for controlling tolerances
-constexpr double abs_tol = 1e-8;
-constexpr double rel_tol = 1e-5;
+static double abs_tol;
+static double rel_tol;
+
+void
+setAbsoluteTol(double tol)
+{
+  abs_tol = tol;
+}
+
+void
+setRelativeTol(double tol)
+{
+  rel_tol = tol;
+}
 
 void
 setStartTime(const double & start)
@@ -1485,7 +1497,7 @@ initializeDimensionalScales(const double U_ref,
   scales.flux_ref = rho_ref * U_ref * Cp_ref * dT_ref;
   scales.source_ref = scales.flux_ref / L_ref;
 
-  scales.nondimensional_T = (std::abs(dT_ref - 1.0) > abs_tol) || (std::abs(T_ref) > abs_tol);
+  scales.nondimensional_T = (std::abs(dT_ref - 1.0) > 1e-6) || (std::abs(T_ref) > 1e-6);
 }
 
 double

--- a/src/base/NekRSProblem.C
+++ b/src/base/NekRSProblem.C
@@ -411,7 +411,12 @@ NekRSProblem::sendBoundaryHeatFluxToNek()
                moose_flux,
                ".\n\nThis may happen if the nekRS mesh "
                "is very different from that used in the App sending heat flux to nekRS and the "
-               "nearest node transfer is only picking up zero values in the coupled App.");
+               "nearest node transfer is only picking up zero values in the coupled App.\n\n"
+               "OR, this error could indicate that your tolerances for comparing the re-normalized "
+               "Nek flux with the incoming MOOSE flux are too tight. If the NekRS flux (",
+               normalized_nek_flux, ") is acceptably close to the MOOSE flux (", moose_flux, "), "
+               "then you can try relaxing the 'normalization_abs_tol' and/or 'normalization_rel_tol' "
+               "parameters");
 }
 
 void
@@ -564,7 +569,12 @@ NekRSProblem::sendVolumeHeatSourceToNek()
                moose_source,
                ".\n\nThis may happen if the nekRS mesh "
                "is very different from that used in the App sending heat source to nekRS and the "
-               "nearest node transfer is only picking up zero values in the coupled App.");
+               "nearest node transfer is only picking up zero values in the coupled App."
+               "OR, this error could indicate that your tolerances for comparing the re-normalized "
+               "Nek heat source with the incoming MOOSE heat source are too tight. If the NekRS heat source (",
+               normalized_nek_source, ") is acceptably close to the MOOSE heat source (", moose_source, "), "
+               "then you can try relaxing the 'normalization_abs_tol' and/or 'normalization_rel_tol' "
+               "parameters");
 }
 
 void

--- a/src/base/NekRSProblem.C
+++ b/src/base/NekRSProblem.C
@@ -50,6 +50,14 @@ NekRSProblem::validParams()
                         "heat source in the NekRS domain is zero anyways (such as if NekRS only "
                         "solves for the fluid and we have solid fuel).");
 
+  params.addRangeCheckedParam<Real>("normalization_abs_tol", 1e-8, "normalization_abs_tol > 0",
+    "Absolute tolerance for checking if the boundary heat flux and volumetric heat sources "
+    "sent from MOOSE to NekRS are re-normalized correctly");
+
+  params.addRangeCheckedParam<Real>("normalization_rel_tol", 1e-5, "normalization_rel_tol > 0",
+    "Absolute tolerance for checking if the boundary heat flux and volumetric heat sources "
+    "sent from MOOSE to NekRS are re-normalized correctly");
+
   params.addParam<PostprocessorName>("min_T",
                                      "If provided, postprocessor used to limit the minimum "
                                      "temperature (in dimensional form) in the nekRS problem");
@@ -66,6 +74,9 @@ NekRSProblem::NekRSProblem(const InputParameters & params)
     _has_heat_source(getParam<bool>("has_heat_source")),
     _usrwrk_indices(MultiMooseEnum("flux heat_source x_displacement y_displacement z_displacement unused"))
 {
+  nekrs::setAbsoluteTol(getParam<Real>("normalization_abs_tol"));
+  nekrs::setRelativeTol(getParam<Real>("normalization_rel_tol"));
+
   // Determine an appropriate default usrwrk indexing; the ordering will always be
   //   0: flux             (if _boundary is true)
   //   1: heat_source      (if _volume is true and _has_heat_source is true)


### PR DESCRIPTION
This adds the ability for the user to easily control the tolerances for checking energy conservation between MOOSE and NekRS (which were previously hard-coded).

Closes #498