### PR TITLE
Convert int into string

### DIFF
--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -234,7 +234,7 @@ OpenMCProblemBase::materialName(const int32_t index) const
 
   const char * name;
   int err = openmc_material_get_name(index, &name);
-  catchOpenMCError(err, "get material name for material with index " + index);
+  catchOpenMCError(err, "get material name for material with index " + std::to_string(index));
 
   std::string n = name;
 
@@ -250,7 +250,7 @@ OpenMCProblemBase::cellID(const int32_t index) const
 {
   int32_t id;
   int err = openmc_cell_get_id(index, &id);
-  catchOpenMCError(err, "get ID for cell with index " + index);
+  catchOpenMCError(err, "get ID for cell with index " + std::to_string(index));
   return id;
 }
 
@@ -262,7 +262,7 @@ OpenMCProblemBase::materialID(const int32_t index) const
 
   int32_t id;
   int err = openmc_material_get_id(index, &id);
-  catchOpenMCError(err, "get ID for material with index " + index);
+  catchOpenMCError(err, "get ID for material with index " + std::to_string(index));
   return id;
 }
 


### PR DESCRIPTION
This fixes a runtime error when cardinal is compiled with clang. The error looks like this:
```
libMesh terminating:
basic_string
application called MPI_Abort(MPI_COMM_WORLD, 1) - process 0
[unset]: PMIU_write error; fd=-1 buf=:cmd=abort exitcode=1 message=application called MPI_Abort(MPI_COMM_WORLD, 1) - process 0
:
system msg for write_line failure : Bad file descriptor
```

Refs #0