### PR TITLE
Allow different orders in bc->wrk

### DIFF
--- a/doc/content/source/problems/NekRSSeparateDomainProblem.md
+++ b/doc/content/source/problems/NekRSSeparateDomainProblem.md
@@ -57,12 +57,12 @@ Pressure information is transferred between NekRS and the 1D T/H code using a gl
 
 ## Transferring data between NekRS and the 1D T/H code
 
-A summary of postProcessors generated is shown in the following table for velocity, temperature, and scalar01 coupling.
- PostProcessors for scalar02 and scalar03 coupling follow the same pattern as scalar01.
-The postProcessor created depends on (1) the `coupling_type` given, (2) whether or not NekRS is solving for temperature
+A summary of postprocessors generated is shown in the following table for velocity, temperature, and scalar01 coupling.
+ Postprocessors for scalar02 and scalar03 coupling follow the same pattern as scalar01.
+The postprocessor created depends on (1) the `coupling_type` given, (2) whether or not NekRS is solving for temperature
  and (3) the optional `coupling_scalars` provided.
 
-| postProcessor created | `coupling_type = inlet` | `coupling_type = outlet` | `coupling_type = 'inlet outlet'` |
+| Postprocessor created | `coupling_type = inlet` | `coupling_type = outlet` | `coupling_type = 'inlet outlet'` |
 | - | - | - | - |
 | dP | $\checkmark$ | $\checkmark$ | $\checkmark$ |
 | inlet_V | $\checkmark$ | &nbsp; | $\checkmark$ |
@@ -136,17 +136,17 @@ which NekRS makes available within the boundary condition functions in the `.oud
 [usrwrk_nrssdp] shows the assignment of "slots" in the `nrs->usrwrk` scratch space
 array with quantities written by Cardinal. Because different quantities are written into
 Cardinal depending on the problem setup, if a particular slice is not needed for a
-case, it will just hold zero values. That is, the *order* of the various quantities
-is always the same in `nrs->usrwrk`.
+case, it will be skipped. That is, the *order* of the various quantities
+is always the same in `nrs->usrwrk`, but with any unused slots cleared out.
 
-!table id=usrwrk_nrssdp caption=Quantities written into the scratch space array by Cardinal
-| Slice | Quantity | When Will There be Non-Zero Values? | How to Access in the `.oudf` File |
+!table id=usrwrk_nrssdp caption=Quantities written into the scratch space array by Cardinal. In the last column, `n` indicates that the value is case-dependent depending on what features you have enabled.
+| Slice | Quantity | When Will It Be Created? | How to Access in the `.oudf` File |
 | :- | :- | :- | :- |
-| 0 | Inlet velocity | if `coupling_type` includes `inlet`  | `bc->wrk[0 * bc->fieldOffset + bc->idM]` |
-| 1 | Inlet temperature | if `coupling_type` includes `inlet` and NekRS's case files include a temperature solve | `bc->wrk[1 * bc->fieldOffset + bc->idM]` |
-| 2 | Inlet scalar01 | if `coupling_type` includes `inlet` and `coupled_scalars` includes `scalar01` | `bc->wrk[2 * bc->fieldOffset + bc->idM]` |
-| 3 | Inlet scalar02 | if `coupling_type` includes `inlet` and `coupled_scalars` includes `scalar02` | `bc->wrk[3 * bc->fieldOffset + bc->idM]` |
-| 4 | Inlet scalar03 | if `coupling_type` includes `inlet` and `coupled_scalars` includes `scalar03` | `bc->wrk[4 * bc->fieldOffset + bc->idM]` |
+| 0 | Inlet velocity | if `coupling_type` includes `inlet`  | `bc->wrk[n * bc->fieldOffset + bc->idM]` |
+| 1 | Inlet temperature | if `coupling_type` includes `inlet` and NekRS's case files include a temperature solve | `bc->wrk[n * bc->fieldOffset + bc->idM]` |
+| 2 | Inlet scalar01 | if `coupling_type` includes `inlet` and `coupled_scalars` includes `scalar01` | `bc->wrk[n * bc->fieldOffset + bc->idM]` |
+| 3 | Inlet scalar02 | if `coupling_type` includes `inlet` and `coupled_scalars` includes `scalar02` | `bc->wrk[n * bc->fieldOffset + bc->idM]` |
+| 4 | Inlet scalar03 | if `coupling_type` includes `inlet` and `coupled_scalars` includes `scalar03` | `bc->wrk[n * bc->fieldOffset + bc->idM]` |
 
 The total number of slots in the scratch space that are allocated by Cardinal
 is controlled with the `n_usrwrk_slots` parameter.
@@ -158,46 +158,34 @@ Any extra slots are noted as `unused`, and are free for non-coupling use.
 
 For example, if your case couples NekRS to MOOSE with `coupling_type = inlet`
 and `coupled_scalars = scalar02`, but has a NekRS case without a temperature solve,
-the slices normally dedicated to storing inlet temperature and scalar01 are still
-allocated (because we keep the order the same in `nrs->usrwrk`), but just won't hold
-any meaningful information.
+the slices normally dedicated to storing inlet temperature and scalar01 are skipped.
 A table similar to the following would print out at the start of your simulation.
-You could use slices 4 onwards for custom purposes.
+You could use slices 2 onwards for custom purposes.
 
 !listing id=l11 caption=Table printed at start of Cardinal simulation that describes available scratch space for a case that couples NekRS to MOOSE via an inlet and with the second passive scalar, but without the first passive scalar or a temperature solve. A total of 7 slots are allocated by setting `n_usrwrk_slots` to 7
 ------------------------------------------------------------------
 | Slice |  Quantity   |        How to Access in NekRS BCs        |
 ------------------------------------------------------------------
 |     0 | velocity    |  bc->wrk[0 * bc->fieldOffset + bc->idM]  |
-|     1 | temperature |  bc->wrk[1 * bc->fieldOffset + bc->idM]  |
-|     2 | scalar01    |  bc->wrk[2 * bc->fieldOffset + bc->idM]  |
-|     3 | scalar02    |  bc->wrk[3 * bc->fieldOffset + bc->idM]  |
+|     1 | scalar02    |  bc->wrk[1 * bc->fieldOffset + bc->idM]  |
+|     2 | unused      |  bc->wrk[2 * bc->fieldOffset + bc->idM]  |
+|     3 | unused      |  bc->wrk[3 * bc->fieldOffset + bc->idM]  |
 |     4 | unused      |  bc->wrk[4 * bc->fieldOffset + bc->idM]  |
 |     5 | unused      |  bc->wrk[5 * bc->fieldOffset + bc->idM]  |
 |     6 | unused      |  bc->wrk[6 * bc->fieldOffset + bc->idM]  |
 ------------------------------------------------------------------
 
-!alert warning
-Allocation of `nrs->usrwrk` and `nrs->o_usrwrk` is done automatically by
-`NekRSSeparateDomainProblem`. If you attempt to run a NekRS input file that accesses `bc->wrk` in the
-`.oudf` file *without* a Cardinal executable (i.e. using something like
-`nrsmpi case 4`), then that scratch space will have to be manually allocated in
-the `.udf` file, or else your input will seg fault. This use case will not be typically
-encountered by most users, but if you really do want to run the NekRS input files
-intended for a Cardinal case with the NekRS executable (perhaps for debugging),
-we recommend simply replacing `bc->wrk` by a dummy value, such as `bc->s = 0.0`
-for the inlet scalar use case. This just replaces a value that normally comes from MOOSE by a fixed
-value. All other aspects of the NekRS case files should not require modification.
+!include seg_fault_warning.md
 
 In other words, the scratch space slots contain pointwise values for each (singly-valued)
 postprocessor value on all the [!ac](GLL) points on the corresponding boundary.
 So, the values in each "slot" correspond to the following postprocessors:
 
-- Slot 0: `inlet_V` postprocessor value
-- Slot 1: `inlet_T` postprocessor value
-- Slot 2: `inlet_S01` postprocessor value
-- Slot 3: `inlet_S02` postprocessor value
-- Slot 4: `inlet_S03` postprocessor value
+- Slot with velocity: `inlet_V` postprocessor value
+- Slot with temperature: `inlet_T` postprocessor value
+- Slot with scalar01: `inlet_S01` postprocessor value
+- Slot with scalar02: `inlet_S02` postprocessor value
+- Slot with scalar03: `inlet_S03` postprocessor value
 
 This allows the user the freedom to choose what type of profile they want to implement at the inlet boundary, i.e. flat or fully-developed. Below are a few example implementations.
 

--- a/doc/content/source/problems/seg_fault_warning.md
+++ b/doc/content/source/problems/seg_fault_warning.md
@@ -1,0 +1,11 @@
+!alert warning
+Allocation of `nrs->usrwrk` and `nrs->o_usrwrk` is done automatically.
+If you attempt to run a NekRS input file that accesses `bc->wrk` in the
+`.oudf` file *without* a Cardinal executable (e.g. like
+`nrsmpi case 4`), then that scratch space will have to be manually allocated in
+the `.udf` file, or else your input will seg fault. This will not be typically
+encountered by most users, but if you really do want to run the NekRS input files
+intended for a Cardinal case with the NekRS executable (perhaps for debugging),
+we recommend simply replacing `bc->wrk` by a dummy value, such as `bc->flux = 0.0`
+for the boundary heat flux use case. This just replaces a value that normally comes from MOOSE by a fixed
+value. All other aspects of the NekRS case files should not require modification.

--- a/src/base/NekRSSeparateDomainProblem.C
+++ b/src/base/NekRSSeparateDomainProblem.C
@@ -142,42 +142,42 @@ NekRSSeparateDomainProblem::NekRSSeparateDomainProblem(const InputParameters & p
 
   // TODO, add checks of BCs if using inlet coupling
 
-  // Determine an appropriate default usrwrk indexing; the ordering will always be
-  //   0: velocity         (if _inlet_coupling is true)
-  //   1: temperature      (if _inlet_coupling is true and NekRS has temperature solve)
-  //   2: scalar01         (if _inlet_coupling is true and _scalar01_coupling is true)
-  //   3: scalar02         (if _inlet_coupling is true and _scalar02_coupling is true)
-  //   4: scalar03         (if _inlet_coupling is true and _scalar03_coupling is true)
-  //
-  // The most we will do is skip allocating terms at the end of this ordering if we
-  // don't need them. We never change the ordering of "earlier" terms.
+  // Determine an appropriate default usrwrk indexing; the ordering will always be as
+  // follows (except that unused terms will be deleted if not needed for coupling)
+  //   velocity         (if _inlet_coupling is true)
+  //   temperature      (if _inlet_coupling is true and NekRS has temperature solve)
+  //   scalar01         (if _inlet_coupling is true and _scalar01_coupling is true)
+  //   scalar02         (if _inlet_coupling is true and _scalar02_coupling is true)
+  //   scalar03         (if _inlet_coupling is true and _scalar03_coupling is true)
   std::vector<std::string> str_indices;
-
-  // there are no necessary coupling arrays if there is not inlet coupling
+  int start = 0;
   if (_inlet_coupling)
   {
-    str_indices = {"velocity", "temperature", "scalar01", "scalar02", "scalar03"};
-    indices.boundary_velocity = 0 * nekrs::scalarFieldOffset();
-    indices.boundary_temperature = 1 * nekrs::scalarFieldOffset();
-    indices.boundary_scalar01 = 2 * nekrs::scalarFieldOffset();
-    indices.boundary_scalar02 = 3 * nekrs::scalarFieldOffset();
-    indices.boundary_scalar03 = 4 * nekrs::scalarFieldOffset();
+    indices.boundary_velocity = start++ * nekrs::scalarFieldOffset();
+    str_indices.push_back("velocity");
 
-    // progressively erase terms from the back if we don't need them
-    if (!_scalar03_coupling)
+    if (nekrs::hasTemperatureSolve())
     {
-      str_indices.erase(str_indices.end());
-      if (!_scalar02_coupling)
-      {
-        str_indices.erase(str_indices.end());
-        if (!_scalar01_coupling)
-        {
-          str_indices.erase(str_indices.end());
+      indices.boundary_temperature = start++ * nekrs::scalarFieldOffset();
+      str_indices.push_back("temperature");
+    }
 
-          if (!nekrs::hasTemperatureSolve())
-            str_indices.erase(str_indices.end());
-        }
-      }
+    if (_scalar01_coupling)
+    {
+      indices.boundary_scalar01 = start++ * nekrs::scalarFieldOffset();
+      str_indices.push_back("scalar01");
+    }
+
+    if (_scalar02_coupling)
+    {
+      indices.boundary_scalar02 = start++ * nekrs::scalarFieldOffset();
+      str_indices.push_back("scalar02");
+    }
+
+    if (_scalar03_coupling)
+    {
+      indices.boundary_scalar03 = start++ * nekrs::scalarFieldOffset();
+      str_indices.push_back("scalar03");
     }
   }
 

--- a/test/tests/conduction/identical_volume/cube/cube.udf
+++ b/test/tests/conduction/identical_volume/cube/cube.udf
@@ -10,7 +10,7 @@ void UDF_LoadKernels(occa::properties & kernelInfo)
 void userq(nrs_t * nrs, dfloat time, occa::memory o_S, occa::memory o_FS)
 {
   auto mesh = nrs->cds->mesh[0];
-  mooseHeatSourceKernel(mesh->Nelements, nrs->cds->fieldOffset[0], nrs->o_usrwrk, o_FS);
+  mooseHeatSourceKernel(mesh->Nelements, 0, nrs->o_usrwrk, o_FS);
 }
 
 void UDF_Setup(nrs_t *nrs)

--- a/test/tests/conduction/nonidentical_volume/cylinder/cylinder.udf
+++ b/test/tests/conduction/nonidentical_volume/cylinder/cylinder.udf
@@ -14,7 +14,7 @@ void userq(nrs_t * nrs, dfloat time, occa::memory o_S, occa::memory o_FS)
   auto mesh = nrs->cds->mesh[0];
 
   // pass the necessary parameters into the kernel we define in the .oudf file
-  mooseHeatSourceKernel(mesh->Nelements, nrs->cds->fieldOffset[0], nrs->o_usrwrk, o_FS);
+  mooseHeatSourceKernel(mesh->Nelements, 0, nrs->o_usrwrk, o_FS);
 }
 
 void UDF_Setup(nrs_t *nrs)

--- a/test/tests/conduction/nonidentical_volume/nondimensional/cylinder.udf
+++ b/test/tests/conduction/nonidentical_volume/nondimensional/cylinder.udf
@@ -10,7 +10,7 @@ void UDF_LoadKernels(occa::properties & kernelInfo)
 void userq(nrs_t * nrs, dfloat time, occa::memory o_S, occa::memory o_FS)
 {
   auto mesh = nrs->cds->mesh[0];
-  mooseHeatSourceKernel(mesh->Nelements, nrs->cds->fieldOffset[0], nrs->o_usrwrk, o_FS);
+  mooseHeatSourceKernel(mesh->Nelements, 0, nrs->o_usrwrk, o_FS);
 }
 
 void UDF_Setup(nrs_t *nrs)

--- a/test/tests/deformation/mesh-velocity-areas/pipe.oudf
+++ b/test/tests/deformation/mesh-velocity-areas/pipe.oudf
@@ -13,9 +13,9 @@ void meshVelocityDirichletConditions(bcData *bc)
 {
   if(bc->id==2)
   {
-    bc->meshu = bc->wrk[bc->idM + 2*bc->fieldOffset];
-    bc->meshv = bc->wrk[bc->idM + 3*bc->fieldOffset];
-    bc->meshw = bc->wrk[bc->idM + 4*bc->fieldOffset];
+    bc->meshu = bc->wrk[bc->idM + 1*bc->fieldOffset];
+    bc->meshv = bc->wrk[bc->idM + 2*bc->fieldOffset];
+    bc->meshw = bc->wrk[bc->idM + 3*bc->fieldOffset];
   }
 }
 

--- a/test/tests/deformation/mesh-velocity-nondimensional/pipe.oudf
+++ b/test/tests/deformation/mesh-velocity-nondimensional/pipe.oudf
@@ -13,9 +13,9 @@ void meshVelocityDirichletConditions(bcData *bc)
 {
   if(bc->id==2)
   {
-    bc->meshu = bc->wrk[bc->idM + 2*bc->fieldOffset];
-    bc->meshv = bc->wrk[bc->idM + 3*bc->fieldOffset];
-    bc->meshw = bc->wrk[bc->idM + 4*bc->fieldOffset];
+    bc->meshu = bc->wrk[bc->idM + 1*bc->fieldOffset];
+    bc->meshv = bc->wrk[bc->idM + 2*bc->fieldOffset];
+    bc->meshw = bc->wrk[bc->idM + 3*bc->fieldOffset];
   }
 }
 

--- a/test/tests/deformation/simple-cube/nekbox.udf
+++ b/test/tests/deformation/simple-cube/nekbox.udf
@@ -10,7 +10,7 @@ void UDF_LoadKernels(occa::properties & kernelInfo)
 void userq(nrs_t * nrs, dfloat time, occa::memory o_S, occa::memory o_FS)
 {
   auto mesh = nrs->cds->mesh[0];
-  mooseHeatSourceKernel(mesh->Nelements, nrs->cds->fieldOffset[0], nrs->o_usrwrk, o_FS);
+  mooseHeatSourceKernel(mesh->Nelements, 0, nrs->o_usrwrk, o_FS);
 }
 
 void UDF_Setup(nrs_t *nrs)

--- a/test/tests/nek_errors/insufficient_scratch/brick.par
+++ b/test/tests/nek_errors/insufficient_scratch/brick.par
@@ -7,7 +7,7 @@
   dt = 5.0e-4
   polynomialOrder = 2
   writeControl = steps
-  writeInterval = 2
+  writeInterval = 20
 
 [VELOCITY]
   viscosity = 1.0

--- a/test/tests/nek_errors/insufficient_scratch/brick.par
+++ b/test/tests/nek_errors/insufficient_scratch/brick.par
@@ -23,3 +23,15 @@
 [TEMPERATURE]
   residualTol = 1e-6
   boundaryTypeMap = t, f, f, f, f, f
+
+[SCALAR01]
+  residualTol = 1e-6
+  boundaryTypeMap = t, t, t, t, t, t
+
+[SCALAR02]
+  residualTol = 1e-6
+  boundaryTypeMap = t, t, t, t, t, t
+
+[SCALAR03]
+  residualTol = 1e-6
+  boundaryTypeMap = t, t, t, t, t, t

--- a/test/tests/nek_errors/insufficient_scratch/brick2.par
+++ b/test/tests/nek_errors/insufficient_scratch/brick2.par
@@ -15,7 +15,6 @@
   stressFormulation = true
 
 [MESH]
-#  boundaryTypeMap = symy,symy,inlet,outlet,symz,symz
   solver = elasticity
   file = "brick.re2"
 

--- a/test/tests/nek_errors/insufficient_scratch/tests
+++ b/test/tests/nek_errors/insufficient_scratch/tests
@@ -53,9 +53,9 @@
   [too_small_f]
     type = RunException
     input = nek_separate_domain.i
-    cli_args = "Problem/n_usrwrk_slots=3 Problem/coupled_scalars='scalar02'"
+    cli_args = "Problem/n_usrwrk_slots=2 Problem/coupled_scalars='scalar02'"
     expect_err = "You did not allocate enough scratch space for Cardinal to complete its coupling!\n"
-                 "'n_usrwrk_slots' must be greater than or equal to 4"
+                 "'n_usrwrk_slots' must be greater than or equal to 3"
     requirement = "The system shall error if the user enters too small a scratch space allocation; "
                   "NekRSSeparateDomainProblem always requires at least 4 slots if scalar02 is coupled "
     required_objects = 'NekRSProblem'
@@ -63,9 +63,9 @@
   [too_small_g]
     type = RunException
     input = nek_separate_domain.i
-    cli_args = "Problem/n_usrwrk_slots=4 Problem/coupled_scalars='scalar03'"
+    cli_args = "Problem/n_usrwrk_slots=2 Problem/coupled_scalars='scalar03'"
     expect_err = "You did not allocate enough scratch space for Cardinal to complete its coupling!\n"
-                 "'n_usrwrk_slots' must be greater than or equal to 5"
+                 "'n_usrwrk_slots' must be greater than or equal to 3"
     requirement = "The system shall error if the user enters too small a scratch space allocation; "
                   "NekRSSeparateDomainProblem always requires at least 5 slots if scalar03 is coupled "
     required_objects = 'NekRSProblem'

--- a/test/tests/nek_errors/insufficient_scratch/tests
+++ b/test/tests/nek_errors/insufficient_scratch/tests
@@ -12,7 +12,7 @@
   [too_small_b]
     type = RunException
     input = nek.i
-    cli_args = "Mesh/volume=true Problem/n_usrwrk_slots=1"
+    cli_args = "Mesh/boundary='6' Mesh/volume=true Problem/n_usrwrk_slots=1"
     expect_err = "You did not allocate enough scratch space for Cardinal to complete its coupling!\n"
                  "'n_usrwrk_slots' must be greater than or equal to 2"
     requirement = "The system shall error if the user enters too small a scratch space allocation; "
@@ -22,9 +22,9 @@
   [too_small_c]
     type = RunException
     input = nek.i
-    cli_args = "Mesh/volume=true Problem/casename='brick2' Problem/has_heat_source=false Problem/n_usrwrk_slots=4"
+    cli_args = "Mesh/volume=true Problem/casename='brick2' Problem/has_heat_source=false Problem/n_usrwrk_slots=1"
     expect_err = "You did not allocate enough scratch space for Cardinal to complete its coupling!\n"
-                 "'n_usrwrk_slots' must be greater than or equal to 5"
+                 "'n_usrwrk_slots' must be greater than or equal to 3"
     requirement = "The system shall error if the user enters too small a scratch space allocation; "
                   "NekRSProblem always requires at least 5 slots if moving meshes are enabled"
     required_objects = 'NekRSProblem'


### PR DESCRIPTION
This FY we are adding support for Nek to interface with MOOSE's stochastic tools module. This means that we need to add another "slot" to `nrs->usrwrk` to hold that incoming information. If we were to keep our current convention where the "ordering" in `nrs->usrwrk` never changes, this means that we're going to end up with quite a lot of unused space allocated (e.g. the first 6 slots) if we only are interested in stochastic modeling.

This PR changes our convention to NOT retain the same order in `nrs->usrwrk` all the time. In other words, if there is a slot in `nrs->usrwrk` that a particular case does not need, we shift all the other slots forward by one, so that there's no "unused gaps" in this array.

I _think_ I caught all places in the documentation and test suite where we need to change this. @anshchaube @ahuxford what do you think of this design change? I think it is nominally only really going to pop up in your use cases, since your situations had more occurrences where there were dummy, empty slots. Are there any considerations I haven't thought of here? If you are both agreeable to this change:

- @anshchaube would you please do a read through `NekRSProblem.md` and make sure I didn't miss anything referring to a rigid order in scratch space?
- @ahuxford would you please do a read through `NekRSSeparateDomainProblem.md` and make sure I didn't miss anything referring to a rigid order in scratch space?

Please note that you'll both probably have to update any local files you have on unmerged branches. Hopefully this isn't too onerous.