### PR TITLE
Throw error if user specifies a duplicate variable

### DIFF
--- a/include/base/NekRSProblemBase.h
+++ b/include/base/NekRSProblemBase.h
@@ -42,6 +42,13 @@ public:
   ~NekRSProblemBase();
 
   /**
+   * Check whether the user has already created a variable using one of the protected
+   * names that the NekRS wrapping is using.
+   * @param[in] name variable name
+   */
+  void checkDuplicateVariableName(const std::string & name) const;
+
+  /**
    * Write NekRS solution field file
    * @param[in] time solution time in NekRS (if NekRS is non-dimensional, this will be non-dimensional)
    * @param[in] step time step index

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -36,6 +36,13 @@ public:
 
   virtual ~OpenMCProblemBase() override;
 
+  /**
+   * Check whether the user has already created a variable using one of the protected
+   * names that the OpenMC wrapping is using.
+   * @param[in] name variable name
+   */
+  void checkDuplicateVariableName(const std::string & name) const;
+
   /// Run a k-eigenvalue OpenMC simulation
   void externalSolve() override;
 

--- a/src/base/NekRSProblem.C
+++ b/src/base/NekRSProblem.C
@@ -771,6 +771,7 @@ NekRSProblem::addExternalVariables()
   NekRSProblemBase::addExternalVariables();
   auto var_params = getExternalVariableParameters();
 
+  checkDuplicateVariableName("temp");
   addAuxVariable("MooseVariable", "temp", var_params);
   _temp_var = _aux->getFieldVariable<Real>(0, "temp").number();
 
@@ -783,6 +784,7 @@ NekRSProblem::addExternalVariables()
     // to nekRS. This is just the variable that nekRS reads from - MOOSE's transfer
     // classes handle any additional interpolations needed from the flux on the
     // sending app (such as BISON) into 'avg_flux'.
+    checkDuplicateVariableName("avg_flux");
     addAuxVariable("MooseVariable", "avg_flux", var_params);
     _avg_flux_var = _aux->getFieldVariable<Real>(0, "avg_flux").number();
 
@@ -805,6 +807,7 @@ NekRSProblem::addExternalVariables()
 
   if (_volume && _has_heat_source)
   {
+    checkDuplicateVariableName("heat_source");
     addAuxVariable("MooseVariable", "heat_source", var_params);
     _heat_source_var = _aux->getFieldVariable<Real>(0, "heat_source").number();
 
@@ -817,12 +820,15 @@ NekRSProblem::addExternalVariables()
   // be needed regardless of whether the displacement is boundary- or volume-based
   if (_moving_mesh)
   {
+    checkDuplicateVariableName("disp_x");
     addAuxVariable("MooseVariable", "disp_x", var_params);
     _disp_x_var = _aux->getFieldVariable<Real>(0, "disp_x").number();
 
+    checkDuplicateVariableName("disp_y");
     addAuxVariable("MooseVariable", "disp_y", var_params);
     _disp_y_var = _aux->getFieldVariable<Real>(0, "disp_y").number();
 
+    checkDuplicateVariableName("disp_z");
     addAuxVariable("MooseVariable", "disp_z", var_params);
     _disp_z_var = _aux->getFieldVariable<Real>(0, "disp_z").number();
   }

--- a/src/base/NekRSProblemBase.C
+++ b/src/base/NekRSProblemBase.C
@@ -742,6 +742,20 @@ NekRSProblemBase::addTemperatureVariable()
 }
 
 void
+NekRSProblemBase::checkDuplicateVariableName(const std::string & name) const
+{
+  if (_aux.get()->hasVariable(name))
+    mooseError("Cardinal is trying to add an auxiliary variable named '", name,
+      "', but you already have a variable by this name. Please choose a different name "
+      "for the auxiliary variable you are adding.");
+
+  if (_nl[0].get()->hasVariable(name))
+    mooseError("Cardinal is trying to add a nonlinear variable named '", name,
+      "', but you already have a variable by this name. Please choose a different name "
+      "for the nonlinear variable you are adding.");
+}
+
+void
 NekRSProblemBase::addExternalVariables()
 {
   if (_outputs)
@@ -775,6 +789,7 @@ NekRSProblemBase::addExternalVariables()
     _var_string = "";
     for (const auto & name : _var_names)
     {
+      checkDuplicateVariableName(name);
       addAuxVariable("MooseVariable", name, var_params);
       _external_vars.push_back(_aux->getFieldVariable<Real>(0, name).number());
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1959,15 +1959,18 @@ OpenMCCellAverageProblem::addExternalVariables()
   var_params.set<MooseEnum>("family") = "MONOMIAL";
   var_params.set<MooseEnum>("order") = "CONSTANT";
 
+  checkDuplicateVariableName(_tally_name);
   addAuxVariable("MooseVariable", _tally_name, var_params);
   _tally_var = _aux->getFieldVariable<Real>(0, _tally_name).number();
 
+  checkDuplicateVariableName("temp");
   addAuxVariable("MooseVariable", "temp", var_params);
   _temp_var = _aux->getFieldVariable<Real>(0, "temp").number();
 
   // we need a density variable if we are transferring density into OpenMC
   if (_has_fluid_blocks)
   {
+    checkDuplicateVariableName("density");
     addAuxVariable("MooseVariable", "density", var_params);
     _density_var = _aux->getFieldVariable<Real>(0, "density").number();
   }
@@ -1976,6 +1979,7 @@ OpenMCCellAverageProblem::addExternalVariables()
   {
     for (std::size_t i = 0; i < _outputs->size(); ++i)
     {
+      checkDuplicateVariableName(_output_name[i]);
       addAuxVariable("MooseVariable", _output_name[i], var_params);
       _external_vars.push_back(_aux->getFieldVariable<Real>(0, _output_name[i]).number());
     }
@@ -2009,6 +2013,7 @@ OpenMCCellAverageProblem::addExternalVariables()
       var_params.set<MooseEnum>("family") = "LAGRANGE";
       var_params.set<MooseEnum>("order") = "FIRST";
       var_params.set<std::vector<SubdomainName>>("block") = v.second;
+      checkDuplicateVariableName(v.first);
       addAuxVariable("MooseVariable", v.first, var_params);
     }
 

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -19,6 +19,7 @@
 #ifdef ENABLE_OPENMC_COUPLING
 
 #include "OpenMCProblemBase.h"
+#include "NonlinearSystem.h"
 #include "AuxiliarySystem.h"
 #include "UserErrorChecking.h"
 
@@ -468,6 +469,20 @@ OpenMCProblemBase::tallyMeanAcrossBins(std::vector<openmc::Tally *> tally) const
     n += t->n_realizations_;
 
   return tallySumAcrossBins(tally) / n;
+}
+
+void
+OpenMCProblemBase::checkDuplicateVariableName(const std::string & name) const
+{
+  if (_aux.get()->hasVariable(name))
+    mooseError("Cardinal is trying to add an auxiliary variable named '", name,
+      "', but you already have a variable by this name. Please choose a different name "
+      "for the auxiliary variable you are adding.");
+
+  if (_nl[0].get()->hasVariable(name))
+    mooseError("Cardinal is trying to add a nonlinear variable named '", name,
+      "', but you already have a variable by this name. Please choose a different name "
+      "for the nonlinear variable you are adding.");
 }
 
 #endif

--- a/test/tests/conduction/boundary_and_volume/prism/tests
+++ b/test/tests/conduction/boundary_and_volume/prism/tests
@@ -13,4 +13,12 @@
                   "can be made better by using finer meshes in the coupled Cardinal case."
     required_objects = 'NekRSProblem'
   []
+  [duplicate_temp]
+    type = RunException
+    input = nek.i
+    cli_args = "AuxVariables/heat_source/order=FIRST"
+    expect_err = "Cardinal is trying to add an auxiliary variable named 'heat_source', but you already have a variable by this name."
+    requirement = "The system shall error if the user specifies a duplicate variable with a name overlapping with special names reserved for Cardinal data transfers."
+    required_objects = 'NekRSProblem'
+  []
 []

--- a/test/tests/deformation/vol-areas/nek.i
+++ b/test/tests/deformation/vol-areas/nek.i
@@ -15,15 +15,6 @@
 [AuxVariables]
   [dummy]
   []
-  [disp_x]
-    order = SECOND
-  []
-  [disp_y]
-    order = SECOND
-  []
-  [disp_z]
-    order = SECOND
-  []
 []
 
 # This AuxVariable and AuxKernel is only here to get the postprocessors

--- a/test/tests/nek_errors/invalid_field/auxvar.i
+++ b/test/tests/nek_errors/invalid_field/auxvar.i
@@ -1,0 +1,23 @@
+[Problem]
+  type = NekRSStandaloneProblem
+  casename = 'pyramid'
+  output = 'temperature'
+[]
+
+[Mesh]
+  type = NekRSMesh
+  volume = true
+[]
+
+[AuxVariables]
+  [temp]
+  []
+[]
+
+[Executioner]
+  type = Transient
+
+  [TimeStepper]
+    type = NekTimeStepper
+  []
+[]

--- a/test/tests/nek_errors/invalid_field/nonlinear.i
+++ b/test/tests/nek_errors/invalid_field/nonlinear.i
@@ -1,0 +1,23 @@
+[Problem]
+  type = NekRSStandaloneProblem
+  casename = 'pyramid'
+  output = 'temperature'
+[]
+
+[Mesh]
+  type = NekRSMesh
+  volume = true
+[]
+
+[Variables]
+  [temp]
+  []
+[]
+
+[Executioner]
+  type = Transient
+
+  [TimeStepper]
+    type = NekTimeStepper
+  []
+[]

--- a/test/tests/nek_errors/invalid_field/tests
+++ b/test/tests/nek_errors/invalid_field/tests
@@ -26,4 +26,18 @@
                   "that don't have a temperature variable."
     required_objects = 'NekRSProblem'
   []
+  [duplicate_auxvar]
+    type = RunException
+    input = auxvar.i
+    expect_err = "Cardinal is trying to add an auxiliary variable named 'temp', but you already have a variable by this name."
+    requirement = "The system shall error if the user manually specifies a duplicate name for an output field."
+    required_objects = 'NekRSProblem'
+  []
+  [duplicate_var]
+    type = RunException
+    input = nonlinear.i
+    expect_err = "Cardinal is trying to add a nonlinear variable named 'temp', but you already have a variable by this name."
+    requirement = "The system shall error if the user manually specifies a duplicate name for an output field."
+    required_objects = 'NekRSProblem'
+  []
 []

--- a/test/tests/neutronics/feedback/lattice/tests
+++ b/test/tests/neutronics/feedback/lattice/tests
@@ -57,4 +57,12 @@
     requirement = "The system shall allow the user to specify a 'fission-q-recoverable' score in the OpenMC tally."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [duplicate_variable]
+    type = RunException
+    input = openmc.i
+    cli_args = "AuxVariables/heat_source/order=FIRST"
+    expect_err = "Cardinal is trying to add an auxiliary variable named 'heat_source', but you already have a variable by this name."
+    requirement = "The system shall error if the user adds a duplicate variable with a name Cardinal reserves for OpenMC coupling."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
 []


### PR DESCRIPTION
Cardinal automatically creates a number of auxiliary variables to facilitate coupling. This can be confusing for new users who mistakenly think they need to create these variables themselves. This PR throws an explicit error telling the user that the name of their aux variable is already reserved for Cardinal.