### PR TITLE
Add syntax parameters for NekRSStandaloneProblem.

### DIFF
--- a/doc/content/source/problems/NekRSStandaloneProblem.md
+++ b/doc/content/source/problems/NekRSStandaloneProblem.md
@@ -151,3 +151,9 @@ the [MOOSE documentation](https://mooseframework.inl.gov/source/index.html) to l
 ## Outputting the Scratch Array
 
 !include write_scratch.md
+
+!syntax parameters /Problem/NekRSStandaloneProblem
+
+!syntax inputs /Problem/NekRSStandaloneProblem
+
+!syntax children /Problem/NekRSStandaloneProblem

--- a/src/base/NekRSProblem.C
+++ b/src/base/NekRSProblem.C
@@ -632,7 +632,9 @@ NekRSProblem::sendVolumeHeatSourceToNek()
   if (moose_source &&
       (std::abs(nek_source * nek_source_print_mult - moose_source) / moose_source) > 0.25)
     mooseDoOnce(mooseWarning("nekRS source differs from MOOSE source by more than 25\%! "
-                             "This could indicate that your geometries do not line up properly."));
+                             "This could indicate that your geometries do not line up properly "
+                             "or there is some other mistake in the data transfer (check the "
+                             "exodus output files to see if the transferred data looks sensible)."));
 
   if (!successful_normalization)
     mooseError("Heat source normalization process failed! nekRS integrated heat source: ",


### PR DESCRIPTION
The documentation page for `NekRSStandaloneProblem` was missing the links to the input parameters. I also improved the warning message that is printed when transferring flux to NekRS, to give a better hint that something might be wrong with the data transfer.