### PR TITLE
Reset tallies between Picard iterations

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -734,12 +734,12 @@ protected:
   const bool _normalize_by_global;
 
   /**
-   * Whether the [Mesh] is fixed and unchanging during the simulation, or whether
-   * the mesh moves spatially and/or is adaptively refine. When the mesh changes
-   * during the simulation, the mapping from OpenMC cells to the [Mesh] must be
-   * re-established after each OpenMC run.
+   * If 'fixed_mesh' is false, this indicates that the [Mesh] is changing during
+   * the simulation (either from adaptive refinement or from deformation).
+   * When the mesh changes during the simulation, the mapping from OpenMC cells to
+   * the [Mesh] must be re-established after each OpenMC run.
    */
-  const bool & _fixed_mesh;
+  const bool & _need_to_reinit_coupling;
 
   /**
    * Whether to check the tallies against the global tally;

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -72,13 +72,8 @@ public:
   static InputParameters validParams();
 
   /**
-   * \brief Initialize the mapping of OpenMC to the MooseMesh and perform any additional setup actions.
-   *
-   * When 'fixed_mesh' is false, this function is called at the start of _each_ OpenMC
-   * run to establish the mapping from the OpenMC cells to the [Mesh].
-   * TODO: this function currently does not re-initialize tallies based on the updated mapping
-   *       (which will certainly need to be updated for any mesh tallies on the [Mesh], and might
-   *       need updating for cell tallies if the identities of the coupled OpenMC cells changes).
+   * Initialize the mapping of OpenMC to the MooseMesh and perform any additional setup actions
+   * like creating tallies.
    */
   void setupProblem();
 
@@ -498,8 +493,14 @@ protected:
   /// Populate maps of MOOSE elements to OpenMC cells
   void mapElemsToCells();
 
-  /// Add tallies for the fluid and/or solid cells
+  /// Add OpenMC tallies to facilitate the coupling
   void initializeTallies();
+
+  /**
+   * Reset any tallies previously added by Cardinal, by deleting them from OpenMC.
+   * Also delete any mesh filters and meshes added to OpenMC for mesh filters.
+   */
+  void resetTallies();
 
   /// Find the material filling each fluid cell
   void getMaterialFills();
@@ -739,7 +740,7 @@ protected:
    * When the mesh changes during the simulation, the mapping from OpenMC cells to
    * the [Mesh] must be re-established after each OpenMC run.
    */
-  const bool & _need_to_reinit_coupling;
+  const bool _need_to_reinit_coupling;
 
   /**
    * Whether to check the tallies against the global tally;
@@ -1064,6 +1065,18 @@ protected:
 
   /// Number of none elements in each mapped OpenMC cell (global)
   std::map<cellInfo, int> _n_none;
+
+  /// Index in OpenMC tallies corresponding to the global tally added by Cardinal
+  unsigned int _global_tally_index;
+
+  /// Index in OpenMC tallies corresponding to the first local tally added by Cardinal
+  unsigned int _local_tally_index;
+
+  /// Index in OpenMC tally filters corresponding to the first filter added by Cardinal
+  unsigned int _filter_index;
+
+  /// Index in OpenMC meshes corresponding to the mesh tally (if used)
+  unsigned int _mesh_index;
 
   /// Conversion rate from eV to Joule
   static constexpr Real EV_TO_JOULE = 1.6022e-19;

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -145,16 +145,6 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
   _n_openmc_cells = 0.0;
   for (const auto & c : openmc::model::cells)
     _n_openmc_cells += c->n_instances_;
-
-  // establish the local -> global element mapping for convenience
-  for (unsigned int e = 0; e < _mesh.nElem(); ++e)
-  {
-    const auto * elem = _mesh.queryElemPtr(e);
-    if (!isLocalElem(elem))
-      continue;
-
-    _local_to_global_elem.push_back(e);
-  }
 }
 
 OpenMCProblemBase::~OpenMCProblemBase() { openmc_finalize(); }

--- a/test/tests/neutronics/relaxation/cell_tallies/tests
+++ b/test/tests/neutronics/relaxation/cell_tallies/tests
@@ -107,11 +107,11 @@
                   "openmc_nonaligned.i case with normalize_by_global_tally=false"
     required_objects = 'OpenMCCellAverageProblem'
   []
-  [local_without_alignment_relax_null_fixed_mesh]
+  [none_fixed_mesh]
     type = Exodiff
-    input = openmc_nonaligned.i
-    exodiff = nonalignment_relaxation_out.e
-    cli_args = "Problem/normalize_by_global_tally=false Problem/relaxation=constant Problem/relaxation_factor=0.5 Outputs/file_base=nonalignment_relaxation_out Problem/fixed_mesh=false"
+    input = openmc.i
+    exodiff = openmc_out.e
+    cli_args = "Outputs/file_base=openmc_out Problem/fixed_mesh=false"
     min_parallel = 2
     requirement = "The system shall correctly re-initialize the same mapping when the MooseMesh does not change "
                   "during a simulation."
@@ -129,6 +129,15 @@
     input = multi_tally.i
     csvdiff = multi_tally_out.csv
     requirement = "The wrapping shall allow output of multiple tally scores, with relaxation applied independently to each score"
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+  [no_relax_with_fixed_mesh]
+    type = RunException
+    input = openmc.i
+    cli_args = "Problem/relaxation=robbins_monro Problem/fixed_mesh=false"
+    expect_err = "When 'fixed_mesh' is false, the mapping from the OpenMC model to the \[Mesh\] may "
+      "vary in time."
+    requirement = "The system shall correctly error if trying to use relaxation with a time-varying mesh."
     required_objects = 'OpenMCCellAverageProblem'
   []
 []

--- a/test/tests/neutronics/relaxation/mesh_tallies/tests
+++ b/test/tests/neutronics/relaxation/mesh_tallies/tests
@@ -19,11 +19,11 @@
                   "additional command line parameters)."
     required_objects = 'OpenMCCellAverageProblem'
   []
-  [global_without_alignment_relax_null_fixed_mesh]
+  [none_fixed_mesh]
     type = Exodiff
     input = openmc.i
-    exodiff = relaxed_out.e
-    cli_args = "Problem/relaxation=constant Problem/relaxation_factor=0.5 Outputs/file_base=relaxed_out Problem/fixed_mesh=false"
+    exodiff = openmc_out.e
+    cli_args = "Problem/relaxation=none Problem/fixed_mesh=false"
     requirement = "The system shall correctly re-initialize the same mapping when the MooseMesh does not change "
                   "during a simulation."
     required_objects = 'OpenMCCellAverageProblem'


### PR DESCRIPTION
If the `[Mesh]` is changing (from adaptivity or spatial deformation), then the tallies created by Cardinal need to be erased and re-created. For mesh tallies, this is obvious because we are tallying on the `[Mesh]`. For cell tallies, it is unlikely, but possible that as the `[Mesh]` changes that new cells are "exposed" to the coupling (because we only add tallies to fissile cells that map to some MOOSE elements). In this case, we'd need to add those cells to the cell instance filter.

These changes simply (i) delete the local and global tallies, (ii) delete the tally filters, and (iii) delete the meshes (if using mesh tallies), then re-creates them. I tested this by turning on this step-by-step regeneration on an existing test, to check that this has no influence on the results. 

The other changes in this PR are just moving existing code into the `setupProblem()` function so that it is called on every time step (if needing to re-init the coupling for moving-mesh reasons).

Closes #461 