### PR TITLE
Correct bug where dash vs. underscore conversion was missing

### DIFF
--- a/test/tests/neutronics/flux/tests
+++ b/test/tests/neutronics/flux/tests
@@ -14,12 +14,29 @@
     requirement = "The system shall correctly normalize flux tallies for eigenvalue simulations when listed in an arbitrary order."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [flip_order_and_name]
+    type = CSVDiff
+    input = flux.i
+    cli_args = 'Problem/tally_score="flux heating" Problem/tally_name="flux0 heating0" Postprocessors/flux_pebble1/variable=flux0 Postprocessors/flux_pebble2/variable=flux0 Postprocessors/flux_pebble3/variable=flux0 Postprocessors/flux_fluid/variable=flux0 Problem/source_rate_normalization="heating"'
+    csvdiff = flux_out.csv
+    requirement = "The system shall correctly normalize flux tallies for eigenvalue simulations when listed in an arbitrary order and with user-defined names."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
   [not_already_added]
     type = CSVDiff
     input = flux.i
     cli_args = 'Problem/tally_score="flux" Problem/source_rate_normalization=heating'
     csvdiff = flux_out.csv
     requirement = "The system shall correctly normalize flux tallies for eigenvalue simulations when the source rate normalization tally is not already added."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+  [missing_name]
+    type = RunException
+    input = flux.i
+    cli_args = 'Problem/tally_score="flux" Problem/tally_name="f"'
+    expect_err = "When specifying 'tally_name', the score indicated in 'source_rate_normalization' must be\n"
+                 "listed in 'tally_score' so that we know what you want to name that score \(heating\)"
+    requirement = "The system shall error if the user tries to name only a partial set of the total tally scores."
     required_objects = 'OpenMCCellAverageProblem'
   []
 []


### PR DESCRIPTION
@lewisgross1296 noticed a bug where, for any `source_rate_normalization` score which happened to have an underscore in it, that we were missing the proper conversion of that name into the equivalent OpenMC score. This was erroneously causing an error to throw suggesting that the user set inconsistent input file settings (our tests just happened to only cover use cases with single-word scores, without any underscores/dashes).

I also added a sanity check that if the user combines `tally_name` for a score not already listed in `tally_score`, that they are prompted to include the score so that we are precisely sure on what the tally names correspond to.