### PR TITLE
Generalize cornerGLLIndices to multiple elements per face

### DIFF
--- a/include/base/NekInterface.h
+++ b/include/base/NekInterface.h
@@ -235,13 +235,6 @@ bool hasScalarVariable(int scalarId);
 bool hasHeatSourceKernel();
 
 /**
- * Get the corner indices for each element
- * @param[in] n order of mesh (0 = first-order, 1 = second-order)
- * @return corner indices of the HEX20 elements
- */
-std::vector<int> cornerGLLIndices(const int & n);
-
-/**
  * Whether the scratch space has already been allocated by the user
  * @return whether scratch space is already allocated
  */

--- a/include/base/NekUtils.h
+++ b/include/base/NekUtils.h
@@ -1,0 +1,50 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#pragma once
+
+#include <vector>
+
+namespace nekrs
+{
+
+/**
+ * \brief Get the corner indices for the GLL points in a NekRS element on a single face
+ *
+ * Support the NekRS mesh face has nodes
+ *
+ * 6 -- 7 -- 8
+ * |    |    |
+ * 3 -- 4 -- 5
+ * |    |    |
+ * 0 -- 1 -- 2
+ *
+ * If 'exact' is false, this method returns {0, 2, 6, 8}. If 'exact' is true,
+ * this method returns:
+ * - element 0: {0, 1, 3, 4}
+ * - element 1: {1, 2, 4, 5}
+ * - element 2: {3, 4, 6, 7}
+ * - element 3: {4, 5, 7, 8}
+ *
+ * @param[in] n order of mesh (1 = first-order, 2 = second-order)
+ * @param[in] exact whether the MOOSE elements will exactly represent the NekRS mesh
+ * @return GLL indices, indexed first by element to build, then second by nodes on that element
+ */
+std::vector<std::vector<int>> cornerGLLIndices(const int & n, const bool exact);
+
+} // end namespace nekrs

--- a/include/mesh/NekRSMesh.h
+++ b/include/mesh/NekRSMesh.h
@@ -24,6 +24,7 @@
 #include "NekBoundaryCoupling.h"
 #include "NekVolumeCoupling.h"
 #include "NekInterface.h"
+#include "NekUtils.h"
 
 /**
  * Representation of a nekRS surface mesh as a native MooseMesh. This is
@@ -334,8 +335,14 @@ protected:
   /// Order of the nekRS solution
   int _nek_polynomial_order;
 
-  /// Number of surface elements in MooseMesh
+  /**
+   * Number of NekRS surface elements in MooseMesh. The total number of surface
+   * elements in the mesh mirror is _n_surface_elems * _n_build_per_surface_elem.
+   */
   int _n_surface_elems;
+
+  /// Number of MOOSE surface elements to build per NekRS surface element
+  int _n_build_per_surface_elem;
 
   /// Number of volume elements in MooseMesh
   int _n_volume_elems;

--- a/src/base/NekInterface.C
+++ b/src/base/NekInterface.C
@@ -62,21 +62,6 @@ setStartTime(const double & start)
   platform->options.setArgs("START TIME", to_string_f(start));
 }
 
-std::vector<int>
-cornerGLLIndices(const int & n)
-{
-  int back_corner = (n + 1) * (n + 1) * n;
-  std::vector<int> corner_indices = {0,
-                                     n,
-                                     (n + 1) * n,
-                                     (n + 1) * (n + 1) - 1,
-                                     back_corner,
-                                     back_corner + n,
-                                     back_corner + (n + 1) * n,
-                                     back_corner + (n + 1) * (n + 1) - 1};
-  return corner_indices;
-}
-
 void
 write_usrwrk_field_file(const int & slot, const std::string & prefix, const dfloat & time, const int & step, const bool & write_coords)
 {

--- a/src/base/NekUtils.C
+++ b/src/base/NekUtils.C
@@ -1,0 +1,49 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#include "NekUtils.h"
+
+namespace nekrs
+{
+
+std::vector<std::vector<int>>
+cornerGLLIndices(const int & n, const bool exact)
+{
+  std::vector<std::vector<int>> corner_indices;
+
+  if (!exact)
+  {
+    corner_indices.resize(1);
+    corner_indices[0] = {0, n, (n + 1) * n, (n + 1) * (n + 1) - 1};
+  }
+  else
+  {
+    for (int row = 0; row < n; ++row)
+    {
+      for (int col = 0; col < n; ++col)
+      {
+        int start = row * (n + 1) + col;
+        corner_indices.push_back({start, start + 1, start + n + 1, start + n + 2});
+      }
+    }
+  }
+
+  return corner_indices;
+}
+
+} // end namespace nekrs

--- a/src/mesh/NekRSMesh.C
+++ b/src/mesh/NekRSMesh.C
@@ -159,6 +159,7 @@ void
 NekRSMesh::initializeMeshParams()
 {
   _nek_polynomial_order = nekrs::mesh::polynomialOrder();
+  _n_build_per_surface_elem = 1;
 
   /**
    * The libMesh face numbering for a 3-D hexagonal element is
@@ -625,61 +626,69 @@ NekRSMesh::addElems()
 void
 NekRSMesh::faceVertices()
 {
-  double * x = (double *)malloc(_n_surface_elems * _n_vertices_per_surface * sizeof(double));
-  double * y = (double *)malloc(_n_surface_elems * _n_vertices_per_surface * sizeof(double));
-  double * z = (double *)malloc(_n_surface_elems * _n_vertices_per_surface * sizeof(double));
-
-  nrs_t * nrs = (nrs_t *)nekrs::nrsPtr();
-  int rank = nekrs::commRank();
+  int n_vertices_in_mirror = _n_build_per_surface_elem * _n_surface_elems * _n_vertices_per_surface;
+  double * x = (double *) malloc(n_vertices_in_mirror * sizeof(double));
+  double * y = (double *) malloc(n_vertices_in_mirror * sizeof(double));
+  double * z = (double *) malloc(n_vertices_in_mirror * sizeof(double));
 
   mesh_t * mesh;
   int Nfp_mirror;
-  auto corner_indices = nekrs::cornerGLLIndices(nekrs::entireMesh()->N);
+  bool build_new_mesh;
+  auto corner_indices = nekrs::cornerGLLIndices(nekrs::entireMesh()->N, false);
 
-  if (_order == 0)
+  switch (_order)
   {
-    // For a first-order mesh mirror, we can take a shortcut and instead just fetch the
-    // corner nodes. In this case, 'mesh' is no longer a custom-build mesh copy, but the
-    // actual mesh for computation
-    mesh = _nek_internal_mesh;
-    Nfp_mirror = 4;
-  }
-  else
-  {
-    // Create a duplicate of the solution mesh, but with the desired order of the mesh
-    // interpolation. Then we can just read the coordinates of the GLL points to find the libMesh
-    // node positions.
-    mesh =
-        createMesh(platform->comm.mpiComm, _order + 1, 1 /* dummy */, nrs->cht, *(nrs->kernelInfo));
-    Nfp_mirror = mesh->Nfp;
+    case order::first:
+    {
+      // For a first-order mesh mirror, we can take a shortcut and instead just fetch the
+      // corner nodes. In this case, 'mesh' is no longer a custom-build mesh copy, but the
+      // actual mesh for computation
+      mesh = _nek_internal_mesh;
+      Nfp_mirror = 4;
+      build_new_mesh = false;
+      break;
+    }
+    case order::second:
+    {
+      // Create a duplicate of the solution mesh, but with the desired order of the mesh
+      // interpolation. Then we read the coordinates of the GLL points to find the libMesh nodes.
+      nrs_t * nrs = (nrs_t *)nekrs::nrsPtr();
+      mesh =
+          createMesh(platform->comm.mpiComm, _order + 1, 1 /* dummy */, nrs->cht, *(nrs->kernelInfo));
+      Nfp_mirror = mesh->Nfp;
+      build_new_mesh = true;
+      break;
+    }
+    default:
+      mooseError("Unhandled NekOrderEnum in NekRSMesh!");
   }
 
   // Allocate space for the coordinates that are on this rank
-  double * xtmp = (double *)malloc(_boundary_coupling.n_faces * Nfp_mirror * sizeof(double));
-  double * ytmp = (double *)malloc(_boundary_coupling.n_faces * Nfp_mirror * sizeof(double));
-  double * ztmp = (double *)malloc(_boundary_coupling.n_faces * Nfp_mirror * sizeof(double));
+  int n_vertices_in_source = _n_build_per_surface_elem * _boundary_coupling.n_faces * Nfp_mirror;
+  double * xtmp = (double *) malloc(n_vertices_in_source * sizeof(double));
+  double * ytmp = (double *) malloc(n_vertices_in_source * sizeof(double));
+  double * ztmp = (double *) malloc(n_vertices_in_source * sizeof(double));
 
   int c = 0;
   for (int k = 0; k < _boundary_coupling.total_n_faces; ++k)
   {
-    if (_boundary_coupling.process[k] == rank)
+    if (_boundary_coupling.process[k] == nekrs::commRank())
     {
       int i = _boundary_coupling.element[k];
       int j = _boundary_coupling.face[k];
       int offset = i * mesh->Nfaces * mesh->Nfp + j * mesh->Nfp;
 
-      for (int v = 0; v < Nfp_mirror; ++v, ++c)
+      for (int build = 0; build < _n_build_per_surface_elem; ++build)
       {
-        int id;
+        for (int v = 0; v < Nfp_mirror; ++v, ++c)
+        {
+          int vertex_offset = build_new_mesh ? v : corner_indices[build][v];
+          int id = mesh->vmapM[offset + vertex_offset];
 
-        if (_order == 0)
-          id = mesh->vmapM[offset + corner_indices[v]];
-        else
-          id = mesh->vmapM[offset + v];
-
-        xtmp[c] = mesh->x[id];
-        ytmp[c] = mesh->y[id];
-        ztmp[c] = mesh->z[id];
+          xtmp[c] = mesh->x[id];
+          ytmp[c] = mesh->y[id];
+          ztmp[c] = mesh->z[id];
+        }
       }
     }
   }
@@ -688,7 +697,7 @@ NekRSMesh::faceVertices()
   nekrs::allgatherv(_boundary_coupling.counts, ytmp, y, Nfp_mirror);
   nekrs::allgatherv(_boundary_coupling.counts, ztmp, z, Nfp_mirror);
 
-  for (int i = 0; i < _n_surface_elems * _n_vertices_per_surface; ++i)
+  for (int i = 0; i < n_vertices_in_mirror; ++i)
   {
     _x.push_back(x[i]);
     _y.push_back(y[i]);

--- a/unit/include/NekInterfaceTest.h
+++ b/unit/include/NekInterfaceTest.h
@@ -1,0 +1,28 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#pragma once
+
+#include "NekUtils.h"
+#include "MooseObjectUnitTest.h"
+
+class NekInterfaceTest : public MooseObjectUnitTest
+{
+public:
+  NekInterfaceTest() : MooseObjectUnitTest("CardinalUnitApp") {}
+};

--- a/unit/src/NekInterfaceTest.C
+++ b/unit/src/NekInterfaceTest.C
@@ -1,0 +1,139 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#include "NekInterfaceTest.h"
+
+TEST_F(NekInterfaceTest, corner_gll)
+{
+  int n = 1;
+  auto first = nekrs::cornerGLLIndices(n, false);
+  EXPECT_EQ(first.size(), 1);
+  EXPECT_EQ(first[0].size(), 4);
+  EXPECT_EQ(first[0][0], 0);
+  EXPECT_EQ(first[0][1], 1);
+  EXPECT_EQ(first[0][2], 2);
+  EXPECT_EQ(first[0][3], 3);
+
+  first = nekrs::cornerGLLIndices(n, true);
+  EXPECT_EQ(first.size(), 1);
+  EXPECT_EQ(first[0].size(), 4);
+  EXPECT_EQ(first[0][0], 0);
+  EXPECT_EQ(first[0][1], 1);
+  EXPECT_EQ(first[0][2], 2);
+  EXPECT_EQ(first[0][3], 3);
+
+  n = 2;
+  auto second = nekrs::cornerGLLIndices(n, false);
+  EXPECT_EQ(second.size(), 1);
+  EXPECT_EQ(second[0].size(), 4);
+  EXPECT_EQ(second[0][0], 0);
+  EXPECT_EQ(second[0][1], 2);
+  EXPECT_EQ(second[0][2], 6);
+  EXPECT_EQ(second[0][3], 8);
+
+  second = nekrs::cornerGLLIndices(n, true);
+  EXPECT_EQ(second.size(), 4);
+  EXPECT_EQ(second[0].size(), 4);
+  EXPECT_EQ(second[0][0], 0);
+  EXPECT_EQ(second[0][1], 1);
+  EXPECT_EQ(second[0][2], 3);
+  EXPECT_EQ(second[0][3], 4);
+
+  EXPECT_EQ(second[1].size(), 4);
+  EXPECT_EQ(second[1][0], 1);
+  EXPECT_EQ(second[1][1], 2);
+  EXPECT_EQ(second[1][2], 4);
+  EXPECT_EQ(second[1][3], 5);
+
+  EXPECT_EQ(second[2].size(), 4);
+  EXPECT_EQ(second[2][0], 3);
+  EXPECT_EQ(second[2][1], 4);
+  EXPECT_EQ(second[2][2], 6);
+  EXPECT_EQ(second[2][3], 7);
+
+  EXPECT_EQ(second[3].size(), 4);
+  EXPECT_EQ(second[3][0], 4);
+  EXPECT_EQ(second[3][1], 5);
+  EXPECT_EQ(second[3][2], 7);
+  EXPECT_EQ(second[3][3], 8);
+
+  n = 3;
+  auto third = nekrs::cornerGLLIndices(n, false);
+  EXPECT_EQ(third.size(), 1);
+  EXPECT_EQ(third[0].size(), 4);
+  EXPECT_EQ(third[0][0], 0);
+  EXPECT_EQ(third[0][1], 3);
+  EXPECT_EQ(third[0][2], 12);
+  EXPECT_EQ(third[0][3], 15);
+
+  third = nekrs::cornerGLLIndices(n, true);
+  EXPECT_EQ(third.size(), 9);
+  EXPECT_EQ(third[0].size(), 4);
+  EXPECT_EQ(third[0][0], 0);
+  EXPECT_EQ(third[0][1], 1);
+  EXPECT_EQ(third[0][2], 4);
+  EXPECT_EQ(third[0][3], 5);
+
+  EXPECT_EQ(third[1].size(), 4);
+  EXPECT_EQ(third[1][0], 1);
+  EXPECT_EQ(third[1][1], 2);
+  EXPECT_EQ(third[1][2], 5);
+  EXPECT_EQ(third[1][3], 6);
+
+  EXPECT_EQ(third[2].size(), 4);
+  EXPECT_EQ(third[2][0], 2);
+  EXPECT_EQ(third[2][1], 3);
+  EXPECT_EQ(third[2][2], 6);
+  EXPECT_EQ(third[2][3], 7);
+
+  EXPECT_EQ(third[3].size(), 4);
+  EXPECT_EQ(third[3][0], 4);
+  EXPECT_EQ(third[3][1], 5);
+  EXPECT_EQ(third[3][2], 8);
+  EXPECT_EQ(third[3][3], 9);
+
+  EXPECT_EQ(third[4].size(), 4);
+  EXPECT_EQ(third[4][0], 5);
+  EXPECT_EQ(third[4][1], 6);
+  EXPECT_EQ(third[4][2], 9);
+  EXPECT_EQ(third[4][3], 10);
+
+  EXPECT_EQ(third[5].size(), 4);
+  EXPECT_EQ(third[5][0], 6);
+  EXPECT_EQ(third[5][1], 7);
+  EXPECT_EQ(third[5][2], 10);
+  EXPECT_EQ(third[5][3], 11);
+
+  EXPECT_EQ(third[6].size(), 4);
+  EXPECT_EQ(third[6][0], 8);
+  EXPECT_EQ(third[6][1], 9);
+  EXPECT_EQ(third[6][2], 12);
+  EXPECT_EQ(third[6][3], 13);
+
+  EXPECT_EQ(third[7].size(), 4);
+  EXPECT_EQ(third[7][0], 9);
+  EXPECT_EQ(third[7][1], 10);
+  EXPECT_EQ(third[7][2], 13);
+  EXPECT_EQ(third[7][3], 14);
+
+  EXPECT_EQ(third[8].size(), 4);
+  EXPECT_EQ(third[8][0], 10);
+  EXPECT_EQ(third[8][1], 11);
+  EXPECT_EQ(third[8][2], 14);
+  EXPECT_EQ(third[8][3], 15);
+}


### PR DESCRIPTION
In preparation for #503, this PR generalizes the function that determines the node indexing for building face elements that mirror the NekRS mesh.