### PR TITLE
Ignore unused params

### DIFF
--- a/include/base/NekInterface.h
+++ b/include/base/NekInterface.h
@@ -625,6 +625,12 @@ int polynomialOrder();
 int Nelements();
 
 /**
+ * Total number of volume elements in the flow portion of the NekRS mesh, summed over all processes
+ * @return number of flow volume elements
+ */
+int NflowElements();
+
+/**
  * Mesh dimension
  * @return mesh dimension
  */

--- a/include/mesh/NekRSMesh.h
+++ b/include/mesh/NekRSMesh.h
@@ -380,6 +380,12 @@ protected:
    */
   const Real & _scaling;
 
+  /// Block ID for the fluid portion of the mesh mirror
+  const unsigned int & _fluid_block_id;
+
+  /// Block ID for the solid portion of the mesh mirror
+  const unsigned int & _solid_block_id;
+
   /// Order of the nekRS solution
   int _nek_polynomial_order;
 
@@ -427,6 +433,9 @@ protected:
 
   /// Total number of volume elements in the nekRS problem
   int _nek_n_volume_elems;
+
+  /// Number of volume elements in the flow portion of the NekRS mesh
+  int _nek_n_flow_elems;
 
   /**
    * \brief \f$x\f$ coordinates of the current GLL points (which can move in time), for this rank

--- a/src/base/CardinalApp.C
+++ b/src/base/CardinalApp.C
@@ -71,6 +71,7 @@ CardinalApp::validParams()
   params.addCommandLineParam<std::string>("nekrs_device_id", "--nekrs-device-id", "NekRS device ID");
 
   params.set<bool>("use_legacy_material_output") = false;
+  params.set<bool>("error_unused") = false;
   return params;
 }
 

--- a/src/base/NekInterface.C
+++ b/src/base/NekInterface.C
@@ -1336,6 +1336,14 @@ polynomialOrder()
   return entireMesh()->N;
 }
 
+int NflowElements()
+{
+  int n_local = flowMesh()->Nelements;
+  int n_global;
+  MPI_Allreduce(&n_local, &n_global, 1, MPI_INT, MPI_SUM, platform->comm.mpiComm);
+  return n_global;
+}
+
 int
 Nelements()
 {

--- a/src/mesh/NekRSMesh.C
+++ b/src/mesh/NekRSMesh.C
@@ -660,12 +660,12 @@ NekRSMesh::addElems()
             boundary_info.add_side(elem, _side_index[f], b_id);
           }
         }
-      }
 
-      if (e < _nek_n_flow_elems)
-        elem->subdomain_id() = _fluid_block_id;
-      else
-        elem->subdomain_id() = _solid_block_id;
+        if (e < _nek_n_flow_elems)
+          elem->subdomain_id() = _fluid_block_id;
+        else
+          elem->subdomain_id() = _solid_block_id;
+      }
     }
   }
 }

--- a/src/mesh/NekRSMesh.C
+++ b/src/mesh/NekRSMesh.C
@@ -41,6 +41,8 @@ NekRSMesh::validParams()
       "order", getNekOrderEnum(), "Order of the mesh interpolation between nekRS and MOOSE");
   params.addRangeCheckedParam<Real>(
       "scaling", 1.0, "scaling > 0.0", "Scaling factor to apply to the mesh");
+  params.addParam<unsigned int>("fluid_block_id", 0, "Subdomain ID to use for the fluid mesh mirror");
+  params.addParam<unsigned int>("solid_block_id", 1, "Subdomain ID to use for the solid mesh mirror");
   params.addClassDescription(
       "Construct a mirror of the NekRS mesh in boundary and/or volume format");
   return params;
@@ -53,6 +55,8 @@ NekRSMesh::NekRSMesh(const InputParameters & parameters)
     _order(getParam<MooseEnum>("order").getEnum<order::NekOrderEnum>()),
     _exact(getParam<bool>("exact")),
     _scaling(getParam<Real>("scaling")),
+    _fluid_block_id(getParam<unsigned int>("fluid_block_id")),
+    _solid_block_id(getParam<unsigned int>("solid_block_id")),
     _n_surface_elems(0),
     _n_volume_elems(0)
 {
@@ -557,6 +561,7 @@ NekRSMesh::buildMesh()
 
   _nek_n_surface_elems = nekrs::mesh::NboundaryFaces();
   _nek_n_volume_elems = nekrs::mesh::Nelements();
+  _nek_n_flow_elems = nekrs::mesh::NflowElements();
 
   // initialize the mesh mapping parameters that depend on order
   initializeMeshParams();
@@ -656,6 +661,11 @@ NekRSMesh::addElems()
           }
         }
       }
+
+      if (e < _nek_n_flow_elems)
+        elem->subdomain_id() = _fluid_block_id;
+      else
+        elem->subdomain_id() = _solid_block_id;
     }
   }
 }


### PR DESCRIPTION
This reverts the recent MOOSE changes that cause unused parameters to error. It also adds another commit that sets up unique block IDs for the solid and fluid regions in NekRS CHT cases.

fyi @anshchaube  once this is merged the unused parameter errors will go away.