### PR TITLE
Remove unused function for fissile materials.

### DIFF
--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -308,15 +308,6 @@ public:
   bool materialFill(const cellInfo & cell_info, int32_t & material_index) const;
 
   /**
-   * Whether a cell contains any fissile materials; for now, this simply returns true for
-   * cells filled by universes or lattices because we have yet to implement something more
-   * sophisticated that recurses down into all the fills
-   * @param[in] cell_info cell ID, instance
-   * @return whether cell contains fissile material
-   */
-  virtual bool cellHasFissileMaterials(const cellInfo & cell_info) const;
-
-  /**
    * Calculate the number of unique OpenMC cells (each with a unique ID & instance)
    * @return number of unique OpenMC Cells in entire model
    */

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -468,29 +468,6 @@ OpenMCProblemBase::importProperties() const
   catchOpenMCError(err, "load temperature and density from a properties.h5 file");
 }
 
-bool
-OpenMCProblemBase::cellHasFissileMaterials(const cellInfo & cell_info) const
-{
-  int32_t material_index;
-  auto is_material_cell = materialFill(cell_info, material_index);
-
-  // TODO: for cells with non-material fills, we need to implement something that recurses
-  // into the cell/universe fills to see if there's anything fissile; until then, just assume
-  // that the cell has something fissile
-  if (!is_material_cell)
-    return true;
-
-  // We know void cells certainly aren't fissionable; if not void, check if fissionable
-  if (material_index != MATERIAL_VOID)
-  {
-    const auto & material = openmc::model::materials[material_index];
-    if (material->fissionable_)
-      return true;
-  }
-
-  return false;
-}
-
 xt::xtensor<double, 1>
 OpenMCProblemBase::relativeError(const xt::xtensor<double, 1> & sum,
                                  const xt::xtensor<double, 1> & sum_sq,


### PR DESCRIPTION
We used to throw a warning if the user adds tallies to a non-fissile region. But now that we support much more general tallies like `flux` or `heating-local`, we didn't need this anymore. Somehow, this function lingered around in the code, so this removal isn't changing any functionality - just tidying up.