### PR TITLE
Refactoring to simplify OpenMCCellAverageProblem

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -23,8 +23,6 @@
 #include "openmc/tallies/filter_cell_instance.h"
 #include "openmc/tallies/filter_mesh.h"
 #include "openmc/mesh.h"
-#include "openmc/tallies/tally.h"
-#include "CardinalEnums.h"
 #include "SymmetryPointGenerator.h"
 
 /**

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -19,8 +19,6 @@
 #pragma once
 
 #include "OpenMCProblemBase.h"
-#include "openmc/tallies/filter_cell.h"
-#include "openmc/tallies/filter_cell_instance.h"
 #include "openmc/tallies/filter_mesh.h"
 #include "openmc/mesh.h"
 #include "SymmetryPointGenerator.h"
@@ -170,12 +168,6 @@ public:
    */
   void getTally(const unsigned int & var_num, const std::vector<xt::xtensor<double, 1>> & tally,
     const unsigned int & score, const bool & print_table);
-
-  /**
-   * Get the cell instance filter for tallies automatically constructed by Cardinal
-   * @return cell instance filter
-   */
-  openmc::Filter * cellInstanceFilter();
 
   /**
    * Get the mesh filter(s) for tallies automatically constructed by Cardinal.
@@ -720,9 +712,6 @@ protected:
    */
   const Real & _scaling;
 
-  /// OpenMC run mode
-  const openmc::RunMode _run_mode;
-
   /**
    * How to normalize the OpenMC tally into units of W/volume. If 'true',
    * normalization is performed by dividing each local tally against a problem-global
@@ -1026,9 +1015,6 @@ protected:
 
   /// Spatial dimension of the Monte Carlo problem
   static constexpr int DIMENSION{3};
-
-  /// Total number of particles simulated
-  unsigned int _total_n_particles;
 
   /// Number of particles simulated in the first iteration
   unsigned int _n_particles_1;

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -22,6 +22,7 @@
 
 #include "ExternalProblem.h"
 #include "PostprocessorInterface.h"
+#include "CardinalEnums.h"
 #include "openmc/tallies/tally.h"
 
 /**
@@ -35,6 +36,20 @@ public:
   static InputParameters validParams();
 
   virtual ~OpenMCProblemBase() override;
+
+  /**
+   * Convert from a MooseEnum for a trigger metric to an OpenMC enum
+   * @param[in] trigger trigger metric
+   * @return OpenMC enum
+   */
+  openmc::TriggerMetric triggerMetric(tally::TallyTriggerTypeEnum trigger) const;
+
+  /**
+   * Convert from a MooseEnum for tally estimator to an OpenMC enum
+   * @param[in] estimator MOOSE estimator enum
+   * @return OpenMC enum
+   */
+  openmc::TallyEstimator tallyEstimator(tally::TallyEstimatorEnum estimator) const;
 
   /**
    * Check whether the user has already created a variable using one of the protected

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -23,6 +23,8 @@
 #include "ExternalProblem.h"
 #include "PostprocessorInterface.h"
 #include "CardinalEnums.h"
+
+#include "openmc/tallies/filter_cell_instance.h"
 #include "openmc/tallies/tally.h"
 
 /**
@@ -36,6 +38,9 @@ public:
   static InputParameters validParams();
 
   virtual ~OpenMCProblemBase() override;
+
+  /// Whether this is the first time OpenMC is running
+  bool firstSolve() const;
 
   /**
    * Convert from a MooseEnum for a trigger metric to an OpenMC enum
@@ -99,6 +104,13 @@ public:
    * value is the cell index, while the second is the cell instance.
    */
   typedef std::pair<int32_t, int32_t> cellInfo;
+
+  /**
+   * Get the cell instance filter corresponding to provided cells
+   * @param[in] tally_cells cells to add to the filter
+   * @return cell instance filter
+   */
+  openmc::Filter * cellInstanceFilter(const std::vector<cellInfo> & tally_cells) const;
 
   /**
    * Get the material name given its index. If the material does not have a name,
@@ -242,6 +254,16 @@ public:
 
 protected:
   /**
+   * Add tally
+   * @param[in] score score type
+   * @param[in] filters tally filters
+   * @param[in] estimator estimator
+   * @return tally, which has been added to OpenMC, but may want to still be queried from Cardinal
+   */
+  openmc::Tally * addTally(const std::vector<std::string> & score,
+    std::vector<openmc::Filter *> & filters, const openmc::TallyEstimator & estimator);
+
+  /**
    * Set an auxiliary elemental variable to a specified value
    * @param[in] var_num variable number
    * @param[in] elem_ids element IDs to set
@@ -305,6 +327,12 @@ protected:
    * total number of cells.
    */
   const int _n_cell_digits;
+
+  /// OpenMC run mode
+  const openmc::RunMode _run_mode;
+
+  /// Total number of particles simulated
+  unsigned int _total_n_particles;
 
   /// Mapping from local element indices to global element indices for this rank
   std::vector<unsigned int> _local_to_global_elem;

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -64,7 +64,7 @@ OpenMCCellAverageProblem::validParams()
       "Subdomain ID(s) for which to add tallies in the OpenMC model; "
       "only used with cell tallies");
   params.addParam<bool>("check_tally_sum",
-                        "Whether to check consistency between the cell-wise tallies "
+                        "Whether to check consistency between the local tallies "
                         "with a global tally");
   params.addParam<bool>(
       "check_zero_tallies",
@@ -72,12 +72,6 @@ OpenMCCellAverageProblem::validParams()
       "Whether to throw an error if any tallies from OpenMC evaluate to zero; "
       "this can be helpful in reducing the number of tallies if you inadvertently add tallies "
       "to a non-fissile region, or for catching geomtery setup errors");
-  params.addParam<bool>(
-      "skip_first_incoming_transfer",
-      false,
-      "Whether to skip the very first density and temperature transfer into OpenMC; "
-      "this can be used to allow whatever initial condition is set in OpenMC's XML "
-      "files to be used in OpenMC's run the first time OpenMC is run");
   params.addParam<MooseEnum>(
       "initial_properties",
       getInitialPropertiesEnum(),
@@ -364,10 +358,6 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     paramError("assume_separate_tallies",
                "Cannot assume separate tallies when either of 'check_tally_sum' or"
                "'normalize_by_global_tally' is true!");
-
-  if (params.isParamSetByUser("skip_first_incoming_transfer"))
-    mooseError("The 'skip_first_incoming_transfer' parameter is deprecated and has been replaced "
-               "by the 'initial_properties' parameter!");
 
   // determine the number of particles set either through XML or the wrapping
   if (_relaxation == relaxation::dufek_gudowski)

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -529,4 +529,38 @@ OpenMCProblemBase::checkDuplicateVariableName(const std::string & name) const
       "for the nonlinear variable you are adding.");
 }
 
+openmc::TallyEstimator
+OpenMCProblemBase::tallyEstimator(tally::TallyEstimatorEnum estimator) const
+{
+  switch (estimator)
+  {
+    case tally::tracklength:
+      return openmc::TallyEstimator::TRACKLENGTH;
+    case tally::collision:
+      return openmc::TallyEstimator::COLLISION;
+    case tally::analog:
+      return openmc::TallyEstimator::ANALOG;
+    default:
+      mooseError("Unhandled TallyEstimatorEnum!");
+  }
+}
+
+openmc::TriggerMetric
+OpenMCProblemBase::triggerMetric(tally::TallyTriggerTypeEnum trigger) const
+{
+  switch (trigger)
+  {
+    case tally::variance:
+      return openmc::TriggerMetric::variance;
+    case tally::std_dev:
+      return openmc::TriggerMetric::standard_deviation;
+    case tally::rel_err:
+      return openmc::TriggerMetric::relative_error;
+    case tally::none:
+      return openmc::TriggerMetric::not_active;
+    default:
+      mooseError("Unhandled TallyTriggerTypeEnum!");
+  }
+}
+
 #endif

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -78,7 +78,9 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
     _single_coord_level(openmc::model::n_coord_levels == 1),
     _fixed_point_iteration(-1),
     _path_output(openmc::settings::path_output),
-    _n_cell_digits(std::to_string(openmc::model::cells.size()).length())
+    _n_cell_digits(std::to_string(openmc::model::cells.size()).length()),
+    _run_mode(openmc::settings::run_mode),
+    _total_n_particles(0)
 {
   if (openmc::settings::run_mode == openmc::RunMode::FIXED_SOURCE)
   {
@@ -258,16 +260,20 @@ OpenMCProblemBase::printPoint(const Point & p) const
   return msg.str();
 }
 
+bool
+OpenMCProblemBase::firstSolve() const
+{
+  return _fixed_point_iteration < 0;
+}
+
 void
 OpenMCProblemBase::externalSolve()
 {
   TIME_SECTION("solveOpenMC", 1, "Solving OpenMC", false);
   _console << " Running OpenMC with " << nParticles() << " particles per batch..." << std::endl;
 
-  bool first_iteration = _fixed_point_iteration < 0;
-
   // apply a new starting fission source
-  if (_reuse_source && !first_iteration)
+  if (_reuse_source && !firstSolve())
   {
     openmc::free_memory_source();
     openmc::model::external_sources.push_back(
@@ -277,6 +283,8 @@ OpenMCProblemBase::externalSolve()
   int err = openmc_run();
   if (err)
     mooseError(openmc_err_msg);
+
+  _total_n_particles += nParticles();
 
   err = openmc_reset_timers();
   if (err)
@@ -561,6 +569,32 @@ OpenMCProblemBase::triggerMetric(tally::TallyTriggerTypeEnum trigger) const
     default:
       mooseError("Unhandled TallyTriggerTypeEnum!");
   }
+}
+
+openmc::Filter *
+OpenMCProblemBase::cellInstanceFilter(const std::vector<cellInfo> & tally_cells) const
+{
+  auto cell_filter =
+      dynamic_cast<openmc::CellInstanceFilter *>(openmc::Filter::create("cellinstance"));
+
+  std::vector<openmc::CellInstance> cells;
+  for (const auto & c : tally_cells)
+    cells.push_back(
+        {gsl::narrow_cast<gsl::index>(c.first), gsl::narrow_cast<gsl::index>(c.second)});
+
+  cell_filter->set_cell_instances(cells);
+  return cell_filter;
+}
+
+openmc::Tally *
+OpenMCProblemBase::addTally(const std::vector<std::string> & score,
+  std::vector<openmc::Filter *> & filters, const openmc::TallyEstimator & estimator)
+{
+  auto tally = openmc::Tally::create();
+  tally->set_scores(score);
+  tally->estimator_ = estimator;
+  tally->set_filters(filters);
+  return tally;
 }
 
 #endif


### PR DESCRIPTION
To help integrate DAGMC into our cell-coupling, this moves some functionality from `OpenMCCellAverageProblem` up to the base class.