### PR TITLE
Add test for pin bundle heat conduction

### DIFF
--- a/tutorials/sfr_7pin/tests
+++ b/tutorials/sfr_7pin/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [solid]
+    type = RunApp
+    input = solid.i
+    min_parallel = 2
+    cli_args = 'Mesh/clad/nt=8 Mesh/fuel/nt=8 MultiApps/active="" Transfers/active="" Executioner/num_steps=1'
+    requirement = "The system shall run a solid heat conduction problem for a 7-pin bundle."
+  []
+[]


### PR DESCRIPTION
The `sfr_7pin` tutorial is missing a test coverage for the heat conduction.