### PR TITLE
Correct fluid/solid block numbering

### DIFF
--- a/include/mesh/NekRSMesh.h
+++ b/include/mesh/NekRSMesh.h
@@ -470,6 +470,15 @@ protected:
   int _nek_n_flow_elems;
 
   /**
+   * \brief "Phase" for each element (fluid = 0, solid = 1)
+   *
+   * TODO: This could be improved so that we don't need to collect this information,
+   * but would require rewriting of a lot of the code used to assemble the members in
+   * NekVolumeCoupling.
+   */
+  std::vector<int> _phase;
+
+  /**
    * \brief \f$x\f$ coordinates of the current GLL points (which can move in time), for this rank
    *
    * This is ordered according to nekRS's internal geometry layout, and is indexed

--- a/test/tests/deformation/mesh-velocity-areas/pipe.i
+++ b/test/tests/deformation/mesh-velocity-areas/pipe.i
@@ -126,33 +126,29 @@
    [bdisp_x_to_nek]
      type = MultiAppNearestNodeTransfer
      source_variable = disp_x_o
-     direction = to_multiapp
-     multi_app = nek
+     to_multi_app = nek
      variable = disp_x
      source_boundary = 2
    []
    [bdisp_y_to_nek]
      type = MultiAppNearestNodeTransfer
      source_variable = disp_y_o
-     direction = to_multiapp
-     multi_app = nek
+     to_multi_app = nek
      variable = disp_y
      source_boundary = 2
    []
    [bdisp_z_to_nek]
      type = MultiAppNearestNodeTransfer
      source_variable = disp_z_o
-     direction = to_multiapp
-     multi_app = nek
+     to_multi_app = nek
      variable = disp_z
      source_boundary = 2
    []
    [synchronize]
     type = MultiAppPostprocessorTransfer
     to_postprocessor = transfer_in
-    direction = to_multiapp
     from_postprocessor = synchronize
-    multi_app = nek
+    to_multi_app = nek
   []
 []
 

--- a/test/tests/deformation/mesh-velocity-nondimensional/pipe.i
+++ b/test/tests/deformation/mesh-velocity-nondimensional/pipe.i
@@ -128,33 +128,29 @@
    [bdisp_x_to_nek]
      type = MultiAppNearestNodeTransfer
      source_variable = disp_x_o
-     direction = to_multiapp
-     multi_app = nek
+     to_multi_app = nek
      variable = disp_x
      source_boundary = 2
    []
    [bdisp_y_to_nek]
      type = MultiAppNearestNodeTransfer
      source_variable = disp_y_o
-     direction = to_multiapp
-     multi_app = nek
+     to_multi_app = nek
      variable = disp_y
      source_boundary = 2
    []
    [bdisp_z_to_nek]
      type = MultiAppNearestNodeTransfer
      source_variable = disp_z_o
-     direction = to_multiapp
-     multi_app = nek
+     to_multi_app = nek
      variable = disp_z
      source_boundary = 2
    []
    [synchronize]
     type = MultiAppPostprocessorTransfer
     to_postprocessor = transfer_in
-    direction = to_multiapp
     from_postprocessor = synchronize
-    multi_app = nek
+    to_multi_app = nek
   []
 []
 


### PR DESCRIPTION
For CHT, NekRS numbers all the fluid elements with lower element IDs than all of the solid elements. This sorting exists on each RANK, but previously we were doing this assignment of subdomain IDs only on the global data. In other words, we were not correctly labeling elements in the solid vs. fluid mesh - it worked in serial, but wasn't computing the total number of fluid elements for parallel runs. This fixes that error.