### PR TITLE
Use input file that new users can actually run without prep steps.

### DIFF
--- a/doc/content/checking_install.md
+++ b/doc/content/checking_install.md
@@ -4,8 +4,8 @@ have all the basic requirements in place, you can try running a few input files.
 1. If you are using OpenMC, try:
 
 ```
-cd tutorials/lwr_solid
-mpiexec -np 2 ../../cardinal-opt -i solid.i --n-threads=2
+cd test/tests/neutronics/feedback/lattice
+mpiexec -np 2 ../../../../../cardinal-opt -i openmc_master.i --n-threads=2
 ```
 
 If you run into any issues when running OpenMC cases, check out our


### PR DESCRIPTION
@vincemilo kindly pointed out that the instructions we provide users to check their OpenMC install aren't fully complete. With the particular tutorial we were telling users to run, you need to first create the mesh by running another input file. This is spelled out clearly on the tutorial documentation page, but not on our "getting started" page.

For simplicity, this just changes the input file we tell users to run.