### PR TITLE
Allow scratch allocation via Cardinal for NekRSStandaloneProblem

### DIFF
--- a/include/actions/NekInitAction.h
+++ b/include/actions/NekInitAction.h
@@ -21,9 +21,11 @@
 #include "MooseObjectAction.h"
 
 /**
- * Initialize Nek application by calling nekrs::setup.
- * This action detects whether Nek should be initialized based on whether
- * NekRSProblem or NekRSStandaloneProblem are used as the Problem.
+ * Initialize Nek application by calling nekrs::setup. This needs to be
+ * in an action so that it occurs before the [Mesh] is constructed (which
+ * is normally the first MOOSE object constructed) because we build the
+ * [Mesh] relying on internal stuff in NekRS, which needs to be initialized
+ * at that point.
  */
 class NekInitAction : public MooseObjectAction
 {
@@ -37,6 +39,9 @@ public:
 protected:
   /// whether a casename was provided in the input file
   const bool _casename_in_input_file;
+
+  /// whether the user specified how many scratch slots to allocate
+  const bool _specified_scratch;
 
   /**
    * Number of slices/slots to allocate in nrs->usrwrk to hold fields

--- a/include/base/NekRSProblem.h
+++ b/include/base/NekRSProblem.h
@@ -226,7 +226,4 @@ protected:
 
   /// volumetric heat source variable read from by nekRS
   unsigned int _heat_source_var;
-
-  /// quantities to write to  nrs->usrwrk (and the order to write them)
-  MultiMooseEnum _usrwrk_indices;
 };

--- a/include/base/NekRSProblemBase.h
+++ b/include/base/NekRSProblemBase.h
@@ -148,7 +148,7 @@ public:
    * Print information showing how the entries in nrs->usrwrk and nrs->o_usrwrk
    * are populated by Cardinal.
    */
-  void printScratchSpaceInfo(const MultiMooseEnum & indices) const;
+  void printScratchSpaceInfo() const;
 
   /**
    * Get the number of usrwrk slots allocated
@@ -470,6 +470,9 @@ protected:
    *    is set to true.
    */
   synchronization::SynchronizationEnum _synchronization_interval;
+
+  /// quantities to write to nrs->usrwrk (and the order to write them)
+  std::vector<std::string> _usrwrk_indices;
 
   /// flag to indicate whether this is the first pass to serialize the solution
   static bool _first;

--- a/include/base/NekRSSeparateDomainProblem.h
+++ b/include/base/NekRSSeparateDomainProblem.h
@@ -121,9 +121,6 @@ protected:
   /// Postprocessor containing the signal of when a synchronization has occurred
   const PostprocessorValue * _transfer_in = nullptr;
 
-  /// quantities to write to  nrs->usrwrk (and the order to write them)
-  MultiMooseEnum _usrwrk_indices;
-
   /// Which NekRS mesh to act on
   const MooseEnum _pp_mesh;
 };

--- a/src/actions/NekInitAction.C
+++ b/src/actions/NekInitAction.C
@@ -52,7 +52,7 @@ NekInitAction::validParams()
 NekInitAction::NekInitAction(const InputParameters & parameters)
   : MooseObjectAction(parameters),
     _casename_in_input_file(isParamValid("casename")),
-    _specified_scratch(parameters.isParamSetByUser("n_userwrk_slots")),
+    _specified_scratch(parameters.isParamSetByUser("n_usrwrk_slots")),
     _n_usrwrk_slots(getParam<unsigned int>("n_usrwrk_slots"))
 {
 }

--- a/src/base/NekRSProblem.C
+++ b/src/base/NekRSProblem.C
@@ -74,8 +74,7 @@ NekRSProblem::validParams()
 NekRSProblem::NekRSProblem(const InputParameters & params)
   : NekRSProblemBase(params),
     _has_heat_source(getParam<bool>("has_heat_source")),
-    _conserve_flux_by_sideset(getParam<bool>("conserve_flux_by_sideset")),
-    _usrwrk_indices(MultiMooseEnum("flux heat_source mesh_velocity_x mesh_velocity_y mesh_velocity_z unused"))
+    _conserve_flux_by_sideset(getParam<bool>("conserve_flux_by_sideset"))
 {
   nekrs::setAbsoluteTol(getParam<Real>("normalization_abs_tol"));
   nekrs::setRelativeTol(getParam<Real>("normalization_rel_tol"));
@@ -90,18 +89,17 @@ NekRSProblem::NekRSProblem(const InputParameters & params)
   //   mesh_velocity_x   (if nekrs::hasElasticitySolver() is true)
   //   mesh_velocity_y   (if nekrs::hasElasticitySolver() is true)
   //   mesh_velocity_z   (if nekrs::hasElasticitySolver() is true)
-  std::vector<std::string> str_indices;
   int start = 0;
   if (_boundary)
   {
     indices.flux = start++ * nekrs::scalarFieldOffset();
-    str_indices.push_back("flux");
+    _usrwrk_indices.push_back("flux");
   }
 
   if (_volume && _has_heat_source)
   {
     indices.heat_source = start++ * nekrs::scalarFieldOffset();
-    str_indices.push_back("heat_source");
+    _usrwrk_indices.push_back("heat_source");
   }
 
   if (nekrs::hasElasticitySolver())
@@ -109,18 +107,16 @@ NekRSProblem::NekRSProblem(const InputParameters & params)
     indices.mesh_velocity_x = start++ * nekrs::scalarFieldOffset();
     indices.mesh_velocity_y = start++ * nekrs::scalarFieldOffset();
     indices.mesh_velocity_z = start++ * nekrs::scalarFieldOffset();
-    str_indices.push_back("mesh_velocity_x");
-    str_indices.push_back("mesh_velocity_y");
-    str_indices.push_back("mesh_velocity_z");
+    _usrwrk_indices.push_back("mesh_velocity_x");
+    _usrwrk_indices.push_back("mesh_velocity_y");
+    _usrwrk_indices.push_back("mesh_velocity_z");
   }
 
-  _minimum_scratch_size_for_coupling = str_indices.size();
+  _minimum_scratch_size_for_coupling = _usrwrk_indices.size();
   for (unsigned int i = _minimum_scratch_size_for_coupling; i < _n_usrwrk_slots; ++i)
-    str_indices.push_back("unused");
+    _usrwrk_indices.push_back("unused");
 
-  _usrwrk_indices = str_indices;
-
-  printScratchSpaceInfo(_usrwrk_indices);
+  printScratchSpaceInfo();
 
   if (nekrs::hasMovingMesh())
   {

--- a/src/base/NekRSProblemBase.C
+++ b/src/base/NekRSProblemBase.C
@@ -315,7 +315,7 @@ NekRSProblemBase::writeFieldFile(const Real & step_end_time, const int & step) c
 }
 
 void
-NekRSProblemBase::printScratchSpaceInfo(const MultiMooseEnum & indices) const
+NekRSProblemBase::printScratchSpaceInfo() const
 {
   if (_n_usrwrk_slots < _minimum_scratch_size_for_coupling)
     mooseError("You did not allocate enough scratch space for Cardinal to complete its coupling!\n"
@@ -326,16 +326,16 @@ NekRSProblemBase::printScratchSpaceInfo(const MultiMooseEnum & indices) const
                       VariadicTableColumnFormat::AUTO,
                       VariadicTableColumnFormat::AUTO});
 
-  for (int i = 0; i < indices.size(); ++i)
-    vt.addRow(i, indices[i], " bc->wrk[" + std::to_string(i) + " * bc->fieldOffset + bc->idM] ");
+  for (int i = 0; i < _usrwrk_indices.size(); ++i)
+    vt.addRow(i, _usrwrk_indices[i], " bc->wrk[" + std::to_string(i) + " * bc->fieldOffset + bc->idM] ");
 
-  if (indices.size() == 0)
+  if (_usrwrk_indices.size() == 0)
   {
     _console << "Skipping allocation of NekRS scratch space because 'n_usrwrk_slots' is 0\n" << std::endl;
   }
   else
   {
-    _console << "Quantities written into NekRS scratch space:" << std::endl;
+    _console << "\nQuantities written into NekRS scratch space:" << std::endl;
     vt.print(_console);
     _console << std::endl;
   }

--- a/src/base/NekRSSeparateDomainProblem.C
+++ b/src/base/NekRSSeparateDomainProblem.C
@@ -65,7 +65,6 @@ NekRSSeparateDomainProblem::NekRSSeparateDomainProblem(const InputParameters & p
     _scalar01_coupling(false),
     _scalar02_coupling(false),
     _scalar03_coupling(false),
-    _usrwrk_indices(MultiMooseEnum("velocity temperature scalar01 scalar02 scalar03 unused")),
     _pp_mesh(getParam<MooseEnum>("nek_mesh"))
 {
   if (_nek_mesh->exactMirror())
@@ -154,49 +153,45 @@ NekRSSeparateDomainProblem::NekRSSeparateDomainProblem(const InputParameters & p
   //   scalar01         (if _inlet_coupling is true and _scalar01_coupling is true)
   //   scalar02         (if _inlet_coupling is true and _scalar02_coupling is true)
   //   scalar03         (if _inlet_coupling is true and _scalar03_coupling is true)
-  std::vector<std::string> str_indices;
   int start = 0;
   if (_inlet_coupling)
   {
     indices.boundary_velocity = start++ * nekrs::scalarFieldOffset();
-    str_indices.push_back("velocity");
+    _usrwrk_indices.push_back("velocity");
 
     if (nekrs::hasTemperatureSolve())
     {
       indices.boundary_temperature = start++ * nekrs::scalarFieldOffset();
-      str_indices.push_back("temperature");
+      _usrwrk_indices.push_back("temperature");
     }
 
     if (_scalar01_coupling)
     {
       indices.boundary_scalar01 = start++ * nekrs::scalarFieldOffset();
-      str_indices.push_back("scalar01");
+      _usrwrk_indices.push_back("scalar01");
     }
 
     if (_scalar02_coupling)
     {
       indices.boundary_scalar02 = start++ * nekrs::scalarFieldOffset();
-      str_indices.push_back("scalar02");
+      _usrwrk_indices.push_back("scalar02");
     }
 
     if (_scalar03_coupling)
     {
       indices.boundary_scalar03 = start++ * nekrs::scalarFieldOffset();
-      str_indices.push_back("scalar03");
+      _usrwrk_indices.push_back("scalar03");
     }
   }
 
-  _minimum_scratch_size_for_coupling = str_indices.size();
+  _minimum_scratch_size_for_coupling = _usrwrk_indices.size();
   for (unsigned int i = _minimum_scratch_size_for_coupling; i < _n_usrwrk_slots; ++i)
-    str_indices.push_back("unused");
+    _usrwrk_indices.push_back("unused");
 
-  _usrwrk_indices = str_indices;
-
-  printScratchSpaceInfo(_usrwrk_indices);
+  printScratchSpaceInfo();
 
   if (_pp_mesh!="fluid")
     mooseError("NekRSSeparateDomainProblem should only act on the Nek fluid mesh.");
-
 }
 
 NekRSSeparateDomainProblem::~NekRSSeparateDomainProblem() { nekrs::freeScratch(); }

--- a/src/base/NekRSSeparateDomainProblem.C
+++ b/src/base/NekRSSeparateDomainProblem.C
@@ -71,6 +71,11 @@ NekRSSeparateDomainProblem::NekRSSeparateDomainProblem(const InputParameters & p
   if (_nek_mesh->exactMirror())
     mooseError("An exact mesh mirror is not yet supported for NekRSSeparateDomainProblem!");
 
+  if (nekrs::hasMovingMesh())
+    mooseWarning("NekRSSeparateDomainProblem currently does not transfer mesh displacements "
+                 "from NekRS to Cardinal. The [Mesh] object in Cardinal won't reflect "
+                 "NekRS's internal mesh changes. This may affect your postprocessor values.");
+
   // check scalar01-03_coupling provided
   for (const auto & s : _coupled_scalars)
   {

--- a/src/base/NekRSStandaloneProblem.C
+++ b/src/base/NekRSStandaloneProblem.C
@@ -47,5 +47,11 @@ NekRSStandaloneProblem::NekRSStandaloneProblem(const InputParameters & params)
     mooseWarning("NekRSStandaloneProblem currently does not transfer mesh displacements "
                  "from NekRS to Cardinal. The [Mesh] object in Cardinal won't reflect "
                  "NekRS's internal mesh changes. This may affect your postprocessor values.");
+
+  for (unsigned int i = 0; i < _n_usrwrk_slots; ++i)
+    _usrwrk_indices.push_back("unused");
+
+  _minimum_scratch_size_for_coupling = _n_usrwrk_slots;
+  printScratchSpaceInfo();
 }
 #endif

--- a/src/base/NekRSStandaloneProblem.C
+++ b/src/base/NekRSStandaloneProblem.C
@@ -46,12 +46,6 @@ NekRSStandaloneProblem::NekRSStandaloneProblem(const InputParameters & params)
   if (nekrs::hasMovingMesh())
     mooseWarning("NekRSStandaloneProblem currently does not transfer mesh displacements "
                  "from NekRS to Cardinal. The [Mesh] object in Cardinal won't reflect "
-                 "nekRS's internal mesh changes. This may affect your postprocessor values.");
-
-  // Cardinal does not automatically allocate any scratch space for this class
-  if (params.isParamSetByUser("n_usrwrk_slots"))
-    checkUnusedParam(params, "n_usrwrk_slots", "using running NekRS as a standalone "
-      "problem through Cardinal");
-  _n_usrwrk_slots = 0;
+                 "NekRS's internal mesh changes. This may affect your postprocessor values.");
 }
 #endif

--- a/test/tests/nek_errors/deformation/tests
+++ b/test/tests/nek_errors/deformation/tests
@@ -49,15 +49,13 @@
   [missing_nekrsproblem]
     type = RunException
     input = nek.i
-    cli_args = "Mesh/displacements='disp_x disp_y disp_z' Problem/type='NekRSSeparateDomainProblem' Problem/casename='user'"
+    cli_args = "Mesh/displacements='disp_x disp_y disp_z' Problem/type='NekRSSeparateDomainProblem' Problem/casename='user' Problem/coupling_type='inlet' Problem/inlet_boundary='1' Problem/outlet_boundary='2'"
     required_objects = 'NekRSProblem'
 
     # nekRS can't use more processors than elements
     max_parallel = 64
 
-    expect_err = "Your nekRS .par file indicates you wish to use one of nekRS's moving mesh solvers. "
-                 "Please switch to type = NekRSProblem in the \[Problem\] block, or remove moving "
-                 "mesh solvers from your .par file's \[Mesh\] block."
+    expect_err = "NekRSSeparateDomainProblem currently does not transfer mesh displacements"
 
     requirement = "The system shall error if the nekRS .par file has a moving mesh solver"
                   "but the problem type in Cardinal is not NekRSProblem."

--- a/test/tests/nek_errors/insufficient_scratch/standalone/brick.oudf
+++ b/test/tests/nek_errors/insufficient_scratch/standalone/brick.oudf
@@ -1,0 +1,16 @@
+void velocityDirichletConditions(bcData *bc)
+{
+  bc->u = 0.1;
+  bc->v = 0.0;
+  bc->w = 0.0;
+}
+
+void scalarDirichletConditions(bcData *bc)
+{
+  bc->s = 573.0;
+}
+
+void scalarNeumannConditions(bcData *bc)
+{
+  bc->flux = 0.0;
+}

--- a/test/tests/nek_errors/insufficient_scratch/standalone/brick.par
+++ b/test/tests/nek_errors/insufficient_scratch/standalone/brick.par
@@ -1,0 +1,40 @@
+[OCCA]
+  backend = CPU
+
+[GENERAL]
+  stopAt = numSteps
+  numSteps = 5
+  dt = 5.0e-4
+  polynomialOrder = 2
+  writeControl = steps
+  writeInterval = 20
+
+[VELOCITY]
+  viscosity = 1.0
+  density = 1.0
+  residualTol = 1.0e-6
+  residualProj = false
+  boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
+
+[MESH]
+  file="../brick.re2"
+
+[PRESSURE]
+  residualTol = 1.0e-5
+  residualProj = false
+
+[TEMPERATURE]
+  residualTol = 1e-6
+  boundaryTypeMap = t, f, f, f, f, f
+
+[SCALAR01]
+  residualTol = 1e-6
+  boundaryTypeMap = t, t, t, t, t, t
+
+[SCALAR02]
+  residualTol = 1e-6
+  boundaryTypeMap = t, t, t, t, t, t
+
+[SCALAR03]
+  residualTol = 1e-6
+  boundaryTypeMap = t, t, t, t, t, t

--- a/test/tests/nek_errors/insufficient_scratch/standalone/brick.udf
+++ b/test/tests/nek_errors/insufficient_scratch/standalone/brick.udf
@@ -1,0 +1,15 @@
+#include "udf.hpp"
+
+void UDF_LoadKernels(occa::properties & kernelInfo)
+{
+}
+
+void UDF_Setup(nrs_t *nrs)
+{
+  nrs->usrwrk = (dfloat *) calloc(nrs->fieldOffset, sizeof(dfloat));
+  nrs->o_usrwrk = platform->device.malloc(1 * nrs->fieldOffset * sizeof(dfloat));
+}
+
+void UDF_ExecuteStep(nrs_t *nrs, dfloat time, int tstep)
+{
+}

--- a/test/tests/nek_errors/insufficient_scratch/standalone/nek_standalone.i
+++ b/test/tests/nek_errors/insufficient_scratch/standalone/nek_standalone.i
@@ -6,8 +6,6 @@
 [Problem]
   type = NekRSStandaloneProblem
   casename = 'brick'
-  n_usrwrk_slots = 1
-  output = 'temperature'
 []
 
 [Executioner]
@@ -16,8 +14,4 @@
   [TimeStepper]
     type = NekTimeStepper
   []
-[]
-
-[Outputs]
-  exodus = true
 []

--- a/test/tests/nek_errors/insufficient_scratch/standalone/tests
+++ b/test/tests/nek_errors/insufficient_scratch/standalone/tests
@@ -1,0 +1,17 @@
+[Tests]
+  [ok_standalone]
+    type = RunApp
+    input = nek_standalone.i
+    requirement = "The system shall not error if there is no scratch space conflict for standalone Nek cases."
+    required_objects = 'NekRSProblem'
+  []
+  [error_standalone]
+    type = RunException
+    input = nek_standalone.i
+    cli_args = 'Problem/n_usrwrk_slots=1'
+    expect_err = "The nrs_t.usrwrk and nrs_t.o_usrwrk arrays are automatically allocated by Cardinal"
+    requirement = "The system shall error if the user tries to allocate scratch from Cardinal for standalone "
+                  "NekRS cases, but the Nek case files are also separately trying to allocate scratch."
+    required_objects = 'NekRSProblem'
+  []
+[]

--- a/test/tests/nek_errors/insufficient_scratch/tests
+++ b/test/tests/nek_errors/insufficient_scratch/tests
@@ -70,14 +70,4 @@
                   "NekRSSeparateDomainProblem always requires at least 5 slots if scalar03 is coupled "
     required_objects = 'NekRSProblem'
   []
-  [standalone]
-    type = RunException
-    input = nek_standalone.i
-    cli_args = "--error"
-    expect_err = "When using running NekRS as a standalone problem through Cardinal, the "
-                 "'n_usrwrk_slots' parameter is unused!"
-    requirement = "The system shall warn if the user enters a scratch alloction for a standalone problem, "
-                  "which does not actually allocate any scratch storage"
-    required_objects = 'NekRSProblem'
-  []
 []

--- a/test/tests/nek_errors/used_scratch/tests
+++ b/test/tests/nek_errors/used_scratch/tests
@@ -2,7 +2,7 @@
   [occupied_scratch_space]
     type = RunException
     input = nek.i
-    expect_err = "The nrs_t.usrwrk and nrs_t.o_usrwrk arrays are automatically allocated by Cardinal!"
+    expect_err = "The nrs_t.usrwrk and nrs_t.o_usrwrk arrays are automatically allocated by Cardinal"
     requirement = "MOOSE shall throw an error if the user attempts to allocate the scratch space "
                   "arrays in NekRS, since they are automatically allocated by Cardinal."
     required_objects = 'NekRSProblem'


### PR DESCRIPTION
For stochastic tools integration, we may want to allow information to flow from MOOSE to NekRS even for the "standalone" NekRS cases. We therefore need to allow Cardinal to allocate scratch for this incoming information, but our previous implementation had simply disabled this. This PR allows scratch allocation from NekRSStandaloneProblem, plus some other simplifying logic.