### PR TITLE
Block restrict temperature and density

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -362,17 +362,18 @@ protected:
    * Read the block parameters and tally information based on user settings
    * @param[in] name phase that these blocks will be mapped to
    * @param[in] blocks list of block ids to write
+   * @param[out] names subdomain names
    */
-  void readBlockParameters(const std::string name, std::unordered_set<SubdomainID> & blocks);
+  void readBlockParameters(const std::string name, std::unordered_set<SubdomainID> & blocks, std::vector<SubdomainName> & names);
 
   /// Read the parameters for 'fluid_blocks'
-  void readFluidBlocks() { readBlockParameters("fluid", _fluid_blocks); }
+  void readFluidBlocks() { readBlockParameters("fluid", _fluid_blocks, _fluid_block_names); }
 
   /// Read the parameters for 'solid_blocks'
-  void readSolidBlocks() { readBlockParameters("solid", _solid_blocks); }
+  void readSolidBlocks() { readBlockParameters("solid", _solid_blocks, _solid_block_names); }
 
   /// Read the parameters for 'tally_blocks'
-  void readTallyBlocks() { readBlockParameters("tally", _tally_blocks); }
+  void readTallyBlocks() { readBlockParameters("tally", _tally_blocks, _tally_block_names); }
 
   /**
    * Cache the material cells contained within each coupling cell;
@@ -875,6 +876,15 @@ protected:
 
   /// Blocks (mapped to OpenMC cells) for which to add tallies
   std::unordered_set<SubdomainID> _tally_blocks;
+
+  /// Blocks in MOOSE mesh that correspond to the fluid phase
+  std::vector<SubdomainName> _fluid_block_names;
+
+  /// Blocks in MOOSE mesh that correspond to the solid phase
+  std::vector<SubdomainName> _solid_block_names;
+
+  /// Blocks in MOOSE mesh that correspond to the solid phase
+  std::vector<SubdomainName> _tally_block_names;
 
   /// Mapping of MOOSE elements to the OpenMC cell they map to (if any)
   std::vector<cellInfo> _elem_to_cell{};

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -983,16 +983,17 @@ OpenMCCellAverageProblem::getCellLevel(const std::string name, unsigned int & ce
 
 void
 OpenMCCellAverageProblem::readBlockParameters(const std::string name,
-                                              std::unordered_set<SubdomainID> & blocks)
+                                              std::unordered_set<SubdomainID> & blocks,
+                                              std::vector<SubdomainName> & names)
 {
   std::string param_name = name + "_blocks";
 
   if (isParamValid(param_name))
   {
-    std::vector<SubdomainName> b = getParam<std::vector<SubdomainName>>(param_name);
-    checkEmptyVector(b, param_name);
+    names = getParam<std::vector<SubdomainName>>(param_name);
+    checkEmptyVector(names, param_name);
 
-    auto b_ids = _mesh.getSubdomainIDs(b);
+    auto b_ids = _mesh.getSubdomainIDs(names);
 
     std::copy(b_ids.begin(), b_ids.end(), std::inserter(blocks, blocks.end()));
 
@@ -1181,8 +1182,6 @@ OpenMCCellAverageProblem::checkCellMappedPhase()
     int n_solid = _n_solid[cell_info];
     int n_fluid = _n_fluid[cell_info];
     int n_none = _n_none[cell_info];
-
-    Real mapped_volume = _cell_to_elem_volume[cell_info];
 
     std::ostringstream vol;
     vol << std::setprecision(3) << std::scientific << "";
@@ -2298,17 +2297,15 @@ OpenMCCellAverageProblem::addExternalVariables()
 
   std::vector<SubdomainName> t;
   std::vector<SubdomainName> d;
-  for (const auto & i : _solid_blocks)
+  for (const auto & i : _solid_block_names)
   {
-    auto s = MooseMeshUtils::hasSubdomainName(_mesh, i) ? _mesh.getSubdomainName(i) : i;
-    t.push_back(s);
+    t.push_back(i);
   }
 
-  for (const auto & i : _fluid_blocks)
+  for (const auto & i : _fluid_block_names)
   {
-    auto s = MooseMeshUtils::hasSubdomainName(_mesh, i) ? _mesh.getSubdomainName(i) : i;
-    t.push_back(s);
-    d.push_back(s);
+    t.push_back(i);
+    d.push_back(i);
   }
 
   // create a temperature variable, but only on the blocks with temperature

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -2296,17 +2296,11 @@ OpenMCCellAverageProblem::addExternalVariables()
   }
 
   std::vector<SubdomainName> t;
-  std::vector<SubdomainName> d;
   for (const auto & i : _solid_block_names)
-  {
     t.push_back(i);
-  }
 
   for (const auto & i : _fluid_block_names)
-  {
     t.push_back(i);
-    d.push_back(i);
-  }
 
   // create a temperature variable, but only on the blocks with temperature
   // feedback to OpenMC; this should be explicitly clear about the data transfer
@@ -2322,7 +2316,7 @@ OpenMCCellAverageProblem::addExternalVariables()
     // feedback to OpenMC; this should be explicitly clear about the data transfer
     checkDuplicateVariableName("density");
     auto rho_params = var_params;
-    rho_params.set<std::vector<SubdomainName>>("block") = d;
+    rho_params.set<std::vector<SubdomainName>>("block") = _fluid_block_names;
     addAuxVariable("MooseVariable", "density", rho_params);
     _density_var = _aux->getFieldVariable<Real>(0, "density").number();
   }

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -23,6 +23,7 @@
 #include "DelimitedFileReader.h"
 #include "TimedPrint.h"
 #include "MooseUtils.h"
+#include "MooseMeshUtils.h"
 #include "NonlinearSystemBase.h"
 #include "Conversion.h"
 #include "VariadicTable.h"
@@ -2298,11 +2299,16 @@ OpenMCCellAverageProblem::addExternalVariables()
   std::vector<SubdomainName> t;
   std::vector<SubdomainName> d;
   for (const auto & i : _solid_blocks)
-    t.push_back(_mesh.getSubdomainName(i));
+  {
+    auto s = MooseMeshUtils::hasSubdomainName(_mesh, i) ? _mesh.getSubdomainName(i) : i;
+    t.push_back(s);
+  }
+
   for (const auto & i : _fluid_blocks)
   {
-    t.push_back(_mesh.getSubdomainName(i));
-    d.push_back(_mesh.getSubdomainName(i));
+    auto s = MooseMeshUtils::hasSubdomainName(_mesh, i) ? _mesh.getSubdomainName(i) : i;
+    t.push_back(s);
+    d.push_back(s);
   }
 
   // create a temperature variable, but only on the blocks with temperature

--- a/test/tests/conduction/boundary_and_volume/prism/moose.i
+++ b/test/tests/conduction/boundary_and_volume/prism/moose.i
@@ -31,14 +31,14 @@
   [source1]
     type = ParsedAux
     variable = source
-    args = 'temperature'
+    coupled_variables = 'temperature'
     function = 'temperature+50'
     block = '1'
   []
   [source2]
     type = ParsedAux
     variable = source
-    args = 'temperature'
+    coupled_variables = 'temperature'
     function = '0.5*temperature+10'
     block = '2'
   []

--- a/test/tests/conduction/boundary_and_volume/prism/openmc.i
+++ b/test/tests/conduction/boundary_and_volume/prism/openmc.i
@@ -46,14 +46,14 @@
   [source1]
     type = ParsedAux
     variable = source_nek
-    args = 'nek_temp'
+    coupled_variables = 'nek_temp'
     function = 'nek_temp+50'
     block = '1'
   []
   [source2]
     type = ParsedAux
     variable = source_bison
-    args = 'bison_temp'
+    coupled_variables = 'bison_temp'
     function = '0.5*bison_temp+10'
     block = '2'
   []

--- a/test/tests/conduction/boundary_and_volume/prism/openmc_exact.i
+++ b/test/tests/conduction/boundary_and_volume/prism/openmc_exact.i
@@ -46,14 +46,14 @@
   [source1]
     type = ParsedAux
     variable = source_nek
-    args = 'nek_temp'
+    coupled_variables = 'nek_temp'
     function = 'nek_temp+50'
     block = '1'
   []
   [source2]
     type = ParsedAux
     variable = source_bison
-    args = 'bison_temp'
+    coupled_variables = 'bison_temp'
     function = '0.5*bison_temp+10'
     block = '2'
   []

--- a/test/tests/conduction/identical_volume/cube/moose.i
+++ b/test/tests/conduction/identical_volume/cube/moose.i
@@ -34,7 +34,7 @@
     type = ParsedAux
     variable = source
     function = 'temperature*7'
-    args = 'temperature'
+    coupled_variables = 'temperature'
     execute_on = 'linear'
   []
 []

--- a/test/tests/conduction/identical_volume/cube/nek_master.i
+++ b/test/tests/conduction/identical_volume/cube/nek_master.i
@@ -30,7 +30,7 @@
     type = ParsedAux
     variable = source
     function = 'nek_temp*7'
-    args = 'nek_temp'
+    coupled_variables = 'nek_temp'
     execute_on = 'timestep_end'
   []
 []

--- a/test/tests/conduction/nonidentical_volume/cylinder/moose.i
+++ b/test/tests/conduction/nonidentical_volume/cylinder/moose.i
@@ -66,7 +66,7 @@ o=0.15
     type = ParsedAux
     variable = source
     function = 'axial+temperature'
-    args = 'axial temperature'
+    coupled_variables = 'axial temperature'
     execute_on = 'linear'
   []
 []

--- a/test/tests/conduction/nonidentical_volume/cylinder/nek_master.i
+++ b/test/tests/conduction/nonidentical_volume/cylinder/nek_master.i
@@ -64,7 +64,7 @@ o=0.15
     type = ParsedAux
     variable = source
     function = 'axial+nek_temp'
-    args = 'axial nek_temp'
+    coupled_variables = 'axial nek_temp'
     execute_on = 'linear'
   []
 []

--- a/test/tests/conduction/nonidentical_volume/cylinder/nek_master_exact.i
+++ b/test/tests/conduction/nonidentical_volume/cylinder/nek_master_exact.i
@@ -64,7 +64,7 @@ o=0.15
     type = ParsedAux
     variable = source
     function = 'axial+nek_temp'
-    args = 'axial nek_temp'
+    coupled_variables = 'axial nek_temp'
     execute_on = 'linear'
   []
 []

--- a/test/tests/conduction/nonidentical_volume/nondimensional/nek_master.i
+++ b/test/tests/conduction/nonidentical_volume/nondimensional/nek_master.i
@@ -64,7 +64,7 @@ o=0.15
     type = ParsedAux
     variable = source
     function = 'axial+nek_temp'
-    args = 'axial nek_temp'
+    coupled_variables = 'axial nek_temp'
     execute_on = 'linear'
   []
 []

--- a/test/tests/deformation/simple-cube/box-test.i
+++ b/test/tests/deformation/simple-cube/box-test.i
@@ -114,7 +114,7 @@
     type = ParsedAux
     variable = difference
     function = 'temp - temp_ansol'
-    args = 'temp temp_ansol'
+    coupled_variables = 'temp temp_ansol'
   []
 []
 

--- a/test/tests/deformation/simple-cube/moose.i
+++ b/test/tests/deformation/simple-cube/moose.i
@@ -105,7 +105,7 @@
     type = ParsedAux
     variable = difference
     function = 'temp - temp_ansol'
-    args = 'temp temp_ansol'
+    coupled_variables = 'temp temp_ansol'
   []
 []
 

--- a/test/tests/deformation/vol-areas/box-test.i
+++ b/test/tests/deformation/vol-areas/box-test.i
@@ -116,7 +116,7 @@
     type = ParsedAux
     variable = difference
     function = 'temp - temp_ansol'
-    args = 'temp temp_ansol'
+    coupled_variables = 'temp temp_ansol'
   []
 []
 

--- a/test/tests/nek_temp/exact/exact.i
+++ b/test/tests/nek_temp/exact/exact.i
@@ -39,7 +39,7 @@
   [difference]
     type = ParsedAux
     variable = difference
-    args = 'analytic temp'
+    coupled_variables = 'analytic temp'
     function = 'temp-analytic'
   []
 []

--- a/test/tests/nek_temp/exact/exact_volume.i
+++ b/test/tests/nek_temp/exact/exact_volume.i
@@ -39,7 +39,7 @@
   [difference]
     type = ParsedAux
     variable = difference
-    args = 'analytic temp'
+    coupled_variables = 'analytic temp'
     function = 'temp-analytic'
   []
 []

--- a/test/tests/nek_temp/first_order/nek.i
+++ b/test/tests/nek_temp/first_order/nek.i
@@ -38,7 +38,7 @@
   [difference]
     type = ParsedAux
     variable = difference
-    args = 'analytic temp'
+    coupled_variables = 'analytic temp'
     function = 'temp-analytic'
   []
 []

--- a/test/tests/nek_temp/first_order/nek_volume.i
+++ b/test/tests/nek_temp/first_order/nek_volume.i
@@ -38,7 +38,7 @@
   [difference]
     type = ParsedAux
     variable = difference
-    args = 'analytic temp'
+    coupled_variables = 'analytic temp'
     function = 'temp-analytic'
   []
 []

--- a/test/tests/nek_temp/second_order/nek.i
+++ b/test/tests/nek_temp/second_order/nek.i
@@ -38,7 +38,7 @@
   [difference]
     type = ParsedAux
     variable = difference
-    args = 'analytic temp'
+    coupled_variables = 'analytic temp'
     function = 'temp-analytic'
   []
 []

--- a/test/tests/nek_temp/second_order/nek_volume.i
+++ b/test/tests/nek_temp/second_order/nek_volume.i
@@ -38,7 +38,7 @@
   [difference]
     type = ParsedAux
     variable = difference
-    args = 'analytic temp'
+    coupled_variables = 'analytic temp'
     function = 'temp-analytic'
   []
 []

--- a/test/tests/neutronics/feedback/different_units/openmc_master.i
+++ b/test/tests/neutronics/feedback/different_units/openmc_master.i
@@ -27,7 +27,7 @@
     type = ParsedAux
     variable = density
     function = '-0.4884*temp+2413.0'
-    args = 'temp'
+    coupled_variables = 'temp'
   []
 []
 

--- a/test/tests/neutronics/feedback/different_units/openmc_master_cm.i
+++ b/test/tests/neutronics/feedback/different_units/openmc_master_cm.i
@@ -27,7 +27,7 @@
     type = ParsedAux
     variable = density
     function = '-0.4884*temp+2413.0'
-    args = 'temp'
+    coupled_variables = 'temp'
   []
 []
 

--- a/test/tests/neutronics/feedback/lattice/openmc_master.i
+++ b/test/tests/neutronics/feedback/lattice/openmc_master.i
@@ -29,7 +29,7 @@
     type = ParsedAux
     variable = density
     function = '-0.4884*temp+2413.0'
-    args = 'temp'
+    coupled_variables = 'temp'
   []
 []
 

--- a/test/tests/neutronics/feedback/single_level/openmc_master.i
+++ b/test/tests/neutronics/feedback/single_level/openmc_master.i
@@ -29,7 +29,7 @@
     type = ParsedAux
     variable = density
     function = '-0.4884*temp+2413.0'
-    args = 'temp'
+    coupled_variables = 'temp'
   []
 []
 

--- a/test/tests/neutronics/feedback/unmapped_moose/openmc_master.i
+++ b/test/tests/neutronics/feedback/unmapped_moose/openmc_master.i
@@ -41,7 +41,7 @@
     type = ParsedAux
     variable = density
     function = '-0.4884*temp+2413.0'
-    args = 'temp'
+    coupled_variables = 'temp'
   []
 []
 

--- a/test/tests/postprocessors/nek_weighted_side_average/moose.i
+++ b/test/tests/postprocessors/nek_weighted_side_average/moose.i
@@ -69,74 +69,74 @@
     type = ParsedAux
     variable = mdot_xp
     function = '834.5*vel_x'
-    args='vel_x'
+    coupled_variables='vel_x'
   []
   [mdot_xm]
     type = ParsedAux
     variable = mdot_xm
     function = '-834.5*vel_x'
-    args='vel_x'
+    coupled_variables='vel_x'
   []
   [mdot_yp]
     type = ParsedAux
     variable = mdot_yp
     function = '834.5*vel_y'
-    args='vel_y'
+    coupled_variables='vel_y'
   []
   [mdot_ym]
     type = ParsedAux
     variable = mdot_ym
     function = '-834.5*vel_y'
-    args='vel_y'
+    coupled_variables='vel_y'
   []
   [mdot_zp]
     type = ParsedAux
     variable = mdot_zp
     function = '834.5*vel_z'
-    args='vel_z'
+    coupled_variables='vel_z'
   []
   [mdot_zm]
     type = ParsedAux
     variable = mdot_zm
     function = '-834.5*vel_z'
-    args='vel_z'
+    coupled_variables='vel_z'
   []
 
   [weighted_temp_xp]
     type = ParsedAux
     variable = weighted_temp_xp
     function = '834.5*vel_x*temp_test'
-    args='vel_x temp_test'
+    coupled_variables='vel_x temp_test'
   []
   [weighted_temp_xm]
     type = ParsedAux
     variable = weighted_temp_xm
     function = '-834.5*vel_x*temp_test'
-    args='vel_x temp_test'
+    coupled_variables='vel_x temp_test'
   []
   [weighted_temp_yp]
     type = ParsedAux
     variable = weighted_temp_yp
     function = '834.5*vel_y*temp_test'
-    args='vel_y temp_test'
+    coupled_variables='vel_y temp_test'
   []
   [weighted_temp_ym]
     type = ParsedAux
     variable = weighted_temp_ym
     function = '-834.5*vel_y*temp_test'
-    args='vel_y temp_test'
+    coupled_variables='vel_y temp_test'
   []
   [weighted_temp_zp]
     type = ParsedAux
     variable = weighted_temp_zp
     function = '834.5*vel_z*temp_test'
-    args='vel_z temp_test'
+    coupled_variables='vel_z temp_test'
   []
   [weighted_temp_zm]
     type = ParsedAux
     variable = weighted_temp_zm
     function = '-834.5*vel_z*temp_test'
-    args='vel_z temp_test'
+    coupled_variables='vel_z temp_test'
   []
 []
 

--- a/test/tests/postprocessors/nek_weighted_side_integral/moose.i
+++ b/test/tests/postprocessors/nek_weighted_side_integral/moose.i
@@ -57,37 +57,37 @@
     type = ParsedAux
     variable = weighted_temp_xp
     function = '834.5*vel_x*temp_test'
-    args='vel_x temp_test'
+    coupled_variables='vel_x temp_test'
   []
   [weighted_temp_xm]
     type = ParsedAux
     variable = weighted_temp_xm
     function = '-834.5*vel_x*temp_test'
-    args='vel_x temp_test'
+    coupled_variables='vel_x temp_test'
   []
   [weighted_temp_yp]
     type = ParsedAux
     variable = weighted_temp_yp
     function = '834.5*vel_y*temp_test'
-    args='vel_y temp_test'
+    coupled_variables='vel_y temp_test'
   []
   [weighted_temp_ym]
     type = ParsedAux
     variable = weighted_temp_ym
     function = '-834.5*vel_y*temp_test'
-    args='vel_y temp_test'
+    coupled_variables='vel_y temp_test'
   []
   [weighted_temp_zp]
     type = ParsedAux
     variable = weighted_temp_zp
     function = '834.5*vel_z*temp_test'
-    args='vel_z temp_test'
+    coupled_variables='vel_z temp_test'
   []
   [weighted_temp_zm]
     type = ParsedAux
     variable = weighted_temp_zm
     function = '-834.5*vel_z*temp_test'
-    args='vel_z temp_test'
+    coupled_variables='vel_z temp_test'
   []
 []
 

--- a/test/tests/userobjects/hexagonal_gap_layered/user_component.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/user_component.i
@@ -37,7 +37,7 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
     type = ParsedAux
     variable = velocity_component
     function = '(0.1*vel_x+0.2*vel_y+0.3*vel_z)/sqrt(0.1*0.1+0.2*0.2+0.3*0.3)'
-    args = 'vel_x vel_y vel_z'
+    coupled_variables = 'vel_x vel_y vel_z'
     execute_on = 'timestep_end nonlinear linear always'
   []
   [uo_x]

--- a/test/tests/userobjects/subchannel_layered/user_component.i
+++ b/test/tests/userobjects/subchannel_layered/user_component.i
@@ -35,7 +35,7 @@
     type = ParsedAux
     variable = velocity_component
     function = '(0.1*vel_x-0.2*vel_y+0.3*vel_z)/sqrt(0.1*0.1+0.2*0.2+0.3*0.3)'
-    args = 'vel_x vel_y vel_z'
+    coupled_variables = 'vel_x vel_y vel_z'
     execute_on = 'timestep_end nonlinear linear always'
   []
   [uo_x]


### PR DESCRIPTION
Users are sometimes confused when they see that `density` or `temp` are defined everywhere over the `[Mesh]`, when only a subset of those values get set into OpenMC (depending on what they set for `solid_blocks` and `fluid_blocks`). This PR now block-restricts the `temp` and `density` variables so that behavior is clearer.

Also took the opportunity to remove some soon-to-be-deprecated syntax.