### PR TITLE
Detecting Convergence of the Fission Source via Shannon Entropy

### DIFF
--- a/doc/content/tutorials/convergence.md
+++ b/doc/content/tutorials/convergence.md
@@ -62,6 +62,7 @@ To determine an appropriate number of inactive batches, you can use the
   of cell divisions to create
 - A Cardinal input file that runs your OpenMC model given some imposed
   temperature and density distribution
+- Criteria used to assess the convergence of the fission source
 
 For example, to run an inactive cycle study for the model developed
 for [the gas compact tutorial](https://cardinal.cels.anl.gov/tutorials/gas_compact.html),
@@ -69,7 +70,7 @@ we would run:
 
 ```
 cd tutorials/gas_compact
-python ../../scripts/inactive_study.py -i unit_cell -input openmc.i
+python ../../scripts/inactive_study.py -i unit_cell -input openmc.i --method=all
 ```
 
 since the Python script used to generate the OpenMC model is named
@@ -82,9 +83,10 @@ of cell layers and number of inactive cycles to consider:
 When the script finishes running, plots of Shannon entropy and $k$, along
 with the saved statepoint files from the simulations, will be available
 in a directory named `inactive_study`. Below are shown example images of
-the Shannon entropy and $k$ plots. You would then select the number of
-inactive cycles to be the point at which both the Shannon entropy and $k$
-reach stationarity.
+the Shannon entropy and $k$ plots. Based on the method of detecting stationarity,
+the script will recommend a minimum number of inactive batches to be used 
+in order to converge the fission source for each layer. Picking the most conservative
+answer will help ensure your simulation is discarding enough batches before tallying.
 
 !media example_entropy_plots.png
   id=entropy

--- a/doc/content/tutorials/convergence.md
+++ b/doc/content/tutorials/convergence.md
@@ -69,7 +69,7 @@ we would run:
 
 ```
 cd tutorials/gas_compact
-python ../../scripts/inactive_study.py -i unit_cell -input openmc.i --method=all
+python ../../scripts/inactive_study.py -i unit_cell -input openmc.i
 ```
 
 since the Python script used to generate the OpenMC model is named
@@ -82,10 +82,16 @@ of cell layers and number of inactive cycles to consider:
 When the script finishes running, plots of Shannon entropy and $k$, along
 with the saved statepoint files from the simulations, will be available
 in a directory named `inactive_study`. Below are shown example images of
-the Shannon entropy and $k$ plots. Based on the method of detecting stationarity,
-the script will recommend a minimum number of inactive batches to be used
-in order to converge the fission source for each layer. Picking the most conservative
-answer will help ensure your simulation is discarding enough batches before tallying.
+the Shannon entropy and $k$ plots. If a method to detect convergence of
+the fission source is supplied (the default is none), then the script will
+report whether the chosen metric succeeded or not. Note, there could be various
+factors affecting whether the metric succeeded or not, and based on user choices,
+it is possible for a metric to succeed when more batches or more particles per
+batch are truly needed. These metrics should be considered along side inspection
+of the plots of the Shannon Entropy, which typically takes longer than the
+eigenvalue to converge. Having a converged fission source is important so that
+when the active batches begin tallying, there is no contamination from the 
+source's initial guess impacting the tallies.
 
 !media example_entropy_plots.png
   id=entropy

--- a/doc/content/tutorials/convergence.md
+++ b/doc/content/tutorials/convergence.md
@@ -5,10 +5,12 @@ In this tutorial, you will learn how to:
 - Use helper scripts in Cardinal to assess convergence of the OpenMC solution
   and of a general MOOSE application
 
-To access this tutorial,
+To access this tutorial, enter the following directory and then also generate
+the necessary mesh file,
 
 ```
 cd cardinal/tutorials/gas_compact
+cardinal-opt -i mesh.i --mesh-only
 ```
 
 !alert! note title=Computing Needs

--- a/doc/content/tutorials/convergence.md
+++ b/doc/content/tutorials/convergence.md
@@ -8,7 +8,7 @@ In this tutorial, you will learn how to:
 To access this tutorial,
 
 ```
-cd cardinal/gas_compact
+cd cardinal/tutorials/gas_compact
 ```
 
 !alert! note title=Computing Needs
@@ -83,7 +83,7 @@ When the script finishes running, plots of Shannon entropy and $k$, along
 with the saved statepoint files from the simulations, will be available
 in a directory named `inactive_study`. Below are shown example images of
 the Shannon entropy and $k$ plots. Based on the method of detecting stationarity,
-the script will recommend a minimum number of inactive batches to be used 
+the script will recommend a minimum number of inactive batches to be used
 in order to converge the fission source for each layer. Picking the most conservative
 answer will help ensure your simulation is discarding enough batches before tallying.
 

--- a/doc/content/tutorials/convergence.md
+++ b/doc/content/tutorials/convergence.md
@@ -62,7 +62,6 @@ To determine an appropriate number of inactive batches, you can use the
   of cell divisions to create
 - A Cardinal input file that runs your OpenMC model given some imposed
   temperature and density distribution
-- Criteria used to assess the convergence of the fission source
 
 For example, to run an inactive cycle study for the model developed
 for [the gas compact tutorial](https://cardinal.cels.anl.gov/tutorials/gas_compact.html),

--- a/scripts/inactive_study.py
+++ b/scripts/inactive_study.py
@@ -20,18 +20,21 @@
 # in order to determine how many inactive cycles are needed to converge both the
 # Shannon entropy and k. This script is run with:
 #
-# python inactive_study.py -i <script_name> -input <file_name> [-n-threads <n_threads>]
+# python inactive_study.py -i <script_name> -input <file_name> --method=method [--winow_lenth=<LENGTH>]  [-n-threads <n_threads>]
 #
-# - the script used to create the OpenMC model is named <script_name>.py;
-#   this script MUST accept '-s' as an argument to add a Shannon entropy mesh
-#   AND '-n' to set the number of layers; please consult the tutorials for
-#   examples if you're unsure of how to do this
-# - the Cardinal input file to run is named <file_name>
-# - by default, the number of threads is taken as the maximum on your system;
-#   otherwise, you can set it by providing -n-threads <n_threads>
+# - The script used to create the OpenMC model is named <script_name>.py.
+#   This script MUST accept '-s' as an argument to add a Shannon entropy mesh
+#   AND '-n' to set the number of layers.
+#   Please consult the tutorials for examples if you're unsure of how to do this.
+# - The Cardinal input file to run is named <file_name>.
+# - By default, the number of threads is taken as the maximum on your system.
+#   Otherwise, you can set it by providing -n-threads <n_threads>.
+# - A detection method must be specified from (all, half, window). If window
+#   is selected, then --window_length must also be specified.
 #
 # This script will create plots named <script_name>_k_<layers>.pdf and
 # <script_name>_entropy_<layers>.pdf in a sub-directory named inactive_study/.
+# It will print reccomendations about the number of inactive batches to use.
 
 # Whether to use saved statepoint files to just generate plots, skipping transport solves
 use_saved_statepoints = False

--- a/scripts/inactive_study.py
+++ b/scripts/inactive_study.py
@@ -219,3 +219,4 @@ if (method != 'none'):
                 extra_str = "--> "
 
             print(extra_str + "Inactive batch: {:6d} Entropy: {:.6f} Window mean: {:.6f} +/- {:.6f}".format(j, entropy[i][j], window_mean, window_dev))
+    print("--> indicates batch which satisfies method. DOES NOT necessarily indicate a converged fission source.")

--- a/scripts/inactive_study.py
+++ b/scripts/inactive_study.py
@@ -29,8 +29,9 @@
 # - The Cardinal input file to run is named <file_name>.
 # - By default, the number of threads is taken as the maximum on your system.
 #   Otherwise, you can set it by providing -n-threads <n_threads>.
-# - A detection method must be specified from (all, half, window). If window
-#   is selected, then --window_length must also be specified. TODO revise
+# - If a detection method is desired it can be specified from all, half, or window.
+#   The default method is none. If the window method is selected, then window_length
+#   must also be specified.
 #
 # This script will create plots named <script_name>_k_<layers>.pdf and
 # <script_name>_entropy_<layers>.pdf in a sub-directory named inactive_study/.
@@ -74,7 +75,7 @@ ap.add_argument('-n-threads', dest='n_threads', type=int,
 ap.add_argument('-input', dest='input_file', type=str, required=True,
                 help='Name of the Cardinal input file to run')
 ap.add_argument('--method', dest = 'method', choices =['all','half','window','none'], default='none',
-                help = 'The method to estimate the number of sufficient inactive batches to discard before tallying in k-eigenvalue mode. ' + 
+                help = 'The method to estimate the number of sufficient inactive batches to discard before tallying in k-eigenvalue mode. ' +
                 'This number is determined by the first batch at which a running average of the Shannon Entropy falls within the standard ' +
                 'deviation of the run. Options are all, half, and window; all uses all batches, half uses the last half of the batches, and ' +
                 'window uses a user-specified number. Additionally, none can be specified if the feature is undesired.')
@@ -203,6 +204,10 @@ if(method != 'none'):
                             "at least this many inactive cycles for this layer.")
                     break
                 else:
+                    if(j == len(entropy[i]) - 1):
+                        print("For layer", nl, ", despite searching over all the batches, no batch"
+                            "produced an entropy value within the window. This can happpen if "
+                            "too few batches are specified. Try again with more batches.") # TODO test this prints in the right place
                     continue
         elif(method == "half"):
             # Brown (2006) "On the Use of Shannon Entropy of the Fission Distribution for Assessing Convergence
@@ -221,6 +226,11 @@ if(method != 'none'):
                             "It is recommended to do at least this many inactive cycles for this layer.")
                     break
                 else:
+                    if(j == len(entropy[i]) -1):
+                        print("For layer", nl, ", despite searching over all the batches, no batch"
+                            "produced an entropy value within one standard deviation of the last "
+                            "half batches This can happpen if too few batches are specified. Try "
+                            "again with more batches.") # TODO test this prints in the right place
                     continue
         else:
             # use all batches as data points for computing mean and standard deviation
@@ -237,4 +247,9 @@ if(method != 'none'):
                             "It is recommended to do at least this many inactive cycles for this layer.")
                     break
                 else:
+                    if(j == len(entropy[i]) -1):
+                        print("For layer", nl, ", despite searching over all the batches, no batch"
+                            "produced an entropy value within one standard deviation of all "
+                            "preceeding batches This can happpen if too few batches are specified."
+                            " Try again with more batches.") # TODO test this prints in the right place
                     continue

--- a/scripts/inactive_study.py
+++ b/scripts/inactive_study.py
@@ -35,7 +35,7 @@
 #
 # This script will create plots named <script_name>_k_<layers>.pdf and
 # <script_name>_entropy_<layers>.pdf in a sub-directory named inactive_study/.
-# It will print reccomendations about the number of inactive batches to use.
+
 
 # Whether to use saved statepoint files to just generate plots, skipping transport solves
 use_saved_statepoints = False
@@ -200,14 +200,13 @@ if(method != 'none'):
                     # if entropy[i][j] is less than window_high and greater than
                     # window_low, then it is within the window and we've succeeded
                     print("For layer", nl, ", batch", j, "produced a value within one "
-                            "standard deviation of the window mean. It is recommended to do "
-                            "at least this many inactive cycles for this layer.")
+                            "standard deviation of the window mean.")
                     break
                 else:
                     if(j == len(entropy[i]) - 1):
                         print("For layer", nl, ", despite searching over all the batches, no batch"
-                            "produced an entropy value within the window. This can happpen if "
-                            "too few batches are specified. Try again with more batches.") # TODO test this prints in the right place
+                            "produced an entropy value within the window. This can happpen if too few" 
+                            "batches or particles per batch are specified.")
                     continue
         elif(method == "half"):
             # Brown (2006) "On the Use of Shannon Entropy of the Fission Distribution for Assessing Convergence
@@ -222,15 +221,14 @@ if(method != 'none'):
                 high = mean + stdev
                 if(high - entropy[i][j] > 0 and entropy[i][j]-low > 0):
                     print("For layer", nl, ", batch", j, "produced a value within one "
-                            "standard deviation of the mean for the last half of entropy values. "
-                            "It is recommended to do at least this many inactive cycles for this layer.")
+                            "standard deviation of the mean for the last half of entropy values.")
                     break
                 else:
                     if(j == len(entropy[i]) -1):
                         print("For layer", nl, ", despite searching over all the batches, no batch"
                             "produced an entropy value within one standard deviation of the last "
-                            "half batches This can happpen if too few batches are specified. Try "
-                            "again with more batches.") # TODO test this prints in the right place
+                            "half batches. This can happpen if too few batches or particles per batch "
+                            "are specified.")
                     continue
         else:
             # use all batches as data points for computing mean and standard deviation
@@ -243,13 +241,12 @@ if(method != 'none'):
                 high = mean + stdev
                 if(high - entropy[i][j] > 0 and entropy[i][j]-low > 0):
                     print("For layer", nl, ", batch", j, "produced a value within one "
-                            "standard deviation of the mean of the last", j ,"entropy values. "
-                            "It is recommended to do at least this many inactive cycles for this layer.")
+                            "standard deviation of the mean of the last", j ,"entropy values.")
                     break
                 else:
                     if(j == len(entropy[i]) -1):
                         print("For layer", nl, ", despite searching over all the batches, no batch"
                             "produced an entropy value within one standard deviation of all "
-                            "preceeding batches This can happpen if too few batches are specified."
-                            " Try again with more batches.") # TODO test this prints in the right place
+                            "preceeding batches. This can happpen if too few batches or particles per batch "
+                            "are specified.")
                     continue


### PR DESCRIPTION
This PR closes #577. It provides the user three options for detecting convergence using Shannon entropy. All methods assess the standard deviation and mean for some set of entropy values. If the current batch's entropy value is within one standard deviation of the mean (of the specified number of batches), it will report this batch number and recommend using at least this many inactive cycles. 

I tested this locally for a case with multiple layers for each detection type, and it went smoothly. If desired, I can provide the example, but I don't think those files need to be pushed. The script is setup to work assuming a user provides the appropriate arguments and input files, so other developers can test that this works locally using their own Cardinal simulation if desired.