### PR TITLE
Get mapping from subdomains to OpenMC materials

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -299,6 +299,15 @@ public:
   static constexpr int32_t UNMAPPED{-1};
 
 protected:
+  /// Loop over the mapped cells, and build a map between subdomains to OpenMC materials
+  void subdomainsToMaterials();
+
+  /**
+   * Get a set of all subdomains that have at least 1 element coupled to an OpenMC cell
+   * @return subdomains with at least 1 element coupled to OpenMC
+   */
+  std::set<SubdomainID> coupledSubdomains();
+
   /**
    * Gather a vector of values to be summed for each cell
    * @param[in] local local values to be summed for the cells
@@ -910,6 +919,9 @@ protected:
   /// Mapping of OpenMC cell indices to the subdomain IDs each maps to
   std::map<cellInfo, std::unordered_set<SubdomainID>> _cell_to_elem_subdomain;
 
+  /// Mapping of elem subdomains to materials
+  std::map<SubdomainID, std::unordered_set<int32_t>> _subdomain_to_material;
+
   /**
    * A point inside the cell, taken simply as the centroid of the first global
    * element inside the cell. This is stored to accelerate the particle search.
@@ -925,7 +937,11 @@ protected:
    */
   std::map<cellInfo, Real> _cell_to_elem_volume;
 
-  /// Material filling each cell
+  /**
+   * Material filling each cell to receive density & temperature feedback. We enforce
+   * that these "fluid" cells are filled with a material (cannot be filled with a lattice
+   * or universe).
+   */
   std::map<cellInfo, int32_t> _cell_to_material;
 
   /// Material-type cells contained within a cell

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -86,6 +86,14 @@ public:
   typedef std::pair<int32_t, int32_t> cellInfo;
 
   /**
+   * Get the material name given its index. If the material does not have a name,
+   * return the ID.
+   * @param[in] index
+   * @return material name
+   */
+  std::string materialName(const int32_t index) const;
+
+  /**
    * Compute relative error
    * @param[in] sum sum of scores
    * @param[in] sum_sq sum of scores squared
@@ -199,6 +207,14 @@ public:
    * @return indices of what is filling the cell
    */
   virtual std::vector<int32_t> cellFill(const cellInfo & cell_info, int & fill_type) const;
+
+  /**
+   * Whether the cell has a material fill (if so, then get the material index)
+   * @param[in] cell_info cell ID, instance
+   * @param[out] material_index material index in the cell
+   * @return whether the cell is filled by a material
+   */
+  bool materialFill(const cellInfo & cell_info, int32_t & material_index) const;
 
   /**
    * Whether a cell contains any fissile materials; for now, this simply returns true for

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -196,7 +196,7 @@ public:
    * Get the fill of an OpenMC cell
    * @param[in] cell_info cell ID, instance
    * @param[out] fill_type fill type of the cell, one of MATERIAL, UNIVERSE, or LATTICE
-   * @return indices of material fills
+   * @return indices of what is filling the cell
    */
   virtual std::vector<int32_t> cellFill(const cellInfo & cell_info, int & fill_type) const;
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1123,6 +1123,10 @@ OpenMCCellAverageProblem::getMaterialFills()
     int fill_type;
     std::vector<int32_t> material_indices = cellFill(cell_info, fill_type);
 
+    if (fill_type != static_cast<int>(openmc::Fill::MATERIAL))
+      mooseError(
+          "Density transfer does not currently support cells filled with universes or lattices!");
+
     // OpenMC checks that for distributed cells, the number of materials either equals 1
     // or the number of distributed cells; therefore, we just need to index based on the cell
     // instance (zero for not-distributed cells, otherwise matches the material index)

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1180,8 +1180,8 @@ OpenMCCellAverageProblem::getMaterialFills()
     int32_t material_index;
     auto is_material_cell = materialFill(cell_info, material_index);
 
-    if (!is_material_cell) // TODO: get here?
-      mooseError("Cannot get material fills of a non-material cell!");
+    if (!is_material_cell)
+      mooseError("Density transfer does not currently support cells filled with universes or lattices!");
 
     _cell_to_material[cell_info] = material_index;
     vt.addRow(printCell(cell_info), materialID(material_index));

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -187,6 +187,25 @@ OpenMCProblemBase::nParticles() const
   return openmc::settings::n_particles;
 }
 
+std::string
+OpenMCProblemBase::materialName(const int32_t index) const
+{
+  const char * name;
+  int err = openmc_material_get_name(index, &name);
+
+  if (err)
+    mooseError("In attempting to get material name for material with index " +
+      Moose::stringify(index) + ", OpenMC reported:\n\n" + std::string(openmc_err_msg));
+
+  std::string n = name;
+
+  // if the material does not have a name, just return the ID instead
+  if (n.empty())
+    n = std::to_string(materialID(index));
+
+  return n;
+}
+
 int32_t
 OpenMCProblemBase::cellID(const int32_t index) const
 {
@@ -326,7 +345,6 @@ OpenMCProblemBase::setCellTemperature(const int32_t & id, const int32_t & instan
 std::vector<int32_t>
 OpenMCProblemBase::cellFill(const cellInfo & cell_info, int & fill_type) const
 {
-  fill_type = static_cast<int>(openmc::Fill::MATERIAL);
   int32_t * materials = nullptr;
   int n_materials = 0;
 
@@ -341,6 +359,25 @@ OpenMCProblemBase::cellFill(const cellInfo & cell_info, int & fill_type) const
   return material_indices;
 }
 
+bool
+OpenMCProblemBase::materialFill(const cellInfo & cell_info, int32_t & material_index) const
+{
+  int fill_type;
+  auto material_indices = cellFill(cell_info, fill_type);
+
+  if (fill_type != static_cast<int>(openmc::Fill::MATERIAL))
+    return false;
+
+  // The number of materials in a cell is either 1, or equal to the number of instances
+  // (if distributed materials were used).
+  if (material_indices.size() == 1)
+    material_index = material_indices[0];
+  else
+    material_index = material_indices[cell_info.second];
+
+  return true;
+}
+
 void
 OpenMCProblemBase::setCellDensity(const Real & density, const cellInfo & cell_info) const
 {
@@ -352,12 +389,15 @@ OpenMCProblemBase::setCellDensity(const Real & density, const cellInfo & cell_in
     mooseError("Densities less than or equal to zero cannot be set in the OpenMC model!\n cell " +
                printCell(cell_info) + " set to density " + Moose::stringify(density) + " (kg/m3)");
 
-  int fill_type;
-  std::vector<int32_t> material_indices = cellFill(cell_info, fill_type);
+  int32_t material_index;
+  auto is_material_cell = materialFill(cell_info, material_index);
+
+  if (!is_material_cell)
+    mooseError("Density transfer does not currently support cells filled with universes or lattices!");
 
   // throw a special error if the cell is void, because the OpenMC error isn't very
   // clear what the mistake is
-  if (material_indices[0] == MATERIAL_VOID)
+  if (material_index == MATERIAL_VOID)
     mooseError("Cannot set density for cell " + printCell(cell_info) +
                " because this cell is void (vacuum)!");
 
@@ -365,11 +405,11 @@ OpenMCProblemBase::setCellDensity(const Real & density, const cellInfo & cell_in
   // auxvariable as well as the MOOSE fluid properties module) to g/cm3
   const char * units = "g/cc";
   int err = openmc_material_set_density(
-      material_indices[cell_info.second], density * _density_conversion_factor, units);
+      material_index, density * _density_conversion_factor, units);
 
   if (err)
     mooseError("In attempting to set material with index " +
-               Moose::stringify(material_indices[cell_info.second]) + " to density " +
+               Moose::stringify(material_index) + " to density " +
                Moose::stringify(density) + " (kg/m3), OpenMC reported:\n\n" +
                std::string(openmc_err_msg));
 }
@@ -403,25 +443,21 @@ OpenMCProblemBase::importProperties() const
 bool
 OpenMCProblemBase::cellHasFissileMaterials(const cellInfo & cell_info) const
 {
-  int fill_type;
-  std::vector<int32_t> material_indices = cellFill(cell_info, fill_type);
+  int32_t material_index;
+  auto is_material_cell = materialFill(cell_info, material_index);
 
   // TODO: for cells with non-material fills, we need to implement something that recurses
   // into the cell/universe fills to see if there's anything fissile; until then, just assume
   // that the cell has something fissile
-  if (fill_type != static_cast<int>(openmc::Fill::MATERIAL))
+  if (!is_material_cell)
     return true;
 
-  // for each material fill, check whether it is fissionable
-  for (const auto & index : material_indices)
+  // We know void cells certainly aren't fissionable; if not void, check if fissionable
+  if (material_index != MATERIAL_VOID)
   {
-    // We know void cells certainly aren't fissionable; if not void, check if fissionable
-    if (index != MATERIAL_VOID)
-    {
-      const auto & material = openmc::model::materials[index];
-      if (material->fissionable_)
-        return true;
-    }
+    const auto & material = openmc::model::materials[material_index];
+    if (material->fissionable_)
+      return true;
   }
 
   return false;

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -190,6 +190,11 @@ OpenMCProblemBase::nParticles() const
 std::string
 OpenMCProblemBase::materialName(const int32_t index) const
 {
+  // OpenMC uses -1 to indicate void materials, which don't have a name. So we return
+  // one ourselves, or else openmc_material_get_name will throw an error.
+  if (index == -1)
+    return "VOID";
+
   const char * name;
   int err = openmc_material_get_name(index, &name);
 

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -361,10 +361,6 @@ OpenMCProblemBase::setCellDensity(const Real & density, const cellInfo & cell_in
     mooseError("Cannot set density for cell " + printCell(cell_info) +
                " because this cell is void (vacuum)!");
 
-  if (fill_type != static_cast<int>(openmc::Fill::MATERIAL))
-    mooseError(
-        "Density transfer does not currently support cells filled with universes or lattices!");
-
   // Multiply density by 0.001 to convert from kg/m3 (the units assumed in the 'density'
   // auxvariable as well as the MOOSE fluid properties module) to g/cm3
   const char * units = "g/cc";

--- a/test/tests/neutronics/feedback/lattice/non_material_fluid.i
+++ b/test/tests/neutronics/feedback/lattice/non_material_fluid.i
@@ -1,0 +1,33 @@
+[Mesh]
+  type = FileMesh
+  file = ../../meshes/pincell.e
+[]
+
+[ICs]
+  [density]
+    type = ConstantIC
+    variable = density
+    value = 1000.0
+  []
+  [temp]
+    type = ConstantIC
+    variable = temp
+    value = 1000.0
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 500.0
+  fluid_blocks = '2'
+  tally_type = mesh
+  fluid_cell_level = 0
+[]
+
+[Executioner]
+  type = Transient
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/neutronics/feedback/lattice/non_material_fluid.i
+++ b/test/tests/neutronics/feedback/lattice/non_material_fluid.i
@@ -1,6 +1,7 @@
 [Mesh]
   type = FileMesh
   file = ../../meshes/pincell.e
+  allow_renumbering = false
 []
 
 [ICs]

--- a/test/tests/neutronics/feedback/lattice/tests
+++ b/test/tests/neutronics/feedback/lattice/tests
@@ -65,4 +65,11 @@
     requirement = "The system shall error if the user adds a duplicate variable with a name Cardinal reserves for OpenMC coupling."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [nonmaterial_fluid]
+    type = RunException
+    input = non_material_fluid.i
+    expect_err = "Density transfer does not currently support cells filled with universes or lattices!"
+    requirement = "The system shall error if trying to set density in a cell filled by a universe or lattice."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
 []

--- a/test/tests/openmc_errors/cell_instances/insufficient_materials/tests
+++ b/test/tests/openmc_errors/cell_instances/insufficient_materials/tests
@@ -2,7 +2,7 @@
   [insufficient_materials]
     type = RunException
     input = fluid.i
-    expect_err = "material 1 is present in more than one fluid cell.\n"
+    expect_err = "material 2 is present in more than one fluid cell.\n"
                  "This means that your model cannot independently change the density in cells filled with this material."
     requirement = "The system shall error if we attempt to set a density in a material that is repeated "
                   "throughout our list of fluid cells."


### PR DESCRIPTION
This adds a table print to show which subdomains map to which OpenMC materials. For a subdomain A, this will display to the user the set of OpenMC materials that the elements in the subdomain map to; the purpose is to help clarify model setup for the user, as well as add infrastructure for later DAGMC models where we're going to impose that each subdomain should map to only 1 OpenMC material (this can be a sanity check on model setup).