### PR TITLE
Add base class to disable unused parameters.

### DIFF
--- a/include/base/CardinalProblem.h
+++ b/include/base/CardinalProblem.h
@@ -1,0 +1,39 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#pragma once
+
+#include "ExternalProblem.h"
+
+/**
+ * Base class for all MOOSE wrappings in Cardinal
+ */
+class CardinalProblem : public ExternalProblem
+{
+public:
+  CardinalProblem(const InputParameters & params);
+
+  static InputParameters validParams();
+
+  /**
+   * Check whether the user has already created a variable using one of the protected
+   * names that the wrapping is using.
+   * @param[in] name variable name
+   */
+  void checkDuplicateVariableName(const std::string & name) const;
+};

--- a/include/base/NekRSProblemBase.h
+++ b/include/base/NekRSProblemBase.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "ExternalProblem.h"
+#include "CardinalProblem.h"
 #include "NekTimeStepper.h"
 #include "NekRSMesh.h"
 #include "Transient.h"
@@ -32,7 +32,7 @@
  * - specifying nondimensional scales
  * - running a single time step of NekRS
  */
-class NekRSProblemBase : public ExternalProblem
+class NekRSProblemBase : public CardinalProblem
 {
 public:
   NekRSProblemBase(const InputParameters & params);
@@ -79,13 +79,6 @@ public:
    */
   void mapFaceDataToNekVolume(const unsigned int & e, const unsigned int & var_num,
     const Real & multiplier, double ** outgoing_data);
-
-  /**
-   * Check whether the user has already created a variable using one of the protected
-   * names that the NekRS wrapping is using.
-   * @param[in] name variable name
-   */
-  void checkDuplicateVariableName(const std::string & name) const;
 
   /**
    * Write NekRS solution field file

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -20,7 +20,7 @@
 
 #define LIBMESH
 
-#include "ExternalProblem.h"
+#include "CardinalProblem.h"
 #include "PostprocessorInterface.h"
 #include "CardinalEnums.h"
 
@@ -30,7 +30,7 @@
 /**
  * Base class for all MOOSE wrappings of OpenMC
  */
-class OpenMCProblemBase : public ExternalProblem, public PostprocessorInterface
+class OpenMCProblemBase : public CardinalProblem, public PostprocessorInterface
 {
 public:
   OpenMCProblemBase(const InputParameters & params);
@@ -76,13 +76,6 @@ public:
    * @return OpenMC enum
    */
   openmc::TallyEstimator tallyEstimator(tally::TallyEstimatorEnum estimator) const;
-
-  /**
-   * Check whether the user has already created a variable using one of the protected
-   * names that the OpenMC wrapping is using.
-   * @param[in] name variable name
-   */
-  void checkDuplicateVariableName(const std::string & name) const;
 
   /// Run a k-eigenvalue OpenMC simulation
   void externalSolve() override;

--- a/src/base/CardinalProblem.C
+++ b/src/base/CardinalProblem.C
@@ -1,0 +1,65 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#include "CardinalProblem.h"
+#include "NonlinearSystem.h"
+#include "AuxiliarySystem.h"
+
+InputParameters
+CardinalProblem::validParams()
+{
+  InputParameters params = ExternalProblem::validParams();
+
+  // these parameters don't do anything for ExternalProblem, and instead just
+  // clutter the MooseDocs
+  params.suppressParameter<bool>("allow_invalid_solution");
+  params.suppressParameter<bool>("boundary_restricted_elem_integrity_check");
+  params.suppressParameter<bool>("boundary_restricted_node_integrity_check");
+  params.suppressParameter<bool>("check_uo_aux_state");
+  params.suppressParameter<bool>("error_on_jacobian_nonzero_reallocation");
+  params.suppressParameter<std::vector<std::vector<TagName>>>("extra_tag_matrices");
+  params.suppressParameter<std::vector<TagName>>("extra_tag_solutions");
+  params.suppressParameter<std::vector<std::vector<TagName>>>("extra_tag_vectors");
+  params.suppressParameter<bool>("force_restart");
+  params.suppressParameter<bool>("fv_bcs_integrity_check");
+  params.suppressParameter<bool>("material_dependency_check");
+  params.suppressParameter<unsigned int>("near_null_space_dimension");
+  params.suppressParameter<unsigned int>("null_space_dimension");
+  params.suppressParameter<unsigned int>("transpose_null_space_dimension");
+
+  return params;
+}
+
+CardinalProblem::CardinalProblem(const InputParameters & params)
+  : ExternalProblem(params)
+{
+}
+
+void
+CardinalProblem::checkDuplicateVariableName(const std::string & name) const
+{
+  if (_aux.get()->hasVariable(name))
+    mooseError("Cardinal is trying to add an auxiliary variable named '", name,
+      "', but you already have a variable by this name. Please choose a different name "
+      "for the auxiliary variable you are adding.");
+
+  if (_nl[0].get()->hasVariable(name))
+    mooseError("Cardinal is trying to add a nonlinear variable named '", name,
+      "', but you already have a variable by this name. Please choose a different name "
+      "for the nonlinear variable you are adding.");
+}

--- a/src/base/NekRSProblemBase.C
+++ b/src/base/NekRSProblemBase.C
@@ -37,7 +37,7 @@ bool NekRSProblemBase::_first = true;
 InputParameters
 NekRSProblemBase::validParams()
 {
-  InputParameters params = ExternalProblem::validParams();
+  InputParameters params = CardinalProblem::validParams();
   params.addParam<std::string>(
       "casename",
       "Case name for the NekRS input files; "
@@ -106,7 +106,7 @@ NekRSProblemBase::validParams()
 }
 
 NekRSProblemBase::NekRSProblemBase(const InputParameters & params)
-  : ExternalProblem(params),
+  : CardinalProblem(params),
     _serialized_solution(NumericVector<Number>::build(_communicator).release()),
     _nondimensional(getParam<bool>("nondimensional")),
     _U_ref(getParam<Real>("U_ref")),
@@ -416,7 +416,7 @@ NekRSProblemBase::fillAuxVariable(const unsigned int var_number, const double * 
 void
 NekRSProblemBase::initialSetup()
 {
-  ExternalProblem::initialSetup();
+  CardinalProblem::initialSetup();
 
   auto executioner = _app.getExecutioner();
   _transient_executioner = dynamic_cast<Transient *>(executioner);
@@ -756,20 +756,6 @@ NekRSProblemBase::addTemperatureVariable()
   // chose to name the temperature variable. For everything else, we just use
   // the name of the output parameter.
   _var_names.push_back("temp");
-}
-
-void
-NekRSProblemBase::checkDuplicateVariableName(const std::string & name) const
-{
-  if (_aux.get()->hasVariable(name))
-    mooseError("Cardinal is trying to add an auxiliary variable named '", name,
-      "', but you already have a variable by this name. Please choose a different name "
-      "for the auxiliary variable you are adding.");
-
-  if (_nl[0].get()->hasVariable(name))
-    mooseError("Cardinal is trying to add a nonlinear variable named '", name,
-      "', but you already have a variable by this name. Please choose a different name "
-      "for the nonlinear variable you are adding.");
 }
 
 void

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -39,7 +39,7 @@
 InputParameters
 OpenMCProblemBase::validParams()
 {
-  InputParameters params = ExternalProblem::validParams();
+  InputParameters params = CardinalProblem::validParams();
   params.addParam<PostprocessorName>(
       "power", "Power (Watts) to normalize the OpenMC tallies; only used for k-eigenvalue mode");
   params.addParam<PostprocessorName>(
@@ -72,7 +72,7 @@ OpenMCProblemBase::validParams()
 }
 
 OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
-  : ExternalProblem(params),
+  : CardinalProblem(params),
     PostprocessorInterface(this),
     _verbose(getParam<bool>("verbose")),
     _reuse_source(getParam<bool>("reuse_source")),
@@ -531,20 +531,6 @@ OpenMCProblemBase::tallyMeanAcrossBins(std::vector<openmc::Tally *> tally, const
     n += t->n_realizations_;
 
   return tallySumAcrossBins(tally, score) / n;
-}
-
-void
-OpenMCProblemBase::checkDuplicateVariableName(const std::string & name) const
-{
-  if (_aux.get()->hasVariable(name))
-    mooseError("Cardinal is trying to add an auxiliary variable named '", name,
-      "', but you already have a variable by this name. Please choose a different name "
-      "for the auxiliary variable you are adding.");
-
-  if (_nl[0].get()->hasVariable(name))
-    mooseError("Cardinal is trying to add a nonlinear variable named '", name,
-      "', but you already have a variable by this name. Please choose a different name "
-      "for the nonlinear variable you are adding.");
 }
 
 std::string


### PR DESCRIPTION
This disables a bunch of user parameters inherited from MOOSE which don't actually do anything, but give the impression that there's lots of extra documentation on the MooseDocs website.