### PR TITLE
Better warnings for single-level geometries

### DIFF
--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -106,6 +106,13 @@ public:
   typedef std::pair<int32_t, int32_t> cellInfo;
 
   /**
+   * Whether a cell is filled with VOID (vacuum)
+   * @param[in] cell_info cell ID, instance
+   * @return whether cell is void
+   */
+  bool cellIsVoid(const cellInfo & cell_info) const;
+
+  /**
    * Get the cell instance filter corresponding to provided cells
    * @param[in] tally_cells cells to add to the filter
    * @return cell instance filter
@@ -149,7 +156,7 @@ public:
   int32_t cellID(const int32_t index) const;
 
   /**
-   * Get the material ID from the material index
+   * Get the material ID from the material index; for VOID cells, this returns -1
    * @param[in] index material index
    * @return cell material ID
    */
@@ -236,7 +243,8 @@ public:
   virtual std::vector<int32_t> cellFill(const cellInfo & cell_info, int & fill_type) const;
 
   /**
-   * Whether the cell has a material fill (if so, then get the material index)
+   * Whether the cell has a material fill (if so, then get the material index). Void counts
+   * as a material, with a material index of -1.
    * @param[in] cell_info cell ID, instance
    * @param[out] material_index material index in the cell
    * @return whether the cell is filled by a material

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -39,6 +39,13 @@ public:
 
   virtual ~OpenMCProblemBase() override;
 
+  /**
+   * Print a full error message when catching errors from OpenMC
+   * @param[in] err OpenMC error code
+   * @param[in] descriptor descriptive message for error
+   */
+  void catchOpenMCError(const int & err, const std::string descriptor) const;
+
   /// Whether this is the first time OpenMC is running
   bool firstSolve() const;
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -566,10 +566,7 @@ OpenMCCellAverageProblem::getTallyTriggerParameters(const InputParameters & para
     int err = openmc_set_n_batches(getParam<unsigned int>("max_batches"),
                                    true /* set the max batches */,
                                    true /* add the last batch for statepoint writing */);
-
-    if (err)
-      mooseError("In attempting to set the maximum number of batches, OpenMC reported:\n\n" +
-                 std::string(openmc_err_msg));
+    catchOpenMCError(err, "set the maximum number of batches");
 
     openmc::settings::trigger_batch_interval = getParam<unsigned int>("batch_interval");
   }
@@ -2695,11 +2692,7 @@ OpenMCCellAverageProblem::cellTemperature(const cellInfo & cell_info)
 
   double T;
   int err = openmc_cell_get_temperature(material_cell.first, &material_cell.second, &T);
-
-  if (err)
-    mooseError("In attempting to get temperature of cell " + printCell(cell_info) +
-               ", OpenMC reported:\n\n" + std::string(openmc_err_msg));
-
+  catchOpenMCError(err, "get temperature of cell " + printCell(cell_info));
   return T;
 }
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1281,10 +1281,9 @@ OpenMCCellAverageProblem::initializeElementToCellMapping()
     int n_missing = 0;
     for (const auto & c : openmc::model::cells)
     {
-      if (c->n_instances_ > 1)
-        mooseError("Internal error: assumption that a single-level OpenMC model does not have "
-          "distributed cells was broken");
-
+      // for a single-level geometry, we know that all cells will have just 1 instance,
+      // because distributed cells are inherently tied to being repeated (which is not
+      // possible with a single universe)
       cellInfo cell {openmc::model::cell_map[c->id_], 0 /* instance */};
       if (!cellIsVoid(cell) && !_cell_to_elem.count(cell))
       {

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1273,12 +1273,44 @@ OpenMCCellAverageProblem::initializeElementToCellMapping()
 
   // If there is a single coordinate level, we can print a helpful message if there are uncoupled
   // cells in the domain
-  if (_single_coord_level)
+  auto n_uncoupled_cells = _n_openmc_cells - _cell_to_elem.size();
+  if (_single_coord_level && n_uncoupled_cells)
   {
-    auto n_uncoupled_cells = _n_openmc_cells - _cell_to_elem.size();
-    if (n_uncoupled_cells)
-      mooseWarning("Skipping multiphysics feedback for " + Moose::stringify(n_uncoupled_cells) +
-                   " OpenMC cells!");
+    // Get the number of uncoupled material cells (which we presumably want to include in our
+    // coupling). We don't care about VOID cells, because they will never have feedback.
+    VariadicTable<std::string, std::string> vt({"Cell", "Contained OpenMC Materials"});
+
+    std::vector<cellInfo> missing_cells;
+    int n_missing = 0;
+    for (const auto & c : openmc::model::cells)
+    {
+      if (c->n_instances_ > 1)
+        mooseError("Internal error: assumption that a single-level OpenMC model does not have "
+          "distributed cells was broken");
+
+      cellInfo cell {openmc::model::cell_map[c->id_], 0 /* instance */};
+      if (!cellIsVoid(cell) && !_cell_to_elem.count(cell))
+      {
+        n_missing++;
+
+        int32_t material_index;
+        materialFill(cell, material_index);
+        vt.addRow(printCell(cell), materialName(material_index));
+      }
+    }
+
+    if (n_missing)
+    {
+      std::stringstream msg;
+      msg << "Skipping multiphysics feedback for " << n_missing <<
+             " OpenMC cells!\n\nThis means that there are " << n_missing <<
+             " non-void cells in your OpenMC model that will not receive feedback\n"
+             "from MOOSE. This is normal if you are intentionally excluding some cells from feedback. The\n"
+             "unmapped cells are:\n\n";
+
+      vt.print(msg);
+      mooseWarning(msg.str());
+    }
   }
 
   // Check that each cell maps to a single phase

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -130,10 +130,7 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
     int err = openmc_set_n_batches(getParam<unsigned int>("batches"),
                                    true /* set the max batches */,
                                    true /* add the last batch for statepoint writing */);
-
-    if (err)
-      mooseError("In attempting to set the number of batches, OpenMC reported:\n\n" +
-                 std::string(openmc_err_msg));
+    catchOpenMCError(err, "set the number of batches");
 
     // if we set the batches from Cardinal, remove whatever statepoint file was
     // created for the #batches set in the XML files; this is just to reduce the
@@ -161,6 +158,14 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
 }
 
 OpenMCProblemBase::~OpenMCProblemBase() { openmc_finalize(); }
+
+void
+OpenMCProblemBase::catchOpenMCError(const int & err, const std::string descriptor) const
+{
+  if (err)
+    mooseError("In attempting to ", descriptor, ", OpenMC reported:\n\n",
+      std::string(openmc_err_msg));
+}
 
 void
 OpenMCProblemBase::fillElementalAuxVariable(const unsigned int & var_num,
@@ -199,10 +204,7 @@ OpenMCProblemBase::materialName(const int32_t index) const
 
   const char * name;
   int err = openmc_material_get_name(index, &name);
-
-  if (err)
-    mooseError("In attempting to get material name for material with index " +
-      Moose::stringify(index) + ", OpenMC reported:\n\n" + std::string(openmc_err_msg));
+  catchOpenMCError(err, "get material name for material with index " + index);
 
   std::string n = name;
 
@@ -218,11 +220,7 @@ OpenMCProblemBase::cellID(const int32_t index) const
 {
   int32_t id;
   int err = openmc_cell_get_id(index, &id);
-
-  if (err)
-    mooseError("In attempting to get ID for cell with index " + Moose::stringify(index) +
-               " , OpenMC reported:\n\n" + std::string(openmc_err_msg));
-
+  catchOpenMCError(err, "get ID for cell with index " + index);
   return id;
 }
 
@@ -234,11 +232,7 @@ OpenMCProblemBase::materialID(const int32_t index) const
 
   int32_t id;
   int err = openmc_material_get_id(index, &id);
-
-  if (err)
-    mooseError("In attempting to get ID for material with index ", Moose::stringify(index),
-               ", OpenMC reported:\n\n", std::string(openmc_err_msg));
-
+  catchOpenMCError(err, "get ID for material with index " + index);
   return id;
 }
 
@@ -348,11 +342,7 @@ OpenMCProblemBase::setCellTemperature(const int32_t & id, const int32_t & instan
   const cellInfo & cell_info) const
 {
   int err = openmc_cell_set_temperature(id, T, &instance, false);
-
-  if (err)
-    mooseError("In attempting to set cell " + printCell(cell_info) + " to temperature " +
-               Moose::stringify(T) + " (K), OpenMC reported:\n\n" +
-               std::string(openmc_err_msg));
+  catchOpenMCError(err, "set cell " + printCell(cell_info) + " to temperature " + Moose::stringify(T) + " (K)");
 }
 
 std::vector<int32_t>
@@ -362,10 +352,7 @@ OpenMCProblemBase::cellFill(const cellInfo & cell_info, int & fill_type) const
   int n_materials = 0;
 
   int err = openmc_cell_get_fill(cell_info.first, &fill_type, &materials, &n_materials);
-
-  if (err)
-    mooseError("In attempting to get fill of cell " + printCell(cell_info) +
-               ", OpenMC reported:\n\n" + std::string(openmc_err_msg));
+  catchOpenMCError(err, "get fill of cell " + printCell(cell_info));
 
   std::vector<int32_t> material_indices;
   material_indices.assign(materials, materials + n_materials);
@@ -420,11 +407,9 @@ OpenMCProblemBase::setCellDensity(const Real & density, const cellInfo & cell_in
   int err = openmc_material_set_density(
       material_index, density * _density_conversion_factor, units);
 
-  if (err)
-    mooseError("In attempting to set material with index " +
+  catchOpenMCError(err, "set material with index " +
                Moose::stringify(material_index) + " to density " +
-               Moose::stringify(density) + " (kg/m3), OpenMC reported:\n\n" +
-               std::string(openmc_err_msg));
+               Moose::stringify(density) + " (kg/m3)");
 }
 
 std::string
@@ -447,10 +432,7 @@ OpenMCProblemBase::importProperties() const
   _console << "Reading temperature and density from properties.h5" << std::endl;
 
   int err = openmc_properties_import("properties.h5");
-  if (err)
-    mooseError("In attempting to load temperature and density from a properties.h5 file, "
-               "OpenMC reported:\n\n" +
-               std::string(openmc_err_msg));
+  catchOpenMCError(err, "load temperature and density from a properties.h5 file");
 }
 
 bool

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -229,15 +229,15 @@ OpenMCProblemBase::cellID(const int32_t index) const
 int32_t
 OpenMCProblemBase::materialID(const int32_t index) const
 {
+  if (index == openmc::MATERIAL_VOID)
+    return -1;
+
   int32_t id;
   int err = openmc_material_get_id(index, &id);
 
   if (err)
-  {
-    std::stringstream msg;
-    msg << "In attempting to get ID for material with index " + Moose::stringify(index) +
-               ", OpenMC reported:\n\n" + std::string(openmc_err_msg);
-  }
+    mooseError("In attempting to get ID for material with index ", Moose::stringify(index),
+               ", OpenMC reported:\n\n", std::string(openmc_err_msg));
 
   return id;
 }
@@ -595,6 +595,16 @@ OpenMCProblemBase::addTally(const std::vector<std::string> & score,
   tally->estimator_ = estimator;
   tally->set_filters(filters);
   return tally;
+}
+
+bool
+OpenMCProblemBase::cellIsVoid(const cellInfo & cell_info) const
+{
+  // material_index will be unchanged if the cell is filled by a universe or lattice.
+  // Otherwise, this will get set to the material index in the cell.
+  int32_t material_index = 0;
+  materialFill(cell_info, material_index);
+  return material_index == MATERIAL_VOID;
 }
 
 #endif

--- a/test/tests/neutronics/void/geometry.xml
+++ b/test/tests/neutronics/void/geometry.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='utf-8'?>
+<geometry>
+  <cell id="1" material="void" region="-1" universe="1" />
+  <cell id="2" material="1" region="-2" universe="1" />
+  <cell id="3" material="1" region="-3" universe="1" />
+  <surface boundary="vacuum" coeffs="0.0 0.0 0.0 1.5" id="1" type="sphere" />
+  <surface boundary="vacuum" coeffs="0.0 0.0 4.0 1.5" id="2" type="sphere" />
+  <surface boundary="vacuum" coeffs="0.0 0.0 8.0 1.5" id="3" type="sphere" />
+</geometry>

--- a/test/tests/neutronics/void/make_openmc_model.py
+++ b/test/tests/neutronics/void/make_openmc_model.py
@@ -1,0 +1,60 @@
+#********************************************************************/
+#*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+#*                             Cardinal                             */
+#*                                                                  */
+#*                  (c) 2021 UChicago Argonne, LLC                  */
+#*                        ALL RIGHTS RESERVED                       */
+#*                                                                  */
+#*                 Prepared by UChicago Argonne, LLC                */
+#*               Under Contract No. DE-AC02-06CH11357               */
+#*                With the U. S. Department of Energy               */
+#*                                                                  */
+#*             Prepared by Battelle Energy Alliance, LLC            */
+#*               Under Contract No. DE-AC07-05ID14517               */
+#*                With the U. S. Department of Energy               */
+#*                                                                  */
+#*                 See LICENSE for full restrictions                */
+#********************************************************************/
+
+import openmc
+
+uo2 = openmc.Material()
+uo2.set_density('g/cc', 10.0)
+uo2.add_element('U', 1.0, enrichment=2.5)
+uo2.add_element('O', 2.0)
+
+mats = openmc.Materials([uo2])
+mats.export_to_xml()
+
+# Create three pebbles filled with plutonium
+R = 1.5
+zmin = 0.0
+zmax = 8.0
+sphere1 = openmc.Sphere(x0=0.0, y0=0.0, z0=zmin, r=R, boundary_type='vacuum')
+sphere2 = openmc.Sphere(x0=0.0, y0=0.0, z0=4.0, r=R, boundary_type='vacuum')
+sphere3 = openmc.Sphere(x0=0.0, y0=0.0, z0=zmax, r=R, boundary_type='vacuum')
+
+solid_cell1 = openmc.Cell(fill=None, region=-sphere1)
+solid_cell2 = openmc.Cell(fill=uo2, region=-sphere2)
+solid_cell3 = openmc.Cell(fill=uo2, region=-sphere3)
+geom = openmc.Geometry([solid_cell1, solid_cell2, solid_cell3])
+geom.export_to_xml()
+
+# Finally, define some run settings
+settings = openmc.Settings()
+settings.batches = 50
+settings.inactive = 10
+settings.particles = 100
+
+L = 5.0
+l = 0.5
+height = 8.0 + 2 * R + 2 * l
+lower_left = (-L, -L, 0)
+upper_right = (L, L, height)
+uniform_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
+settings.source = openmc.source.Source(space=uniform_dist)
+settings.temperature = {'default': 600.0,
+                        'method': 'nearest',
+                        'multipole': False,
+                        'range': (294.0, 1600.0)}
+settings.export_to_xml()

--- a/test/tests/neutronics/void/materials.xml
+++ b/test/tests/neutronics/void/materials.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material depletable="true" id="1">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="0.00022623866603420858" name="U234" />
+    <nuclide ao="0.02531160246829241" name="U235" />
+    <nuclide ao="0.9743462195687997" name="U238" />
+    <nuclide ao="0.00011593929687363616" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+</materials>

--- a/test/tests/neutronics/void/openmc.i
+++ b/test/tests/neutronics/void/openmc.i
@@ -1,0 +1,26 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../meshes/sphere.e
+  []
+  [multiple]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 8'
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  verbose = true
+  power = 10.0
+  tally_type = 'cell'
+  solid_cell_level = 0
+  solid_blocks = '1'
+
+  initial_properties = xml
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/neutronics/void/settings.xml
+++ b/test/tests/neutronics/void/settings.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<settings>
+  <run_mode>eigenvalue</run_mode>
+  <particles>1000</particles>
+  <batches>50</batches>
+  <inactive>10</inactive>
+  <source strength="1.0">
+    <space type="fission">
+      <parameters>-5.0 -5.0 0 5.0 5.0 12.0</parameters>
+    </space>
+  </source>
+  <temperature_default>600.0</temperature_default>
+  <temperature_method>nearest</temperature_method>
+  <temperature_multipole>false</temperature_multipole>
+  <temperature_range>294.0 1600.0</temperature_range>
+</settings>

--- a/test/tests/neutronics/void/tests
+++ b/test/tests/neutronics/void/tests
@@ -1,0 +1,10 @@
+[Tests]
+  [ignore_missing_void]
+    type = RunException
+    input = openmc.i
+    cli_args = '-error'
+    expect_err = "Skipping multiphysics feedback for 1 OpenMC cells!"
+    requirement = 'The system shall ignore void cells when printing warnings about uncoupled cells. '
+                  'This input ignores two pebbles for coupling, but one of the pebbles is void.'
+    required_objects = 'OpenMCCellAverageProblem'
+[]

--- a/test/tests/neutronics/void/tests
+++ b/test/tests/neutronics/void/tests
@@ -7,4 +7,5 @@
     requirement = 'The system shall ignore void cells when printing warnings about uncoupled cells. '
                   'This input ignores two pebbles for coupling, but one of the pebbles is void.'
     required_objects = 'OpenMCCellAverageProblem'
+  []
 []

--- a/test/tests/openmc_errors/densities/void_density.i
+++ b/test/tests/openmc_errors/densities/void_density.i
@@ -40,7 +40,6 @@
   tally_blocks = '1'
   verbose = true
 
-  solid_cell_level = 0
   fluid_cell_level = 0
 []
 


### PR DESCRIPTION
For single-level geometries, we currently throw a warning to the user if their OpenMC model contains additional cells that weren't coupled to MOOSE. For DagMC models, there will typically be an implicit complement cell (VOID material), which will be uncoupled to MOOSE. This can be misleading to the user if they mistakenly think they are missing coupling for one cell, even if that cell is void and it would never receive feedback anyways.

This PR excludes void cells from the warning messages shown to users, as well as adds a table to show more information about neglected cells.