### PR TITLE
Add more multi-app init tests to confirm the parallel behavior

### DIFF
--- a/test/tests/nek_stochastic/quiet_init/ethier.par
+++ b/test/tests/nek_stochastic/quiet_init/ethier.par
@@ -1,1 +1,42 @@
-../ethier.par
+[GENERAL]
+polynomialOrder = 3
+stopAt = numSteps
+numSteps = 5
+dt = 2e-03
+timeStepper = tombo3
+writeControl = steps
+writeInterval = 5
+
+[PRESSURE]
+residualTol = 1e-08
+
+[VELOCITY]
+boundaryTypeMap = inlet
+residualTol = 1e-12
+density = 1.0
+viscosity = -100
+
+[TEMPERATURE]
+boundaryTypeMap = flux
+residualTol = 1e-12
+rhoCp = 1.0
+conductivity = -100
+
+[SCALAR01]
+boundaryTypeMap = flux
+residualTol = 1e-12
+rho = 1.0
+diffusivity = -100
+
+[SCALAR02]
+solver = none
+
+[CASEDATA]
+P_U0 = 0.5
+P_V0 = 0.1
+P_W0 = 0.2
+P_A0 = 0.025
+P_D0 = 0.5
+P_OMEGA = 15.0
+P_AMP = 1.5
+

--- a/test/tests/nek_stochastic/quiet_init/tests
+++ b/test/tests/nek_stochastic/quiet_init/tests
@@ -1,7 +1,74 @@
 [Tests]
-  [driver_multi]
+  [clear0]
+    type = RunCommand
+    command = 'rm -rf .cache/'
+    requirement = "The system shall clear the cache before attempting the test with another set of ranks."
+    required_objects = 'NekRSProblem'
+  []
+  [driver_multi_1]
     type = CSVDiff
     input = driver_multi.i
+    min_parallel = 1
+    max_parallel = 1
+    prereq = clear0
+    csvdiff = 'driver_multi_out_nek0.csv driver_multi_out_nek1.csv driver_multi_out_nek2.csv'
+    requirement = "The system shall stochastic values to be sent from MOOSE to NekRS. This example sends 3 values to "
+                  "3 unique NekRS solves, without any restart or overlap of MPI communicators. We check that the values "
+                  "are properly received in the scratch space by using that value to set a dummy scalar01. We purposefully "
+                  "put this test in its own directory to prove that there are no requirements on precompilation."
+    required_objects = 'NekRSProblem'
+  []
+  [clear1]
+    type = RunCommand
+    command = 'rm -rf .cache/'
+    requirement = "The system shall clear the cache before attempting the test with another set of ranks."
+    required_objects = 'NekRSProblem'
+  []
+  [driver_multi_2]
+    type = CSVDiff
+    input = driver_multi.i
+    min_parallel = 2
+    max_parallel = 2
+    prereq = clear1
+    csvdiff = 'driver_multi_out_nek0.csv driver_multi_out_nek1.csv driver_multi_out_nek2.csv'
+    requirement = "The system shall stochastic values to be sent from MOOSE to NekRS. This example sends 3 values to "
+                  "3 unique NekRS solves, without any restart or overlap of MPI communicators. We check that the values "
+                  "are properly received in the scratch space by using that value to set a dummy scalar01. We purposefully "
+                  "put this test in its own directory to prove that there are no requirements on precompilation."
+    required_objects = 'NekRSProblem'
+  []
+  [clear2]
+    type = RunCommand
+    command = 'rm -rf .cache/'
+    prereq = driver_multi_2
+    requirement = "The system shall clear the cache before attempting the test with another set of ranks."
+    required_objects = 'NekRSProblem'
+  []
+  [driver_multi_3]
+    type = CSVDiff
+    input = driver_multi.i
+    min_parallel = 3
+    max_parallel = 3
+    prereq = clear2
+    csvdiff = 'driver_multi_out_nek0.csv driver_multi_out_nek1.csv driver_multi_out_nek2.csv'
+    requirement = "The system shall stochastic values to be sent from MOOSE to NekRS. This example sends 3 values to "
+                  "3 unique NekRS solves, without any restart or overlap of MPI communicators. We check that the values "
+                  "are properly received in the scratch space by using that value to set a dummy scalar01. We purposefully "
+                  "put this test in its own directory to prove that there are no requirements on precompilation."
+    required_objects = 'NekRSProblem'
+  []
+  [clear3]
+    type = RunCommand
+    command = 'rm -rf .cache/'
+    prereq = driver_multi_3
+    requirement = "The system shall clear the cache before attempting the test with another set of ranks."
+    required_objects = 'NekRSProblem'
+  []
+  [driver_multi_4]
+    type = CSVDiff
+    input = driver_multi.i
+    min_parallel = 4
+    prereq = clear3
     csvdiff = 'driver_multi_out_nek0.csv driver_multi_out_nek1.csv driver_multi_out_nek2.csv'
     requirement = "The system shall stochastic values to be sent from MOOSE to NekRS. This example sends 3 values to "
                   "3 unique NekRS solves, without any restart or overlap of MPI communicators. We check that the values "


### PR DESCRIPTION
I am seeing a likely regression in an upcoming release of nekRS in how it handles calling `nekrs::setup` multiple times. To add additional testing ahead of time, this expands the repeated-sub-app tests to include additional choices for MPI ranks.