### PR TITLE
Move symmetry operation into a user object

### DIFF
--- a/doc/content/source/auxkernels/PointTransformationAux.md
+++ b/doc/content/source/auxkernels/PointTransformationAux.md
@@ -6,33 +6,32 @@
 
 Displays the $x$, $y$, or $z$ coordinates that get mapped to OpenMC. This
 auxiliary kernel can be used to ensure that the
-`symmetry_plane_normal`, `symmetry_axis`, and `symmetry_angle` parameters on
-[OpenMCCellAverageProblem](/problems/OpenMCCellAverageProblem.md)
-apply the desired transformations. In other words, this class only displays the
-*transformed* spatial coordinates that get sent into the
-`openmc::exhaustive_find_cell` routine.
+`normal`, `rotation_axis`, and `rotation_angle` parameters on
+[SymmetryPointGenerator](/userobjects/SymmetryPointGenerator.md)
+apply the desired transformations. In other words, this class displays the
+*transformed* spatial coordinates.
 
 ## Example Input Syntax
 
 As an example, we can visualize the transformed $x$, $y$, and $z$ coordinates
-for an OpenMC mapping that obeys 1/6th symmetry with a symmetry plane normal
+for a mapping that obeys 1/6th symmetry with a symmetry plane normal
 of $\hat{n}=\hat{y}$ and a symmetry axis of $\hat{m}=\hat{z}$ with the following.
 
 !listing test/tests/symmetry/rotation.i
   start=AuxKernels
   end=Executioner
 
-Then, the `x` variable will show the transformed $x$ coordinate that gets mapped
-to OpenMC - as shown in [xfig], the $x$ coordinate obeys 1/6th symmetry.
+Then, the `x` variable will show the transformed $x$ coordinate
+- as shown in [xfig], the $x$ coordinate obeys 1/6th symmetry.
 
 !media sixth_symmetry.png
   id=xfig
-  caption=Example visualization of the transformed $x$ that gets mapped to this particular OpenMC model, as viewed looking down the negative $z$ axis
+  caption=Example visualization of the transformed $x$, as viewed looking down the negative $z$ axis
   style=width:60%;margin-left:auto;margin-right:auto;halign:center
 
 The OpenMC model would then need to correspond to the blue 1/6th slice in
-[slice] in order for the applied `symmetry_plane_normal`, symmetry_axis`,
-and `symmetry_angle` to properly map to the OpenMC domain.
+[slice] in order for the applied `normal`, `rotation_axis`,
+and `rotation_angle` to properly map to the OpenMC domain.
 
 !media slice.png
   id=slice

--- a/doc/content/source/problems/OpenMCCellAverageProblem.md
+++ b/doc/content/source/problems/OpenMCCellAverageProblem.md
@@ -622,55 +622,18 @@ reads from.
 #### Symmetric Data Transfers
 
 Many neutronics problems are symmetric - such as half-core or quarter-core symmetry.
-However, some MOOSE mesh generators (such asthe
-[Reactor module](https://mooseframework.inl.gov/modules/reactor/index.html) don't
-support generating symmetric geometries by slicing along arbitrary planes. This class supports
+However, some MOOSE mesh generators (such as in the
+[Reactor module](https://mooseframework.inl.gov/modules/reactor/index.html)) don't
+yet support symmetric geometries by slicing along arbitrary planes. This class supports
 both half-symmetric OpenMC models and general $n$-th symmetric rotational models by
 coupling symmetric OpenMC models to full-system thermal-fluid models.
 
-!alert note
-When using symmetric data transfers, elements with centroids that *perfectly* align with
-one of the symmetry planes in the OpenMC model can occasionally not map correctly, due
-to roundoff errors. It is recommended to use meshes that avoid this possibility.
-It can be helpful when setting up symmetric models to visualize the actual
-$x$, $y$, and $z$ coordinates that get sent into OpenMC - the
-[PointTransformationAux](/auxkernels/PointTransformationAux.md) can be used for
-this purpose.
-
-##### Half-Symmetry
-
-Half-symmetry allows you to reflect across a general plane. The point `(0.0, 0.0, 0.0)` is
-assumed as the origin of the plane, and the `symmetry_plane_normal` parameter provides the
-normal vector for the plane.
-Then, any points in the `[Mesh]` that are on the "positive"
-side of the plane (the direction in which the normal points) are reflected across
-the plane before they are mapped to OpenMC cells.
-For example, [symmetry] shows a half-symmetric OpenMC model of a fuel assembly
-and the mesh to which data is sent. The `symmetry_plane_normal` is shown as
-$\hat{n}$. If asymmetries exist in whatever
+The symmetric mapping is specified with the `symmetry_mapper` parameter, a
+[SymmetryPointGenerator](/userobjects/SymmetryPointGenerator.md) user object.
+Note that if asymmetries exist in whatever
 physics OpenMC is coupled to, they will be averaged on both sides of the plane
-before sending temperatures and densities to OpenMC.
-
-!media symmetry_transfers.png
-  id=symmetry
-  caption=Illustration of symmetric data transfers to/from OpenMC
-
-##### Rotational Symmetry
-
-This class also supports general rotational symmetry, such as to define quarter-symmetry
-in the unit circle.
-Again, you specify the `symmetry_plane_normal` to define *one*
-of the planes bounding the symmetric region. Then, you must also provide a
-`symmetry_axis` about which to rotate, and a `symmetry_angle` (in degrees) to indicate
-the angle of the symmetry sector (sweeping clockwise from the vector $\hat{n}\times\hat{m}$, where $\hat{m}$
-is the `symmetry_axis`). For example, [symmetry_b] shows a 1/6th symmetric OpenMC model
-of a fuel assembly and the mesh to which data is sent. The `symmetry_plane_normal` is
-shown as $\hat{n}$. For this case, the `symmetry_axis` is set to the positive $z$ axis,
-pointing out of the picture. The `symmetry_angle` is then 60 degrees.
-
-!media symmetry_transfers_b.png
-  id=symmetry_b
-  caption=Illustration of symmetric angular data transfers to/from OpenMC
+before sending temperatures and densities to OpenMC. Please consult the
+[SymmetryPointGenerator](/userobjects/SymmetryPointGenerator.md) for more information.
 
 !syntax parameters /Problem/OpenMCCellAverageProblem
 

--- a/doc/content/source/userobjects/SymmetryPointGenerator.md
+++ b/doc/content/source/userobjects/SymmetryPointGenerator.md
@@ -1,0 +1,65 @@
+# SymmetryPointGenerator
+
+!syntax description /UserObjects/SymmetryPointGenerator
+
+## Description
+
+This user object maps from a point $(x_0, y_0, z_0)$ to a new point
+$(x_1, y_1, z_1)$ according to either a mirror-symmetric or rotationally-symmetric
+mapping. This class is most commonly used to transfer data between
+a symmetric OpenMC model and a whole-domain `[Mesh]`.
+
+!alert note
+Elements with centroids that *perfectly* align with
+one of the symmetry planes can occasionally not map correctly due
+to roundoff errors. It is recommended to use meshes that avoid this possibility.
+It can be helpful when setting up symmetric models to visualize the transformed
+$x_1$, $y_1$, and $z_1$ coordinates - the
+[PointTransformationAux](/auxkernels/PointTransformationAux.md) can be used for
+this purpose.
+
+### Mirror Symmetry
+
+Mirror symmetry, also referred to as "half-symmetry," reflects a point across a general plane
+with origin `(0.0, 0.0, 0.0)` and normal given by the `normal` parameter.
+Points on the "positive"
+side of the plane (the direction in which the normal points) are reflected across
+the plane.
+For example, [symmetry] shows a half-symmetric OpenMC model of a fuel assembly
+and the mesh to which data is sent. The `normal` is shown as
+$\hat{n}$.
+
+!media symmetry_transfers.png
+  id=symmetry
+  caption=Illustration of symmetric data transfers to/from OpenMC
+
+### Rotational Symmetry
+
+This class also supports general rotational symmetry, such as to define quarter-symmetry
+in the unit circle.
+Again, you specify the `normal` to define *one*
+of the planes bounding the symmetric region. Then, you must also provide a
+`rotation_axis` about which to rotate, and a `rotation_angle` (in degrees) to indicate
+the angle of the symmetry sector (sweeping clockwise from the vector $\hat{n}\times\hat{m}$, where $\hat{m}$
+is the `rotation_axis`). For example, [symmetry_b] shows a 1/6th symmetric OpenMC model
+of a fuel assembly and the mesh to which data is sent. The `normal` is
+shown as $\hat{n}$. For this case, the `rotation_axis` is set to the positive $z$ axis,
+pointing out of the picture. The `rotation_angle` is then 60 degrees.
+
+!media symmetry_transfers_b.png
+  id=symmetry_b
+  caption=Illustration of symmetric angular data transfers to/from OpenMC
+
+## Example Input Syntax
+
+Below is an example input file that constructs the rotational symmetry
+shown in [symmetry_b].
+
+!listing test/tests/neutronics/symmetry/rotational/openmc.i
+  block=UserObjects
+
+!syntax parameters /UserObjects/SymmetryPointGenerator
+
+!syntax inputs /UserObjects/SymmetryPointGenerator
+
+!syntax children /UserObjects/SymmetryPointGenerator

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -1053,8 +1053,8 @@ protected:
    */
   const std::vector<SubdomainName> * _temperature_blocks;
 
-  /// Helper utility to rotate [Mesh] points according to symmetry in OpenMC model
-  std::unique_ptr<SymmetryPointGenerator> _symmetry;
+  /// Userobject that maps from a partial-symmetry OpenMC model to a whole-domain [Mesh]
+  const SymmetryPointGenerator * _symmetry;
 
   /// Number of solid elements in each mapped OpenMC cell (global)
   std::map<cellInfo, int> _n_solid;

--- a/include/userobjects/SymmetryPointGenerator.h
+++ b/include/userobjects/SymmetryPointGenerator.h
@@ -18,25 +18,23 @@
 
 #pragma once
 
-#include "Moose.h"
-#include "MooseTypes.h"
-#include "libmesh/point.h"
+#include "ThreadedGeneralUserObject.h"
 
 /**
- * Class that rotates/reflects a point about symmetry planes; the origin
- * for reflection and rotation is (0.0, 0.0, 0.0)
+ * Class that maps from a point (x, y, z) to a new point that is
+ * either rotationally symmetry or mirrored. The origin for reflection
+ * and rotation is (0, 0, 0).
  */
-class SymmetryPointGenerator
+class SymmetryPointGenerator : public ThreadedGeneralUserObject
 {
 public:
-  SymmetryPointGenerator(const Point & normal);
+  static InputParameters validParams();
 
-  /**
-   * Initialize information needed to transform points with angular symmetry
-   * @param[in] axis axis of symmetry
-   * @param[in] angle angular sector width for symmetry
-   */
-  void initializeAngularSymmetry(const Point & axis, const Real & angle);
+  SymmetryPointGenerator(const InputParameters & parameters);
+
+  virtual void initialize() {}
+  virtual void finalize() {}
+  virtual void execute() {}
 
   /**
    * Whether point is on the positive side of a plane; points exactly on plane return false
@@ -69,6 +67,9 @@ public:
   int sector(const Point & p) const;
 
 protected:
+  /// Whether rotational symmetry is applied; otherwise, the domain is mirror-symmetric
+  const bool _rotational_symmetry;
+
   /// Normal defining the first symmetry plane
   Point _normal;
 
@@ -83,7 +84,4 @@ protected:
 
   /// Normal defining the reflection plane, for odd-numbered sectors
   Point _reflection_normal;
-
-  /// Whether rotational symmetry is applied
-  bool _rotational_symmetry;
 };

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -213,10 +213,13 @@ OpenMCCellAverageProblem::validParams()
                            "Number of particles to use for first iteration "
                            "when using Dufek-Gudowski relaxation");
 
+  params.addParam<UserObjectName>("symmetry_mapper", "User object (of type SymmetryPointGenerator) "
+    "to map from a symmetric OpenMC model to a full-domain [Mesh]. For example, you can use this "
+    "to map from a quarter-symmetric OpenMC model to a whole-domain [Mesh].");
   params.addParam<Point>("symmetry_plane_normal",
-                         "Normal that defines a symmetry plane in the OpenMC model");
+               "Normal that defines a symmetry plane in the OpenMC model");
   params.addParam<Point>("symmetry_axis",
-                         "Axis about which to rotate for angle-symmetric OpenMC models");
+               "Axis about which to rotate for angle-symmetric OpenMC models");
   params.addRangeCheckedParam<Real>(
       "symmetry_angle",
       "symmetry_angle > 0 & symmetry_angle <= 180",
@@ -334,23 +337,8 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     if (_mesh.getMesh().allow_renumbering() && !_mesh.getMesh().is_replicated())
       mooseError("Mesh tallies currently require 'allow_renumbering = false' to be set in the [Mesh]!");
 
-  if (isParamValid("symmetry_plane_normal"))
-  {
-    const auto & normal = getParam<Point>("symmetry_plane_normal");
-    _symmetry.reset(new SymmetryPointGenerator(normal));
-
-    checkJointParams(params, {"symmetry_axis", "symmetry_angle"}, "specifying angular symmetry");
-
-    if (isParamValid("symmetry_axis"))
-    {
-      const auto & axis = getParam<Point>("symmetry_axis");
-      const auto & angle = getParam<Real>("symmetry_angle");
-      _symmetry->initializeAngularSymmetry(axis, angle);
-    }
-  }
-  else
-    checkUnusedParam(params, {"symmetry_plane_normal", "symmetry_axis", "symmetry_angle"},
-                             "not setting a symmetry plane");
+  if (isParamValid("symmetry_plane_normal") || isParamValid("symmetry_axis") || isParamValid("symmetry_angle"))
+    mooseError("The 'symmetry_plane_normal', 'symmetry_axis', and 'symmetry_angle' functionality has been moved into the SymmetryPointGenerator user object. Please add a SymmetryPointGenerator user object and pass into the 'symmetry_mapper' parameter.");
 
   if (_assume_separate_tallies && _needs_global_tally)
     paramError("assume_separate_tallies",
@@ -486,12 +474,6 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
         mooseError("Unhandled OutputEnum in OpenMCCellAverageProblem!");
     }
   }
-
-  setupProblem();
-
-  initializeTallies();
-
-  checkMeshTemplateAndTranslations();
 }
 
 void
@@ -501,6 +483,18 @@ OpenMCCellAverageProblem::initialSetup()
 
   if (_adaptivity.isOn() && _fixed_mesh)
     mooseError("When using mesh adaptivity, 'fixed_mesh' must be false!");
+
+  if (isParamValid("symmetry_mapper"))
+  {
+    auto name = getParam<UserObjectName>("symmetry_mapper");
+    _symmetry = &getUserObject<SymmetryPointGenerator>(name);
+  }
+
+  setupProblem();
+
+  initializeTallies();
+
+  checkMeshTemplateAndTranslations();
 }
 
 void

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -488,6 +488,9 @@ OpenMCCellAverageProblem::initialSetup()
   {
     auto name = getParam<UserObjectName>("symmetry_mapper");
     _symmetry = &getUserObject<SymmetryPointGenerator>(name);
+
+    if (!_symmetry)
+      mooseError("The 'symmetry_mapper' user object has to be of type SymmetryPointGenerator!");
   }
 
   setupProblem();

--- a/src/userobjects/SymmetryPointGenerator.C
+++ b/src/userobjects/SymmetryPointGenerator.C
@@ -36,6 +36,8 @@ SymmetryPointGenerator::validParams()
       "If rotationally symmetric, the angle (degrees) from the 'normal' plane "
       "through which to rotate to form the symmetric wedge. If not specified, then the"
       "geometry is mirror-symmetric.");
+  params.addClassDescription("Maps from a point (x, y, z) to a new point that is either "
+    "mirror-symmetric or rotationally-symmetric from the point.");
   return params;
 }
 

--- a/src/userobjects/SymmetryPointGenerator.C
+++ b/src/userobjects/SymmetryPointGenerator.C
@@ -18,45 +18,68 @@
 
 #include "SymmetryPointGenerator.h"
 #include "GeometryUtility.h"
-#include "MooseUtils.h"
-#include "math.h"
+#include "UserErrorChecking.h"
 
-SymmetryPointGenerator::SymmetryPointGenerator(const Point & normal) : _rotational_symmetry(false)
+registerMooseObject("CardinalApp", SymmetryPointGenerator);
+
+InputParameters
+SymmetryPointGenerator::validParams()
 {
-  Point zero(0.0, 0.0, 0.0);
-  if (normal.absolute_fuzzy_equals(zero))
-    mooseError("The 'symmetry_plane_normal' cannot have zero norm!");
-
-  _normal = normal / normal.norm();
+  InputParameters params = GeneralUserObject::validParams();
+  params.addRequiredParam<Point>("normal", "Normal of the symmetry plane");
+  params.addParam<Point>("rotation_axis",
+                         "If rotationally symmetric, the axis about which to rotate. "
+                         "If not specified, then the geometry is mirror-symmetric.");
+  params.addRangeCheckedParam<Real>(
+      "rotation_angle",
+      "rotation_angle > 0 & rotation_angle <= 180",
+      "If rotationally symmetric, the angle (degrees) from the 'normal' plane "
+      "through which to rotate to form the symmetric wedge. If not specified, then the"
+      "geometry is mirror-symmetric.");
+  return params;
 }
 
-void
-SymmetryPointGenerator::initializeAngularSymmetry(const Point & axis, const Real & angle)
+SymmetryPointGenerator::SymmetryPointGenerator(const InputParameters & params)
+  : ThreadedGeneralUserObject(params),
+    _rotational_symmetry(isParamValid("rotation_axis"))
 {
-  _rotational_symmetry = true;
+  checkJointParams(params, {"rotation_axis", "rotation_angle"}, "specifying rotational symmetry");
 
-  // symmetry axis cannot be zero norm
+  auto n = getParam<Point>("normal");
   Point zero(0.0, 0.0, 0.0);
-  if (axis.absolute_fuzzy_equals(zero))
-    mooseError("The 'symmetry_axis' cannot have zero norm!");
+  if (n.absolute_fuzzy_equals(zero))
+    mooseError("The 'normal' cannot have zero norm!");
 
-  // the symmetry axis needs to be perpendicular to the plane normal
-  if (!MooseUtils::absoluteFuzzyEqual(axis * _normal, 0.0))
-    mooseError("The 'symmetry_axis' must be perpendicular to the 'symmetry_plane_normal'!");
+  _normal = n / n.norm();
 
-  _rotational_axis = axis / axis.norm();
+  if (_rotational_symmetry)
+  {
+    const auto & axis = getParam<Point>("rotation_axis");
+    const auto & angle = getParam<Real>("rotation_angle");
 
-  // unit circle must be divisible by angle
-  if (!MooseUtils::absoluteFuzzyEqual(fmod(360.0, angle), 0))
-    mooseError("The unit circle must be divisible by the 'symmetry_angle'!");
+    // symmetry axis cannot be zero norm
+    Point zero(0.0, 0.0, 0.0);
+    if (axis.absolute_fuzzy_equals(zero))
+      mooseError("The 'rotation_axis' cannot have zero norm!");
 
-  _angle = angle * M_PI / 180.0;
+    // the symmetry axis needs to be perpendicular to the plane normal
+    if (!MooseUtils::absoluteFuzzyEqual(axis * _normal, 0.0))
+      mooseError("The 'rotation_axis' must be perpendicular to the 'normal'!");
 
-  _zero_theta = _normal.cross(_rotational_axis);
-  _zero_theta = _zero_theta / _zero_theta.norm();
+    _rotational_axis = axis / axis.norm();
 
-  _reflection_normal = geom_utility::rotatePointAboutAxis(_normal, -_angle / 2.0, _rotational_axis);
-  _reflection_normal = _reflection_normal / _reflection_normal.norm();
+    // unit circle must be divisible by angle
+    if (!MooseUtils::absoluteFuzzyEqual(fmod(360.0, angle), 0))
+      mooseError("The unit circle must be evenly divisible by the 'rotation_angle'!");
+
+    _angle = angle * M_PI / 180.0;
+
+    _zero_theta = _normal.cross(_rotational_axis);
+    _zero_theta = _zero_theta / _zero_theta.norm();
+
+    _reflection_normal = geom_utility::rotatePointAboutAxis(_normal, -_angle / 2.0, _rotational_axis);
+    _reflection_normal = _reflection_normal / _reflection_normal.norm();
+  }
 }
 
 bool

--- a/test/tests/neutronics/symmetry/openmc.i
+++ b/test/tests/neutronics/symmetry/openmc.i
@@ -75,7 +75,14 @@ height = 6.343                           # height of the full core (m)
   solid_cell_level = 1
   fluid_cell_level = 1
 
-  symmetry_plane_normal = '${fparse -sqrt(3.0) / 2.0} 0.5 0.0'
+  symmetry_mapper = sym
+[]
+
+[UserObjects]
+  [sym]
+    type = SymmetryPointGenerator
+    normal = '${fparse -sqrt(3.0) / 2.0} 0.5 0.0'
+  []
 []
 
 [Postprocessors]

--- a/test/tests/neutronics/symmetry/rotational/openmc.i
+++ b/test/tests/neutronics/symmetry/rotational/openmc.i
@@ -76,9 +76,16 @@
   tally_type = cell
   solid_cell_level = 1
 
-  symmetry_plane_normal = '${fparse -sqrt(3.0) / 2.0} 0.5 0.0'
-  symmetry_axis = '0.0 0.0 1.0'
-  symmetry_angle = 60.0
+  symmetry_mapper = sym
+[]
+
+[UserObjects]
+  [sym]
+    type = SymmetryPointGenerator
+    normal = '${fparse -sqrt(3.0) / 2.0} 0.5 0.0'
+    rotation_axis = '0.0 0.0 1.0'
+    rotation_angle = 60.0
+  []
 []
 
 [Postprocessors]

--- a/test/tests/neutronics/symmetry/tests
+++ b/test/tests/neutronics/symmetry/tests
@@ -14,4 +14,11 @@
     requirement = "The system shall correctly reflect points about a symmetry plane"
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [wrong_uo]
+    type = RunException
+    input = wrong_uo.i
+    expect_err = "The 'symmetry_mapper' user object has to be of type SymmetryPointGenerator!"
+    requirement = "The system shall error if the symmetry mapper is not of the correct type"
+    required_objects = 'OpenMCCellAverageProblem'
+  []
 []

--- a/test/tests/neutronics/symmetry/triso/openmc.i
+++ b/test/tests/neutronics/symmetry/triso/openmc.i
@@ -78,7 +78,14 @@
   tally_type = cell
   solid_cell_level = 1
 
-  symmetry_plane_normal = '-1.0 0.0 0.0'
+  symmetry_mapper = sym
+[]
+
+[UserObjects]
+  [sym]
+    type = SymmetryPointGenerator
+    normal = '-1.0 0.0 0.0'
+  []
 []
 
 [Executioner]

--- a/test/tests/neutronics/symmetry/wrong_uo.i
+++ b/test/tests/neutronics/symmetry/wrong_uo.i
@@ -8,6 +8,8 @@ height = 6.343                           # height of the full core (m)
     type = FileMeshGenerator
     file = solid_mesh_in.e
   []
+
+  allow_renumbering = false
 []
 
 [Problem]

--- a/test/tests/neutronics/symmetry/wrong_uo.i
+++ b/test/tests/neutronics/symmetry/wrong_uo.i
@@ -1,0 +1,34 @@
+num_layers = 1
+
+channel_diameter = 0.016                 # diameter of the coolant channels (m)
+height = 6.343                           # height of the full core (m)
+
+[Mesh]
+  [solid]
+    type = FileMeshGenerator
+    file = solid_mesh_in.e
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 1000.0
+  scaling = 100.0
+  solid_blocks = '1 2'
+  tally_type = mesh
+  mesh_template = solid_mesh_in.e
+  solid_cell_level = 1
+
+  symmetry_mapper = sym
+[]
+
+[UserObjects]
+  [sym]
+    type = NearestNodeNumberUO
+    point = '0.0 0.0 0.0'
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/symmetry/reflection.i
+++ b/test/tests/symmetry/reflection.i
@@ -52,10 +52,16 @@
   solid_cell_level = 0
   tally_type = cell
   normalize_by_global_tally = false
-
-  symmetry_plane_normal = '1.0 1.0 1.0'
-
   initial_properties = xml
+
+  symmetry_mapper = sym
+[]
+
+[UserObjects]
+  [sym]
+    type = SymmetryPointGenerator
+    normal = '1.0 1.0 1.0'
+  []
 []
 
 [Executioner]

--- a/test/tests/symmetry/rotation.i
+++ b/test/tests/symmetry/rotation.i
@@ -53,12 +53,18 @@
   solid_cell_level = 0
   tally_type = cell
   normalize_by_global_tally = false
-
-  symmetry_plane_normal = '0.0 1.0 0.0'
-  symmetry_axis = '0.0 0.0 1.0'
-  symmetry_angle = ${fparse 360.0 / 6.0}
-
   initial_properties = xml
+
+  symmetry_mapper = sym
+[]
+
+[UserObjects]
+  [sym]
+    type = SymmetryPointGenerator
+    normal = '0.0 1.0 0.0'
+    rotation_axis = '0.0 0.0 1.0'
+    rotation_angle = ${fparse 360.0 / 6.0}
+  []
 []
 
 [Executioner]

--- a/test/tests/userobjects/symmetry_point_generator/test.i
+++ b/test/tests/userobjects/symmetry_point_generator/test.i
@@ -1,0 +1,20 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Problem]
+  type = FEProblem
+  solve = false
+[]
+
+[UserObjects]
+  [spg]
+    type = SymmetryPointGenerator
+    normal = '1.0 0.0 0.0'
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/userobjects/symmetry_point_generator/tests
+++ b/test/tests/userobjects/symmetry_point_generator/tests
@@ -1,0 +1,30 @@
+[Tests]
+  [zero_normal_norm]
+    type = RunException
+    input = test.i
+    cli_args = 'UserObjects/spg/normal="0.0 0.0 0.0"'
+    expect_err = "The 'normal' cannot have zero norm!"
+    requirement = "The system shall error if the normal has zero length"
+  []
+  [non_perpendicular_axis]
+    type = RunException
+    input = test.i
+    cli_args = 'UserObjects/spg/rotation_axis="1.0 0.0 0.0" UserObjects/spg/rotation_angle=90.0'
+    expect_err = "The 'rotation_axis' must be perpendicular to the 'normal'!"
+    requirement = "The system shall error if the rotation axis is not perpendicular to the symmetry normal"
+  []
+  [zero_axis_norm]
+    type = RunException
+    input = test.i
+    cli_args = 'UserObjects/spg/rotation_axis="0.0 0.0 0.0" UserObjects/spg/rotation_angle=90.0'
+    expect_err = "The 'rotation_axis' cannot have zero norm!"
+    requirement = "The system shall error if the rotation axis has zero length"
+  []
+  [non_integer_angle]
+    type = RunException
+    input = test.i
+    cli_args = 'UserObjects/spg/rotation_axis="0.0 1.0 0.0" UserObjects/spg/rotation_angle=92.0'
+    expect_err = "The unit circle must be evenly divisible by the 'rotation_angle'!"
+    requirement = "The system shall error if the rotation angle does not describe a valid symmetry wedge"
+  []
+[]

--- a/unit/include/SymmetryPointGeneratorTest.h
+++ b/unit/include/SymmetryPointGeneratorTest.h
@@ -24,5 +24,52 @@
 class SymmetryPointGeneratorTest : public MooseObjectUnitTest
 {
 public:
-  SymmetryPointGeneratorTest() : MooseObjectUnitTest("CardinalUnitApp") {}
+  SymmetryPointGeneratorTest() : MooseObjectUnitTest("CardinalUnitApp") { buildObjects(); }
+
+protected:
+  void buildObjects()
+  {
+    InputParameters p1 = _factory.getValidParams("SymmetryPointGenerator");
+    p1.set<Point>("normal") = {1.0, 0.0, 0.0};
+    _fe_problem->addUserObject("SymmetryPointGenerator", "spg1", p1);
+    _spg1 = &_fe_problem->getUserObject<SymmetryPointGenerator>("spg1");
+
+    InputParameters p2 = _factory.getValidParams("SymmetryPointGenerator");
+    p2.set<Point>("normal") = {-1.0, 1.0, 0.0};
+    _fe_problem->addUserObject("SymmetryPointGenerator", "spg2", p2);
+    _spg2 = &_fe_problem->getUserObject<SymmetryPointGenerator>("spg2");
+
+    InputParameters p3 = _factory.getValidParams("SymmetryPointGenerator");
+    p3.set<Point>("normal") = {1.0, -2.0, -3.0};
+    _fe_problem->addUserObject("SymmetryPointGenerator", "spg3", p3);
+    _spg3 = &_fe_problem->getUserObject<SymmetryPointGenerator>("spg3");
+
+    InputParameters p4 = _factory.getValidParams("SymmetryPointGenerator");
+    p4.set<Point>("normal") = {1.0, 0.0, 0.0};
+    p4.set<Point>("rotation_axis") = {0.0, 0.0, 1.0};
+    p4.set<Real>("rotation_angle") = 90.0;
+    _fe_problem->addUserObject("SymmetryPointGenerator", "spg4", p4);
+    _spg4 = &_fe_problem->getUserObject<SymmetryPointGenerator>("spg4");
+
+    InputParameters p5 = _factory.getValidParams("SymmetryPointGenerator");
+    p5.set<Point>("normal") = {0.0, 1.0, 0.0};
+    p5.set<Point>("rotation_axis") = {0.0, 0.0, 1.0};
+    p5.set<Real>("rotation_angle") = 60.0;
+    _fe_problem->addUserObject("SymmetryPointGenerator", "spg5", p5);
+    _spg5 = &_fe_problem->getUserObject<SymmetryPointGenerator>("spg5");
+
+    InputParameters p6 = _factory.getValidParams("SymmetryPointGenerator");
+    p6.set<Point>("normal") = {0.0, 1.0, 0.0};
+    p6.set<Point>("rotation_axis") = {0.0, 0.0, 1.0};
+    p6.set<Real>("rotation_angle") = 360.0 / 5.0;
+    _fe_problem->addUserObject("SymmetryPointGenerator", "spg6", p6);
+    _spg6 = &_fe_problem->getUserObject<SymmetryPointGenerator>("spg6");
+  }
+
+  const SymmetryPointGenerator * _spg1;
+  const SymmetryPointGenerator * _spg2;
+  const SymmetryPointGenerator * _spg3;
+  const SymmetryPointGenerator * _spg4;
+  const SymmetryPointGenerator * _spg5;
+  const SymmetryPointGenerator * _spg6;
 };

--- a/unit/src/SymmetryPointGeneratorTest.C
+++ b/unit/src/SymmetryPointGeneratorTest.C
@@ -18,83 +18,18 @@
 
 #include "SymmetryPointGeneratorTest.h"
 
-TEST_F(SymmetryPointGeneratorTest, errors)
-{
-  try
-  {
-    Point n1(0.0, 0.0, 0.0);
-    SymmetryPointGenerator sg(n1);
-  }
-  catch (const std::exception & e)
-  {
-    std::string msg(e.what());
-    ASSERT_NE(msg.find("The 'symmetry_plane_normal' cannot have zero norm!"), std::string::npos)
-        << "failed with unexpected error: " << msg;
-  }
-
-  try
-  {
-    Point n1(1.0, 0.0, 0.0);
-    SymmetryPointGenerator sg(n1);
-
-    Point n2(1.0, 0.0, 0.0);
-    sg.initializeAngularSymmetry(n2, 90.0);
-  }
-  catch (const std::exception & e)
-  {
-    std::string msg(e.what());
-    ASSERT_NE(msg.find("The 'symmetry_axis' must be perpendicular to the 'symmetry_plane_normal'!"),
-              std::string::npos)
-        << "failed with unexpected error: " << msg;
-  }
-
-  try
-  {
-    Point n1(1.0, 0.0, 0.0);
-    SymmetryPointGenerator sg(n1);
-
-    Point n2(0.0, 0.0, 0.0);
-    sg.initializeAngularSymmetry(n2, 90.0);
-  }
-  catch (const std::exception & e)
-  {
-    std::string msg(e.what());
-    ASSERT_NE(msg.find("The 'symmetry_axis' cannot have zero norm!"), std::string::npos)
-        << "failed with unexpected error: " << msg;
-  }
-
-  try
-  {
-    Point n1(1.0, 0.0, 0.0);
-    SymmetryPointGenerator sg(n1);
-
-    Point n2(0.0, 0.0, 1.0);
-    sg.initializeAngularSymmetry(n2, 92.0);
-  }
-  catch (const std::exception & e)
-  {
-    std::string msg(e.what());
-    ASSERT_NE(msg.find("The unit circle must be divisible by the 'symmetry_angle'!"),
-              std::string::npos)
-        << "failed with unexpected error: " << msg;
-  }
-}
-
 TEST_F(SymmetryPointGeneratorTest, reflect_y_axis)
 {
-  Point n(1.0, 0.0, 0.0);
-  SymmetryPointGenerator sg(n);
-
   // point already on the negative side of the plane
   Point pt1(-1, -1, 0.0);
-  Point pt1_r = sg.transformPoint(pt1);
+  Point pt1_r = _spg1->transformPoint(pt1);
   EXPECT_DOUBLE_EQ(pt1_r(0), pt1(0));
   EXPECT_DOUBLE_EQ(pt1_r(1), pt1(1));
   EXPECT_DOUBLE_EQ(pt1_r(2), pt1(2));
 
   // points on the positive side of the plane
   Point pt2(1.0, 1.0, -2.0);
-  Point pt2_r = sg.transformPoint(pt2);
+  Point pt2_r = _spg1->transformPoint(pt2);
   EXPECT_DOUBLE_EQ(pt2_r(0), -1.0);
   EXPECT_DOUBLE_EQ(pt2_r(1), 1.0);
   EXPECT_DOUBLE_EQ(pt2_r(2), -2.0);
@@ -102,26 +37,22 @@ TEST_F(SymmetryPointGeneratorTest, reflect_y_axis)
 
 TEST_F(SymmetryPointGeneratorTest, reflect_xy_plane)
 {
-  Point n(-1.0, 1.0, 0.0);
-  n = n / n.norm();
-  SymmetryPointGenerator sg(n);
-
   // point already on the negative side of the plane
   Point pt1(1, -0.1, 0.0);
-  Point pt1_r = sg.transformPoint(pt1);
+  Point pt1_r = _spg2->transformPoint(pt1);
   EXPECT_DOUBLE_EQ(pt1_r(0), pt1(0));
   EXPECT_DOUBLE_EQ(pt1_r(1), pt1(1));
   EXPECT_DOUBLE_EQ(pt1_r(2), pt1(2));
 
   // points on the positive side of the plane
   Point pt2(0.0, 1.0, -2.0);
-  Point pt2_r = sg.transformPoint(pt2);
+  Point pt2_r = _spg2->transformPoint(pt2);
   EXPECT_DOUBLE_EQ(pt2_r(0), 1.0);
   EXPECT_LE(abs(pt2_r(1) - 0.0), 5e-16);
   EXPECT_DOUBLE_EQ(pt2_r(2), -2.0);
 
   Point pt3(-1.0, 2.0, 2.0);
-  Point pt3_r = sg.transformPoint(pt3);
+  Point pt3_r = _spg2->transformPoint(pt3);
   EXPECT_DOUBLE_EQ(pt3_r(0), 2.0);
   EXPECT_DOUBLE_EQ(pt3_r(1), -1.0);
   EXPECT_DOUBLE_EQ(pt3_r(2), 2.0);
@@ -129,13 +60,8 @@ TEST_F(SymmetryPointGeneratorTest, reflect_xy_plane)
 
 TEST_F(SymmetryPointGeneratorTest, reflect_general_plane)
 {
-  Point n(1.0, -2.0, -3.0);
-  n = n / n.norm();
-
-  SymmetryPointGenerator sg(n);
   Point pt1(-1.0, -3.0, -4.0);
-
-  Point pt1r = sg.transformPoint(pt1);
+  Point pt1r = _spg3->transformPoint(pt1);
   EXPECT_LE(abs(pt1r(0) - -3.42857142857), 1e-8);
   EXPECT_LE(abs(pt1r(1) - 1.85714285714), 1e-8);
   EXPECT_LE(abs(pt1r(2) - 3.28571428571), 1e-8);
@@ -143,55 +69,50 @@ TEST_F(SymmetryPointGeneratorTest, reflect_general_plane)
 
 TEST_F(SymmetryPointGeneratorTest, rotate_about_z)
 {
-  Point n(1.0, 0.0, 0.0);
-  Point a(0.0, 0.0, 1.0);
-  SymmetryPointGenerator sg(n);
-  sg.initializeAngularSymmetry(a, 90.0);
-
   Point pt(2.0, 3.0, 5.0);
-  Point ptr = sg.transformPoint(pt);
+  Point ptr = _spg4->transformPoint(pt);
   EXPECT_DOUBLE_EQ(ptr(0), -2.0);
   EXPECT_DOUBLE_EQ(ptr(1), -3.0);
   EXPECT_DOUBLE_EQ(ptr(2), 5.0);
 
   Point pt1(3.0, 2.0, 5.0);
-  ptr = sg.transformPoint(pt1);
+  ptr = _spg4->transformPoint(pt1);
   EXPECT_DOUBLE_EQ(ptr(0), -3.0);
   EXPECT_DOUBLE_EQ(ptr(1), -2.0);
   EXPECT_DOUBLE_EQ(ptr(2), 5.0);
 
   Point pt2(-2.0, 3.0, 5.0);
-  ptr = sg.transformPoint(pt2);
+  ptr = _spg4->transformPoint(pt2);
   EXPECT_DOUBLE_EQ(ptr(0), -2.0);
   EXPECT_DOUBLE_EQ(ptr(1), -3.0);
   EXPECT_DOUBLE_EQ(ptr(2), 5.0);
 
   Point pt3(-3.0, 2.0, 5.0);
-  ptr = sg.transformPoint(pt3);
+  ptr = _spg4->transformPoint(pt3);
   EXPECT_DOUBLE_EQ(ptr(0), -3.0);
   EXPECT_DOUBLE_EQ(ptr(1), -2.0);
   EXPECT_DOUBLE_EQ(ptr(2), 5.0);
 
   Point pt4(-2.0, -3.0, 5.0);
-  ptr = sg.transformPoint(pt4);
+  ptr = _spg4->transformPoint(pt4);
   EXPECT_DOUBLE_EQ(ptr(0), -2.0);
   EXPECT_DOUBLE_EQ(ptr(1), -3.0);
   EXPECT_DOUBLE_EQ(ptr(2), 5.0);
 
   Point pt5(-3.0, -2.0, 5.0);
-  ptr = sg.transformPoint(pt5);
+  ptr = _spg4->transformPoint(pt5);
   EXPECT_DOUBLE_EQ(ptr(0), -3.0);
   EXPECT_DOUBLE_EQ(ptr(1), -2.0);
   EXPECT_DOUBLE_EQ(ptr(2), 5.0);
 
   Point pt6(2.0, -3.0, 5.0);
-  ptr = sg.transformPoint(pt6);
+  ptr = _spg4->transformPoint(pt6);
   EXPECT_DOUBLE_EQ(ptr(0), -2.0);
   EXPECT_DOUBLE_EQ(ptr(1), -3.0);
   EXPECT_DOUBLE_EQ(ptr(2), 5.0);
 
   Point pt7(3.0, 2.0, 5.0);
-  ptr = sg.transformPoint(pt7);
+  ptr = _spg4->transformPoint(pt7);
   EXPECT_DOUBLE_EQ(ptr(0), -3.0);
   EXPECT_DOUBLE_EQ(ptr(1), -2.0);
   EXPECT_DOUBLE_EQ(ptr(2), 5.0);
@@ -199,52 +120,42 @@ TEST_F(SymmetryPointGeneratorTest, rotate_about_z)
 
 TEST_F(SymmetryPointGeneratorTest, sector_6)
 {
-  Point n(0.0, 1.0, 0.0);
-  Point a(0.0, 0.0, 1.0);
-  SymmetryPointGenerator sg(n);
-  sg.initializeAngularSymmetry(a, 360.0 / 6.0);
-
   Point p1(5.0, -0.1, 0.0);
-  EXPECT_EQ(sg.sector(p1), 0);
+  EXPECT_EQ(_spg5->sector(p1), 0);
 
   Point p2(1.0, -11.0, 0.0);
-  EXPECT_EQ(sg.sector(p2), 1);
+  EXPECT_EQ(_spg5->sector(p2), 1);
 
   Point p3(-7.0, -1.0, 0.0);
-  EXPECT_EQ(sg.sector(p3), 2);
+  EXPECT_EQ(_spg5->sector(p3), 2);
 
   Point p4(-7.0, 1.0, 0.0);
-  EXPECT_EQ(sg.sector(p4), 3);
+  EXPECT_EQ(_spg5->sector(p4), 3);
 
   Point p5(0.1, 0.8, 0.0);
-  EXPECT_EQ(sg.sector(p5), 4);
+  EXPECT_EQ(_spg5->sector(p5), 4);
 
   Point p6(19.0, 1.0, 0.0);
-  EXPECT_EQ(sg.sector(p6), 5);
+  EXPECT_EQ(_spg5->sector(p6), 5);
 }
 
 TEST_F(SymmetryPointGeneratorTest, sector_5)
 {
-  Point n(0.0, 1.0, 0.0);
-  Point a(0.0, 0.0, 1.0);
-  SymmetryPointGenerator sg(n);
-  sg.initializeAngularSymmetry(a, 360.0 / 5.0);
-
   Point p1(5.0, -0.1, 0.0);
-  EXPECT_EQ(sg.sector(p1), 0);
+  EXPECT_EQ(_spg6->sector(p1), 0);
 
   Point p2(1.0, -11.0, 0.0);
-  EXPECT_EQ(sg.sector(p2), 1);
+  EXPECT_EQ(_spg6->sector(p2), 1);
 
   Point p3(-7.0, -1.0, 0.0);
-  EXPECT_EQ(sg.sector(p3), 2);
+  EXPECT_EQ(_spg6->sector(p3), 2);
 
   Point p4(-7.0, 1.0, 0.0);
-  EXPECT_EQ(sg.sector(p4), 2);
+  EXPECT_EQ(_spg6->sector(p4), 2);
 
   Point p5(0.1, 2.8, 0.0);
-  EXPECT_EQ(sg.sector(p5), 3);
+  EXPECT_EQ(_spg6->sector(p5), 3);
 
   Point p6(19.0, 1.0, 0.0);
-  EXPECT_EQ(sg.sector(p6), 4);
+  EXPECT_EQ(_spg6->sector(p6), 4);
 }


### PR DESCRIPTION
As I'm increasing the complexity of the OpenMC wrapping, some functionality should be moved into other classes to better encapsulate them. This moves the `SymmetryPointGenerator` from a general C++ class to a `UserObject`, so that all the logic on input parameters can be moved out of `OpenMCCellAverageProblem`.