### PR TITLE
Fix error catching when user needs either level or lowest

### DIFF
--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -2614,7 +2614,8 @@ OpenMCCellAverageProblem::checkTallySum(const unsigned int & score) const
     std::stringstream msg;
     msg << _tally_score[score] << " tallies do not match the global " << _tally_score[score] << " tally:\n"
         << " Global value: " << Moose::stringify(_global_sum_tally[score])
-        << "\n Tally sum: " << Moose::stringify(_local_sum_tally[score])
+        << "\n Tally sum:    " << Moose::stringify(_local_sum_tally[score])
+        << "\n Difference:   " << _global_sum_tally[score] - _local_sum_tally[score]
         << "\n\nYou can turn off this check by setting 'check_tally_sum' to false.\n"
            "Or, if you're using mesh tallies that don't perfectly align with cell boundaries,\n"
            "you could be missing a small portion of the tally scores. To normalize by the total\n"

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -764,7 +764,7 @@ OpenMCCellAverageProblem::getCellLevel(const std::string name, unsigned int & ce
     bool using_single_level = isParamValid(param_name);
     bool using_lowest_level = isParamValid(lowest_param_name);
 
-    if (using_single_level && using_lowest_level)
+    if (using_single_level == using_lowest_level)
       paramError(param_name,
                  "When specifying " + name + " blocks for coupling, either '" + param_name +
                      "' or '" + lowest_param_name +


### PR DESCRIPTION
This PR fixes error code which previously would not throw an error if the user forgot to specify the cell level.