### PR TITLE
Add boxCoords function to geometry utility.

### DIFF
--- a/include/utils/GeometryUtility.h
+++ b/include/utils/GeometryUtility.h
@@ -137,4 +137,11 @@ namespace geom_utility {
    */
   bool pointOnEdge(const Point & point, const std::vector<Point> & corners,
     const unsigned int & axis);
+
+  /**
+   * Get corner points of a bounding box, with side length re-scaled
+   * @param[in] box bounding box to start from
+   * @param[in] factor by which to multiply the bounding box side
+   */
+  std::vector<Point> boxCorners(const BoundingBox & box, const Real & factor);
 } // end of namespace geom_utility

--- a/include/utils/GeometryUtility.h
+++ b/include/utils/GeometryUtility.h
@@ -20,6 +20,7 @@
 
 #include "Moose.h"
 #include "libmesh/point.h"
+#include "libmesh/mesh_tools.h"
 
 namespace geom_utility {
   /**

--- a/src/utils/GeometryUtility.C
+++ b/src/utils/GeometryUtility.C
@@ -238,4 +238,27 @@ Point rotatePointAboutAxis(const Point & p, const Real & angle, const Point & ax
   return pt;
 }
 
+std::vector<Point> boxCorners(const BoundingBox & box, const Real & factor)
+{
+  Point diff = (box.max() - box.min()) / 2.0;
+  Point origin = box.min() + diff;
+
+  // Rescale sidelength of box by specified factor
+  diff *= factor;
+
+  // Vectors for sides of box
+  Point dx(2.0 * diff(0), 0.0, 0.0);
+  Point dy(0.0, 2.0 * diff(1), 0.0);
+  Point dz(0.0, 0.0, 2.0 * diff(2));
+
+  std::vector<Point> verts(8, origin - diff);
+  const unsigned int pts_per_dim = 2;
+  for (unsigned int z = 0; z < pts_per_dim; z++)
+    for (unsigned int y = 0; y < pts_per_dim; y++)
+      for (unsigned int x = 0; x < pts_per_dim; x++)
+        verts[pts_per_dim * pts_per_dim * z + pts_per_dim * y + x] += x * dx + y * dy + z * dz;
+
+  return verts;
+}
+
 } // end namespace geom_utility

--- a/unit/src/GeometryUtilityTest.C
+++ b/unit/src/GeometryUtilityTest.C
@@ -264,3 +264,43 @@ TEST_F(GeometryUtilityTest, point_in_polygon)
   EXPECT_FALSE(geom_utility::pointInPolygon(pt_not_in2, {pt8, pt9, pt10, pt11}, 2));
   EXPECT_TRUE(geom_utility::pointInPolygon(pt_edge2, {pt8, pt9, pt10, pt11}, 2));
 }
+
+TEST_F(GeometryUtilityTest, boxCorners)
+{
+  Point min(-1.0, -0.5, 4.0);
+  Point max(3.0, 0.5, 6.0);
+
+  BoundingBox box(min, max);
+  auto c = geom_utility::boxCorners(box, 0.85);
+  EXPECT_DOUBLE_EQ(c[0](0), -0.7);
+  EXPECT_DOUBLE_EQ(c[0](1), -0.425);
+  EXPECT_DOUBLE_EQ(c[0](2), 4.15);
+
+  EXPECT_DOUBLE_EQ(c[1](0), 2.7);
+  EXPECT_DOUBLE_EQ(c[1](1), -0.425);
+  EXPECT_DOUBLE_EQ(c[1](2), 4.15);
+
+  EXPECT_DOUBLE_EQ(c[2](0), -0.7);
+  EXPECT_DOUBLE_EQ(c[2](1), 0.425);
+  EXPECT_DOUBLE_EQ(c[2](2), 4.15);
+
+  EXPECT_DOUBLE_EQ(c[3](0), 2.7);
+  EXPECT_DOUBLE_EQ(c[3](1), 0.425);
+  EXPECT_DOUBLE_EQ(c[3](2), 4.15);
+
+  EXPECT_DOUBLE_EQ(c[4](0), -0.7);
+  EXPECT_DOUBLE_EQ(c[4](1), -0.425);
+  EXPECT_DOUBLE_EQ(c[4](2), 5.85);
+
+  EXPECT_DOUBLE_EQ(c[5](0), 2.7);
+  EXPECT_DOUBLE_EQ(c[5](1), -0.425);
+  EXPECT_DOUBLE_EQ(c[5](2), 5.85);
+
+  EXPECT_DOUBLE_EQ(c[6](0), -0.7);
+  EXPECT_DOUBLE_EQ(c[6](1), 0.425);
+  EXPECT_DOUBLE_EQ(c[6](2), 5.85);
+
+  EXPECT_DOUBLE_EQ(c[7](0), 2.7);
+  EXPECT_DOUBLE_EQ(c[7](1), 0.425);
+  EXPECT_DOUBLE_EQ(c[7](2), 5.85);
+}


### PR DESCRIPTION
Adds a function to get the corner coordinates of a bounding box with an additional length scaling. Supports #535