### PR TITLE
Deprecate residualProj to prepare for upcoming Nek release

### DIFF
--- a/test/tests/auxkernels/nek_spatial_bin_component_aux/brick.par
+++ b/test/tests/auxkernels/nek_spatial_bin_component_aux/brick.par
@@ -14,15 +14,12 @@
   viscosity = -880.2742616033756
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = false
   boundaryTypeMap = t, t, t

--- a/test/tests/cht/nondimensional/sfr_pin.par
+++ b/test/tests/cht/nondimensional/sfr_pin.par
@@ -34,11 +34,9 @@
   density = 1.0
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
 

--- a/test/tests/cht/nondimensional/sfr_pin_turb.par
+++ b/test/tests/cht/nondimensional/sfr_pin_turb.par
@@ -34,7 +34,6 @@
   density = 1.0
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6

--- a/test/tests/cht/pebble/onepebble2.par
+++ b/test/tests/cht/pebble/onepebble2.par
@@ -9,7 +9,6 @@ writeInterval = 5
 
 [PRESSURE]
 residualTol = 1e-06
-residualProj = false
 
 [VELOCITY]
 boundaryTypeMap = W, O, v

--- a/test/tests/cht/sfr_pincell/sfr_pin.par
+++ b/test/tests/cht/sfr_pincell/sfr_pin.par
@@ -20,11 +20,9 @@
   density = 834.5
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 64.21

--- a/test/tests/conduction/boundary_and_volume/prism/pyramid.par
+++ b/test/tests/conduction/boundary_and_volume/prism/pyramid.par
@@ -12,16 +12,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 10.5
   rhoCp = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = t, f, I, I, I, I

--- a/test/tests/conduction/boundary_and_volume/prism/pyramid_low.par
+++ b/test/tests/conduction/boundary_and_volume/prism/pyramid_low.par
@@ -15,16 +15,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 10.5
   rhoCp = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = t, f, I, I, I, I

--- a/test/tests/conduction/identical_interface/cube/cube.par
+++ b/test/tests/conduction/identical_interface/cube/cube.par
@@ -12,16 +12,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 2.5
   rhoCp = 1.0
   residualTol = 1.0e-10
-  residualProj = false
   boundaryTypeMap = I, I, I, f, I, t

--- a/test/tests/conduction/identical_interface/pyramid/pyramid.par
+++ b/test/tests/conduction/identical_interface/pyramid/pyramid.par
@@ -12,16 +12,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 2.5
   rhoCp = 1.0
   residualTol = 1.0e-10
-  residualProj = false
   boundaryTypeMap = t, f, I, I, I, I

--- a/test/tests/conduction/identical_volume/cube/cube.par
+++ b/test/tests/conduction/identical_volume/cube/cube.par
@@ -12,16 +12,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 1.5
   rhoCp = 1.0
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = I, t, t, t, t, I

--- a/test/tests/conduction/nonidentical_interface/cylinders/cylinder.par
+++ b/test/tests/conduction/nonidentical_interface/cylinders/cylinder.par
@@ -12,16 +12,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = wall, wall, inlet, outlet
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 2.5
   rhoCp = 1.0
   residualTol = 1.0e-10
-  residualProj = false
   boundaryTypeMap = t, f, I, I

--- a/test/tests/conduction/nonidentical_volume/cylinder/cylinder.par
+++ b/test/tests/conduction/nonidentical_volume/cylinder/cylinder.par
@@ -12,16 +12,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 1.5
   rhoCp = 1.0
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = t, I, I

--- a/test/tests/conduction/nonidentical_volume/cylinder/cylinder_low.par
+++ b/test/tests/conduction/nonidentical_volume/cylinder/cylinder_low.par
@@ -15,16 +15,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 1.5
   rhoCp = 1.0
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = t, I, I

--- a/test/tests/conduction/nonidentical_volume/nondimensional/cylinder.par
+++ b/test/tests/conduction/nonidentical_volume/nondimensional/cylinder.par
@@ -27,16 +27,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = -10.0
   rhoCp = 1.0
   residualTol = 1.0e-7
-  residualProj = false
   boundaryTypeMap = t, I, I

--- a/test/tests/conduction/zero_flux/pyramid.par
+++ b/test/tests/conduction/zero_flux/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/deformation/simple-cube/nekbox.par
+++ b/test/tests/deformation/simple-cube/nekbox.par
@@ -15,16 +15,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 1.0
   rhoCp = 0.0
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = t, t, t, t, t, t

--- a/test/tests/deformation/vol-areas/nekbox.par
+++ b/test/tests/deformation/vol-areas/nekbox.par
@@ -15,16 +15,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 1.0
   rhoCp = 0.0
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = t, t, t, t, t, t

--- a/test/tests/multiple_nek_apps/subdirectory/pyramid/pyramid.par
+++ b/test/tests/multiple_nek_apps/subdirectory/pyramid/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/multiple_nek_apps/two_channels/pin.par
+++ b/test/tests/multiple_nek_apps/two_channels/pin.par
@@ -16,11 +16,9 @@
   density = 834.5
   boundaryTypeMap = W, W, W
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 0.1

--- a/test/tests/nek_errors/deformation/user.par
+++ b/test/tests/nek_errors/deformation/user.par
@@ -18,7 +18,6 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall
 
 [PRESSURE]
@@ -29,5 +28,4 @@
 #  conductivity = 1.0
 #  rhoCp = 0.0
 #  residualTol = 1.0e-5
-#  residualProj = false
 #  boundaryTypeMap = I, f, I, I, I, I

--- a/test/tests/nek_errors/incorrect_executioner/brick.par
+++ b/test/tests/nek_errors/incorrect_executioner/brick.par
@@ -13,14 +13,11 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = I, I, f, I, I, I

--- a/test/tests/nek_errors/incorrect_mesh/brick.par
+++ b/test/tests/nek_errors/incorrect_mesh/brick.par
@@ -13,14 +13,11 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = I, I, f, I, I, I

--- a/test/tests/nek_errors/incorrect_nek_bc/brick.par
+++ b/test/tests/nek_errors/incorrect_nek_bc/brick.par
@@ -13,14 +13,11 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = I, I, f, I, I, I

--- a/test/tests/nek_errors/incorrect_timestepper/brick.par
+++ b/test/tests/nek_errors/incorrect_timestepper/brick.par
@@ -13,14 +13,11 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = I, I, f, I, I, I

--- a/test/tests/nek_errors/insufficient_scratch/brick.par
+++ b/test/tests/nek_errors/insufficient_scratch/brick.par
@@ -13,12 +13,10 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   residualTol = 1e-6

--- a/test/tests/nek_errors/insufficient_scratch/standalone/brick.par
+++ b/test/tests/nek_errors/insufficient_scratch/standalone/brick.par
@@ -13,7 +13,6 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [MESH]
@@ -21,7 +20,6 @@
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   residualTol = 1e-6

--- a/test/tests/nek_errors/invalid_bid/brick.par
+++ b/test/tests/nek_errors/invalid_bid/brick.par
@@ -13,14 +13,11 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = I, f, I, I, I, I

--- a/test/tests/nek_errors/invalid_bid_postprocessor/brick.par
+++ b/test/tests/nek_errors/invalid_bid_postprocessor/brick.par
@@ -13,14 +13,11 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f

--- a/test/tests/nek_errors/invalid_field/pyramid.par
+++ b/test/tests/nek_errors/invalid_field/pyramid.par
@@ -14,9 +14,7 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false

--- a/test/tests/nek_errors/invalid_scalar/pyramid.par
+++ b/test/tests/nek_errors/invalid_scalar/pyramid.par
@@ -14,9 +14,7 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false

--- a/test/tests/nek_errors/invalid_transfer_pp/cube.par
+++ b/test/tests/nek_errors/invalid_transfer_pp/cube.par
@@ -12,16 +12,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 2.5
   rhoCp = 1.0
   residualTol = 1.0e-10
-  residualProj = false
   boundaryTypeMap = I, I, I, f, I, t

--- a/test/tests/nek_errors/mpi_setup_multiple_inputs/pyramid.par
+++ b/test/tests/nek_errors/mpi_setup_multiple_inputs/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/nek_errors/no_occa_source_kernel/cube.par
+++ b/test/tests/nek_errors/no_occa_source_kernel/cube.par
@@ -12,16 +12,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 1.5
   rhoCp = 1.0
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = I, t, t, t, t, I

--- a/test/tests/nek_errors/no_temp_var/brick.par
+++ b/test/tests/nek_errors/no_temp_var/brick.par
@@ -13,9 +13,7 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false

--- a/test/tests/nek_errors/used_scratch/brick.par
+++ b/test/tests/nek_errors/used_scratch/brick.par
@@ -13,12 +13,10 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   residualTol = 1e-6

--- a/test/tests/nek_file_output/nek_as_master/pyramid.par
+++ b/test/tests/nek_file_output/nek_as_master/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/nek_file_output/nek_as_master_even/pyramid.par
+++ b/test/tests/nek_file_output/nek_as_master_even/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/nek_file_output/nek_as_sub/pyramid.par
+++ b/test/tests/nek_file_output/nek_as_sub/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/nek_file_output/nek_as_sub_even/pyramid.par
+++ b/test/tests/nek_file_output/nek_as_sub_even/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/nek_file_output/usrwrk/brick.par
+++ b/test/tests/nek_file_output/usrwrk/brick.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 834.5
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f

--- a/test/tests/nek_mesh/exact/brick.par
+++ b/test/tests/nek_mesh/exact/brick.par
@@ -16,12 +16,10 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/test/tests/nek_mesh/first_order/pyramid.par
+++ b/test/tests/nek_mesh/first_order/pyramid.par
@@ -13,15 +13,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, I, I, I, I

--- a/test/tests/nek_mesh/second_order/pyramid.par
+++ b/test/tests/nek_mesh/second_order/pyramid.par
@@ -13,15 +13,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, I, I, I, I

--- a/test/tests/nek_mesh/sidesets/cube/cube.par
+++ b/test/tests/nek_mesh/sidesets/cube/cube.par
@@ -12,16 +12,13 @@
 [VELOCITY]
   solver = none
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = 1.5
   rhoCp = 1.0
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = f, f, f, f, f, f

--- a/test/tests/nek_mesh/sidesets/pyramid/pyramid.par
+++ b/test/tests/nek_mesh/sidesets/pyramid/pyramid.par
@@ -13,15 +13,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = false
   boundaryTypeMap = f, f, f, f, I, I, I, I

--- a/test/tests/nek_output/pyramid.par
+++ b/test/tests/nek_output/pyramid.par
@@ -14,17 +14,14 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f
 
 [SCALAR01]

--- a/test/tests/nek_standalone/from_restart/pyramid.par
+++ b/test/tests/nek_standalone/from_restart/pyramid.par
@@ -15,15 +15,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/nek_standalone/start_time/pyramid.par
+++ b/test/tests/nek_standalone/start_time/pyramid.par
@@ -18,15 +18,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/nek_stochastic/device/pyramid.par
+++ b/test/tests/nek_stochastic/device/pyramid.par
@@ -14,14 +14,11 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = t, t, t, t, t, t, t, t

--- a/test/tests/nek_temp/exact/brick.par
+++ b/test/tests/nek_temp/exact/brick.par
@@ -16,12 +16,10 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/test/tests/nek_temp/first_order/pyramid.par
+++ b/test/tests/nek_temp/first_order/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/nek_temp/second_order/pyramid.par
+++ b/test/tests/nek_temp/second_order/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/nek_warnings/no_temp_solve/brick.par
+++ b/test/tests/nek_warnings/no_temp_solve/brick.par
@@ -13,12 +13,10 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = symy, symy, inlet, outlet, symz, symz
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/test/tests/nek_warnings/unused_boundary/pyramid.par
+++ b/test/tests/nek_warnings/unused_boundary/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/postprocessors/dimensionless_numbers/dimensional/brick.par
+++ b/test/tests/postprocessors/dimensionless_numbers/dimensional/brick.par
@@ -13,15 +13,12 @@
   viscosity = 2.37e-4
   density = 834.5
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = false
   boundaryTypeMap = t, t, t

--- a/test/tests/postprocessors/dimensionless_numbers/nondimensional/brick.par
+++ b/test/tests/postprocessors/dimensionless_numbers/nondimensional/brick.par
@@ -13,15 +13,12 @@
   viscosity = -880.2742616033756
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = false
   boundaryTypeMap = t, t, t

--- a/test/tests/postprocessors/nek_heat_flux_integral/pyramid.par
+++ b/test/tests/postprocessors/nek_heat_flux_integral/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj = false
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/postprocessors/nek_pressure_surface_force/brick.par
+++ b/test/tests/postprocessors/nek_pressure_surface_force/brick.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 834.5
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f

--- a/test/tests/postprocessors/nek_side_average/pyramid.par
+++ b/test/tests/postprocessors/nek_side_average/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/postprocessors/nek_side_extrema/pyramid.par
+++ b/test/tests/postprocessors/nek_side_extrema/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/postprocessors/nek_side_integral/pyramid.par
+++ b/test/tests/postprocessors/nek_side_integral/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/postprocessors/nek_usrwrk_boundary_integral/pyramid.par
+++ b/test/tests/postprocessors/nek_usrwrk_boundary_integral/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/postprocessors/nek_volume_average/pyramid.par
+++ b/test/tests/postprocessors/nek_volume_average/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/postprocessors/nek_volume_extrema/pyramid.par
+++ b/test/tests/postprocessors/nek_volume_extrema/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/postprocessors/nek_volume_integral/pyramid.par
+++ b/test/tests/postprocessors/nek_volume_integral/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/postprocessors/nek_weighted_side_average/brick.par
+++ b/test/tests/postprocessors/nek_weighted_side_average/brick.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 834.5
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f

--- a/test/tests/postprocessors/nek_weighted_side_integral/brick.par
+++ b/test/tests/postprocessors/nek_weighted_side_integral/brick.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 834.5
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f

--- a/test/tests/sockeye_coupling/sockeye_master/pyramid.par
+++ b/test/tests/sockeye_coupling/sockeye_master/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/sockeye_coupling/sockeye_sub/pyramid.par
+++ b/test/tests/sockeye_coupling/sockeye_sub/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/test/tests/userobjects/gap/dimensional/sfr_7pin.par
+++ b/test/tests/userobjects/gap/dimensional/sfr_7pin.par
@@ -14,11 +14,9 @@
   density = 834.5
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/test/tests/userobjects/gap/nondimensional/sfr_7pin.par
+++ b/test/tests/userobjects/gap/nondimensional/sfr_7pin.par
@@ -14,11 +14,9 @@
   density = 834.5
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/test/tests/userobjects/hexagonal_gap_layered/normals/sfr_7pin.par
+++ b/test/tests/userobjects/hexagonal_gap_layered/normals/sfr_7pin.par
@@ -14,11 +14,9 @@
   density = 834.5
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/test/tests/userobjects/hexagonal_gap_layered/sfr_7pin.par
+++ b/test/tests/userobjects/hexagonal_gap_layered/sfr_7pin.par
@@ -14,11 +14,9 @@
   density = 834.5
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/test/tests/userobjects/interval/brick.par
+++ b/test/tests/userobjects/interval/brick.par
@@ -13,15 +13,12 @@
   viscosity = -880.2742616033756
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = false
   boundaryTypeMap = t, t, t

--- a/test/tests/userobjects/layered_layered/brick.par
+++ b/test/tests/userobjects/layered_layered/brick.par
@@ -14,15 +14,12 @@
   viscosity = -880.2742616033756
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = false
   boundaryTypeMap = t, t, t

--- a/test/tests/userobjects/nek_scalar_value/pyramid.par
+++ b/test/tests/userobjects/nek_scalar_value/pyramid.par
@@ -17,7 +17,6 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]

--- a/test/tests/userobjects/radial_layered/cylinder.par
+++ b/test/tests/userobjects/radial_layered/cylinder.par
@@ -14,15 +14,12 @@
   viscosity = -880.2742616033756
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = false
   boundaryTypeMap = t, t, t

--- a/test/tests/userobjects/side/dimensional/sfr_7pin.par
+++ b/test/tests/userobjects/side/dimensional/sfr_7pin.par
@@ -14,11 +14,9 @@
   density = 834.5
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/test/tests/userobjects/side/nondimensional/sfr_7pin.par
+++ b/test/tests/userobjects/side/nondimensional/sfr_7pin.par
@@ -14,11 +14,9 @@
   density = 834.5
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/test/tests/userobjects/sideset_layered/sfr_7pin.par
+++ b/test/tests/userobjects/sideset_layered/sfr_7pin.par
@@ -14,11 +14,9 @@
   density = 834.5
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/test/tests/userobjects/subchannel_layered/sfr_7pin.par
+++ b/test/tests/userobjects/subchannel_layered/sfr_7pin.par
@@ -14,11 +14,9 @@
   density = 834.5
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/test/tests/userobjects/volume/dimensional/sfr_7pin.par
+++ b/test/tests/userobjects/volume/dimensional/sfr_7pin.par
@@ -14,11 +14,9 @@
   density = 834.5
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/test/tests/userobjects/volume/nondimensional/sfr_7pin.par
+++ b/test/tests/userobjects/volume/nondimensional/sfr_7pin.par
@@ -14,11 +14,9 @@
   density = 834.5
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   solver = none

--- a/tutorials/fhr_reflector/cht/fluid.par
+++ b/tutorials/fhr_reflector/cht/fluid.par
@@ -27,12 +27,10 @@
   viscosity = -100.0
   density = 1.0
   residualTol = 1.0e-8
-  residualProj = false
   boundaryTypeMap = W, W, symy, W, v, o, W, W
 
 [PRESSURE]
   residualTol = 1.0e-8
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = -1500.5

--- a/tutorials/fhr_reflector/conduction/fluid.par
+++ b/tutorials/fhr_reflector/conduction/fluid.par
@@ -27,12 +27,10 @@
   viscosity = -100.0
   density = 1.0
   residualTol = 1.0e-8
-  residualProj = false
   boundaryTypeMap = W, W, symy, W, v, o, W, W
 
 [PRESSURE]
   residualTol = 1.0e-8
-  residualProj = false
 
 [TEMPERATURE]
   conductivity = -1500.5

--- a/tutorials/gas_compact_cht/ranstube.par
+++ b/tutorials/gas_compact_cht/ranstube.par
@@ -34,7 +34,6 @@
 
 [PRESSURE]
   residualTol = 1e-04
-  residualProj = true
 
 [VELOCITY]
   solver = none
@@ -42,7 +41,6 @@
   density = 1.0
   boundaryTypeMap = v, o, W
   residualTol = 1e-06
-  residualProj = true
 
 [TEMPERATURE]
   rhoCp = 1.0

--- a/tutorials/gas_compact_multiphysics/ranstube.par
+++ b/tutorials/gas_compact_multiphysics/ranstube.par
@@ -35,7 +35,6 @@
 
 [PRESSURE]
   residualTol = 1e-04
-  residualProj = true
 
 [VELOCITY]
   solver = none
@@ -43,7 +42,6 @@
   density = 1.0
   boundaryTypeMap = v, o, W
   residualTol = 1e-06
-  residualProj = true
 
 [TEMPERATURE]
   rhoCp = 1.0

--- a/tutorials/restart_nek_and_moose/create_checkpoints/pyramid.par
+++ b/tutorials/restart_nek_and_moose/create_checkpoints/pyramid.par
@@ -14,15 +14,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/tutorials/restart_nek_and_moose/read_from_checkpoints/pyramid.par
+++ b/tutorials/restart_nek_and_moose/read_from_checkpoints/pyramid.par
@@ -15,15 +15,12 @@
   viscosity = 1.0
   density = 1.0
   residualTol = 1.0e-6
-  residualProj = false
   boundaryTypeMap = inlet, outlet, wall, wall, wall, wall, wall, wall
 
 [PRESSURE]
   residualTol = 1.0e-5
-  residualProj = false
 
 [TEMPERATURE]
   solver = none
   residualTol = 1.0e-5
-  residualProj  = no
   boundaryTypeMap = f, f, f, f, f, f, f, f

--- a/tutorials/subchannel/sfr_7pin.par
+++ b/tutorials/subchannel/sfr_7pin.par
@@ -14,11 +14,9 @@
   density = 834.5
   boundaryTypeMap = W, W, v, O
   residualTol = 1.0e-6
-  residualProj = false
 
 [PRESSURE]
   residualTol = 1.0e-6
-  residualProj = false
 
 [TEMPERATURE]
   solver = none


### PR DESCRIPTION
`residualProj` is fully deprecated in the next NekRS release, so we can remove it ahead of time to simplify the larger PR.