### PR TITLE
Remove nek_mesh parameter from NekRSSeparateDomainProblem

### DIFF
--- a/include/base/CardinalEnums.h
+++ b/include/base/CardinalEnums.h
@@ -33,6 +33,21 @@ MooseEnum getRelaxationEnum();
 MooseEnum getTallyTriggerEnum();
 MooseEnum getInitialPropertiesEnum();
 MultiMooseEnum getTallyScoreEnum();
+MooseEnum getNekMeshEnum();
+
+namespace nek_mesh
+{
+
+/**
+ * Enumeration of possible meshes to operate upon within NekRS
+ */
+enum NekMeshEnum
+{
+  fluid,
+  solid,
+  all
+};
+} // namespace nek_mesh
 
 namespace synchronization
 {

--- a/include/base/NekInterface.h
+++ b/include/base/NekInterface.h
@@ -207,7 +207,7 @@ mesh_t * temperatureMesh();
  * @param[in] pp_mesh which NekRS mesh to operate on
  * @return mesh to act on
  */
-mesh_t * getMesh(const MooseEnum & pp_mesh);
+mesh_t * getMesh(const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Get the process rank
@@ -427,7 +427,7 @@ bool normalizeHeatSource(const NekVolumeCoupling & nek_volume_coupling,
  * @param[in] pp_mesh which NekRS mesh to operate on
  * @return area integral
  */
-double area(const std::vector<int> & boundary_id, const MooseEnum & pp_mesh);
+double area(const std::vector<int> & boundary_id, const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Compute the area integral of a given slot in the usrwrk array over a set of boundary IDs
@@ -437,7 +437,7 @@ double area(const std::vector<int> & boundary_id, const MooseEnum & pp_mesh);
  * @return area integral of a component of the usrwrk array
  */
 double usrWrkSideIntegral(const std::vector<int> & boundary_id, const unsigned int & slot,
-                          const MooseEnum & pp_mesh);
+                          const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Compute the area integral of a given integrand over a set of boundary IDs
@@ -447,14 +447,14 @@ double usrWrkSideIntegral(const std::vector<int> & boundary_id, const unsigned i
  * @return area integral of a field
  */
 double sideIntegral(const std::vector<int> & boundary_id, const field::NekFieldEnum & integrand,
-                    const MooseEnum & pp_mesh);
+                    const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Compute the volume over the entire scalar mesh
  * @param[in] pp_mesh which NekRS mesh to operate on
  * @return volume integral
  */
-double volume(const MooseEnum & pp_mesh);
+double volume(const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Dimensionalize a volume
@@ -498,7 +498,7 @@ void dimensionalizeSideIntegral(const field::NekFieldEnum & integrand,
 void dimensionalizeSideIntegral(const field::NekFieldEnum & integrand,
                                 const std::vector<int> & boundary_id,
                                 double & integral,
-                                const MooseEnum & pp_mesh);
+                                const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Compute the volume integral of a given integrand over the entire scalar mesh
@@ -509,7 +509,7 @@ void dimensionalizeSideIntegral(const field::NekFieldEnum & integrand,
  */
 double volumeIntegral(const field::NekFieldEnum & integrand,
                       const double & volume,
-                      const MooseEnum & pp_mesh);
+                      const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Compute the mass flowrate over a set of boundary IDs
@@ -518,7 +518,7 @@ double volumeIntegral(const field::NekFieldEnum & integrand,
  * @return mass flowrate
  */
 double massFlowrate(const std::vector<int> & boundary_id,
-                    const MooseEnum & pp_mesh);
+                    const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Compute the mass flux weighted integral of a given integrand over a set of boundary IDs
@@ -529,7 +529,7 @@ double massFlowrate(const std::vector<int> & boundary_id,
  */
 double sideMassFluxWeightedIntegral(const std::vector<int> & boundary_id,
                                     const field::NekFieldEnum & integrand,
-                                    const MooseEnum & pp_mesh);
+                                    const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Compute the integral of pressure on a surface, multiplied by the unit normal
@@ -539,7 +539,7 @@ double sideMassFluxWeightedIntegral(const std::vector<int> & boundary_id,
  * @param[in] pp_mesh which NekRS mesh to operate on
  * @return pressure surface force, along a particular direction
  */
-double pressureSurfaceForce(const std::vector<int> & boundary_id, const Point & direction, const MooseEnum & pp_mesh);
+double pressureSurfaceForce(const std::vector<int> & boundary_id, const Point & direction, const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Compute the heat flux over a set of boundary IDs
@@ -548,7 +548,7 @@ double pressureSurfaceForce(const std::vector<int> & boundary_id, const Point & 
  * @return heat flux area integral
  */
 double heatFluxIntegral(const std::vector<int> & boundary_id,
-                        const MooseEnum & pp_mesh);
+                        const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Limit the temperature in nekRS to within the range of [min_T, max_T]
@@ -565,7 +565,7 @@ void limitTemperature(const double * min_T, const double * max_T);
  * @param[out] grad_f gradient of field
  */
 void gradient(const int offset, const double * f, double * grad_f,
-              const MooseEnum & pp_mesh);
+              const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Find the minimum of a given field over the entire nekRS domain
@@ -574,7 +574,7 @@ void gradient(const int offset, const double * f, double * grad_f,
  * @return minimum value of field in volume
  */
 double volumeMinValue(const field::NekFieldEnum & field,
-                      const MooseEnum & pp_mesh);
+                      const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Find the maximum of a given field over the entire nekRS domain
@@ -583,7 +583,7 @@ double volumeMinValue(const field::NekFieldEnum & field,
  * @return maximum value of field in volume
  */
 double volumeMaxValue(const field::NekFieldEnum & field,
-                      const MooseEnum & pp_mesh);
+                      const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Find the minimum of a given field over a set of boundary IDs
@@ -593,7 +593,7 @@ double volumeMaxValue(const field::NekFieldEnum & field,
  * @return minimum value of field on boundary
  */
 double sideMinValue(const std::vector<int> & boundary_id, const field::NekFieldEnum & field,
-                    const MooseEnum & pp_mesh);
+                    const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
  * Find the maximum of a given field over a set of boundary IDs
@@ -603,7 +603,7 @@ double sideMinValue(const std::vector<int> & boundary_id, const field::NekFieldE
  * @param maximum value of field on boundary
  */
 double sideMaxValue(const std::vector<int> & boundary_id, const field::NekFieldEnum & field,
-                    const MooseEnum & pp_mesh);
+                    const nek_mesh::NekMeshEnum pp_mesh);
 
 namespace mesh
 {

--- a/include/base/NekRSSeparateDomainProblem.h
+++ b/include/base/NekRSSeparateDomainProblem.h
@@ -44,13 +44,13 @@ public:
   virtual void initialSetup() override;
 
   /// Send boundary velocity to nekRS
-  void sendBoundaryVelocityToNek(const MooseEnum & pp_mesh);
+  void sendBoundaryVelocityToNek(const nek_mesh::NekMeshEnum pp_mesh);
 
   /// Send boundary temperature to nekRS
-  void sendBoundaryTemperatureToNek(const MooseEnum & pp_mesh);
+  void sendBoundaryTemperatureToNek(const nek_mesh::NekMeshEnum pp_mesh);
 
   ///Send scalar to NekRS
-  void sendBoundaryScalarToNek(const MooseEnum & pp_mesh,
+  void sendBoundaryScalarToNek(const nek_mesh::NekMeshEnum pp_mesh,
                                const int scalarId,
                                const double scalarValue);
 
@@ -65,7 +65,7 @@ protected:
    * @param[in] elem_id global element ID
    * @param[in] velocity boundary velocity
    */
-  void velocity(const MooseEnum & pp_mesh, const int elem_id, const double velocity);
+  void velocity(const nek_mesh::NekMeshEnum pp_mesh, const int elem_id, const double velocity);
 
   /**
    * Send temperature from 1d system code to the nekRS mesh
@@ -73,7 +73,7 @@ protected:
    * @param[in] elem_id global element ID
    * @param[in] temperature boundary temperature
    */
-  void temperature(const MooseEnum & pp_mesh, const int elem_id, const double temperature);
+  void temperature(const nek_mesh::NekMeshEnum pp_mesh, const int elem_id, const double temperature);
 
   /**
    * Send scalar from 1d system code to the nekRS mesh
@@ -82,7 +82,7 @@ protected:
    * @param[in] scalarId corresponding NekRS scalar ID
    * @param[in] scalarValue boundary scalar value
    */
-  void scalar(const MooseEnum & pp_mesh, const int elem_id, const int scalarId, const double scalarValue);
+  void scalar(const nek_mesh::NekMeshEnum pp_mesh, const int elem_id, const int scalarId, const double scalarValue);
 
   /// Type of coupling to apply to NekRS
   const MultiMooseEnum _coupling_type;
@@ -121,6 +121,6 @@ protected:
   /// Postprocessor containing the signal of when a synchronization has occurred
   const PostprocessorValue * _transfer_in = nullptr;
 
-  /// Which NekRS mesh to act on
-  const MooseEnum _pp_mesh;
+  /// Which NekRS mesh to act on (always the fluid mesh)
+  const nek_mesh::NekMeshEnum _pp_mesh = nek_mesh::fluid;
 };

--- a/include/postprocessors/NekPostprocessor.h
+++ b/include/postprocessors/NekPostprocessor.h
@@ -50,5 +50,5 @@ protected:
   const NekRSProblemBase * _nek_problem;
 
   /// Which NekRS mesh to act on
-  const MooseEnum _pp_mesh;
+  const nek_mesh::NekMeshEnum _pp_mesh;
 };

--- a/src/base/CardinalEnums.C
+++ b/src/base/CardinalEnums.C
@@ -19,6 +19,12 @@
 #include "CardinalEnums.h"
 
 MooseEnum
+getNekMeshEnum()
+{
+  return MooseEnum("fluid solid all", "all");
+}
+
+MooseEnum
 getSynchronizationEnum()
 {
   return MooseEnum("constant parent_app", "constant");

--- a/src/base/NekInterface.C
+++ b/src/base/NekInterface.C
@@ -224,14 +224,15 @@ temperatureMesh()
 }
 
 mesh_t *
-getMesh(const MooseEnum & pp_mesh)
+getMesh(const nek_mesh::NekMeshEnum pp_mesh)
 {
-  if (pp_mesh == "fluid")
+  if (pp_mesh == nek_mesh::fluid)
     return flowMesh();
-  else if (pp_mesh == "all")
+  else if (pp_mesh == nek_mesh::all)
     return entireMesh();
   else
-    mooseError("Cardinal cannot operate on this mesh region of ", pp_mesh);
+    mooseError("This object does not support operations on the solid part of the NekRS mesh!\n"
+      "Valid options for 'mesh' are 'fluid' or 'all'.");
 }
 
 int
@@ -668,7 +669,7 @@ copyDeformationToDevice()
 
 double
 sideMaxValue(const std::vector<int> & boundary_id, const field::NekFieldEnum & field,
-             const MooseEnum & pp_mesh)
+             const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
 
@@ -707,7 +708,7 @@ sideMaxValue(const std::vector<int> & boundary_id, const field::NekFieldEnum & f
 }
 
 double
-volumeMaxValue(const field::NekFieldEnum & field, const MooseEnum & pp_mesh)
+volumeMaxValue(const field::NekFieldEnum & field, const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
 
@@ -740,7 +741,7 @@ volumeMaxValue(const field::NekFieldEnum & field, const MooseEnum & pp_mesh)
 }
 
 double
-volumeMinValue(const field::NekFieldEnum & field, const MooseEnum & pp_mesh)
+volumeMinValue(const field::NekFieldEnum & field, const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
 
@@ -774,7 +775,7 @@ volumeMinValue(const field::NekFieldEnum & field, const MooseEnum & pp_mesh)
 
 double
 sideMinValue(const std::vector<int> & boundary_id, const field::NekFieldEnum & field,
-             const MooseEnum & pp_mesh)
+             const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
 
@@ -887,7 +888,7 @@ centroid(int local_elem_id)
 }
 
 double
-volume(const MooseEnum & pp_mesh)
+volume(const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
 
@@ -958,7 +959,7 @@ void
 dimensionalizeSideIntegral(const field::NekFieldEnum & integrand,
                            const std::vector<int> & boundary_id,
                            double & integral,
-			                     const MooseEnum & pp_mesh)
+			                     const nek_mesh::NekMeshEnum pp_mesh)
 {
   // dimensionalize the field if needed
   solution::dimensionalize(integrand, integral);
@@ -973,7 +974,7 @@ dimensionalizeSideIntegral(const field::NekFieldEnum & integrand,
 
 double
 volumeIntegral(const field::NekFieldEnum & integrand, const Real & volume,
-               const MooseEnum & pp_mesh)
+               const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
 
@@ -1000,7 +1001,7 @@ volumeIntegral(const field::NekFieldEnum & integrand, const Real & volume,
 }
 
 double
-area(const std::vector<int> & boundary_id, const MooseEnum & pp_mesh)
+area(const std::vector<int> & boundary_id, const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
 
@@ -1034,7 +1035,7 @@ area(const std::vector<int> & boundary_id, const MooseEnum & pp_mesh)
 
 double
 usrWrkSideIntegral(const std::vector<int> & boundary_id, const unsigned int & slot,
-                   const MooseEnum & pp_mesh)
+                   const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
   nrs_t * nrs = (nrs_t *) nrsPtr();
@@ -1067,7 +1068,7 @@ usrWrkSideIntegral(const std::vector<int> & boundary_id, const unsigned int & sl
 
 double
 sideIntegral(const std::vector<int> & boundary_id, const field::NekFieldEnum & integrand,
-             const MooseEnum & pp_mesh)
+             const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
 
@@ -1103,7 +1104,7 @@ sideIntegral(const std::vector<int> & boundary_id, const field::NekFieldEnum & i
 }
 
 double
-massFlowrate(const std::vector<int> & boundary_id, const MooseEnum & pp_mesh)
+massFlowrate(const std::vector<int> & boundary_id, const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
   nrs_t * nrs = (nrs_t *)nrsPtr();
@@ -1153,7 +1154,7 @@ massFlowrate(const std::vector<int> & boundary_id, const MooseEnum & pp_mesh)
 double
 sideMassFluxWeightedIntegral(const std::vector<int> & boundary_id,
                              const field::NekFieldEnum & integrand,
-                             const MooseEnum & pp_mesh)
+                             const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
   nrs_t * nrs = (nrs_t *)nrsPtr();
@@ -1209,7 +1210,7 @@ sideMassFluxWeightedIntegral(const std::vector<int> & boundary_id,
 }
 
 double
-pressureSurfaceForce(const std::vector<int> & boundary_id, const Point & direction, const MooseEnum & pp_mesh)
+pressureSurfaceForce(const std::vector<int> & boundary_id, const Point & direction, const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
   nrs_t * nrs = (nrs_t *)nrsPtr();
@@ -1251,7 +1252,7 @@ pressureSurfaceForce(const std::vector<int> & boundary_id, const Point & directi
 }
 
 double
-heatFluxIntegral(const std::vector<int> & boundary_id, const MooseEnum & pp_mesh)
+heatFluxIntegral(const std::vector<int> & boundary_id, const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
   nrs_t * nrs = (nrs_t *)nrsPtr();
@@ -1304,7 +1305,7 @@ heatFluxIntegral(const std::vector<int> & boundary_id, const MooseEnum & pp_mesh
 }
 
 void
-gradient(const int offset, const double * f, double * grad_f, const MooseEnum & pp_mesh)
+gradient(const int offset, const double * f, double * grad_f, const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
 

--- a/src/base/NekRSSeparateDomainProblem.C
+++ b/src/base/NekRSSeparateDomainProblem.C
@@ -47,10 +47,6 @@ NekRSSeparateDomainProblem::validParams()
   params.addRequiredParam<std::vector<int>>("outlet_boundary", "NekRS outlet boundary ID");
   params.addRequiredParam<std::vector<int>>("inlet_boundary", "NekRS inlet boundary ID");
 
-  MooseEnum pp_mesh("fluid solid all", "fluid");
-  params.addParam<MooseEnum>(
-      "nek_mesh", pp_mesh, "NekRS mesh to act on");
-
   return params;
 }
 
@@ -64,8 +60,7 @@ NekRSSeparateDomainProblem::NekRSSeparateDomainProblem(const InputParameters & p
     _coupled_scalars(getParam<MultiMooseEnum>("coupled_scalars")),
     _scalar01_coupling(false),
     _scalar02_coupling(false),
-    _scalar03_coupling(false),
-    _pp_mesh(getParam<MooseEnum>("nek_mesh"))
+    _scalar03_coupling(false)
 {
   if (_nek_mesh->exactMirror())
     mooseError("An exact mesh mirror is not yet supported for NekRSSeparateDomainProblem!");
@@ -185,9 +180,6 @@ NekRSSeparateDomainProblem::NekRSSeparateDomainProblem(const InputParameters & p
   }
 
   _minimum_scratch_size_for_coupling = _usrwrk_indices.size();
-
-  if (_pp_mesh!="fluid")
-    mooseError("NekRSSeparateDomainProblem should only act on the Nek fluid mesh.");
 }
 
 NekRSSeparateDomainProblem::~NekRSSeparateDomainProblem() { nekrs::freeScratch(); }
@@ -267,7 +259,7 @@ NekRSSeparateDomainProblem::syncSolutions(ExternalProblem::Direction direction)
 }
 
 void
-NekRSSeparateDomainProblem::sendBoundaryVelocityToNek(const MooseEnum & pp_mesh)
+NekRSSeparateDomainProblem::sendBoundaryVelocityToNek(const nek_mesh::NekMeshEnum pp_mesh)
 {
   auto & solution = _aux->solution();
   auto sys_number = _aux->number();
@@ -290,7 +282,7 @@ NekRSSeparateDomainProblem::sendBoundaryVelocityToNek(const MooseEnum & pp_mesh)
 }
 
 void
-NekRSSeparateDomainProblem::sendBoundaryTemperatureToNek(const MooseEnum & pp_mesh)
+NekRSSeparateDomainProblem::sendBoundaryTemperatureToNek(const nek_mesh::NekMeshEnum pp_mesh)
 {
   auto & solution = _aux->solution();
   auto sys_number = _aux->number();
@@ -313,7 +305,7 @@ NekRSSeparateDomainProblem::sendBoundaryTemperatureToNek(const MooseEnum & pp_me
 }
 
 void
-NekRSSeparateDomainProblem::sendBoundaryScalarToNek(const MooseEnum & pp_mesh,
+NekRSSeparateDomainProblem::sendBoundaryScalarToNek(const nek_mesh::NekMeshEnum pp_mesh,
                                                     const int scalarId,
                                                     const double scalarValue)
 {
@@ -437,7 +429,7 @@ NekRSSeparateDomainProblem::addExternalVariables()
 }
 
 void
-NekRSSeparateDomainProblem::velocity(const MooseEnum & pp_mesh,
+NekRSSeparateDomainProblem::velocity(const nek_mesh::NekMeshEnum pp_mesh,
                                      const int elem_id,
                                      const double velocity)
 {
@@ -465,7 +457,7 @@ NekRSSeparateDomainProblem::velocity(const MooseEnum & pp_mesh,
 }
 
 void
-NekRSSeparateDomainProblem::temperature(const MooseEnum & pp_mesh,
+NekRSSeparateDomainProblem::temperature(const nek_mesh::NekMeshEnum pp_mesh,
                                         const int elem_id,
                                         const double temperature)
 {
@@ -493,7 +485,7 @@ NekRSSeparateDomainProblem::temperature(const MooseEnum & pp_mesh,
 }
 
 void
-NekRSSeparateDomainProblem::scalar(const MooseEnum & pp_mesh,
+NekRSSeparateDomainProblem::scalar(const nek_mesh::NekMeshEnum pp_mesh,
                                    const int elem_id,
                                    const int scalarId,
                                    const double scalar)

--- a/src/postprocessors/NekPostprocessor.C
+++ b/src/postprocessors/NekPostprocessor.C
@@ -25,9 +25,8 @@ NekPostprocessor::validParams()
 {
   InputParameters params = GeneralPostprocessor::validParams();
 
-  MooseEnum mesh("fluid solid all", "all");
   params.addParam<MooseEnum>(
-      "mesh", mesh, "NekRS mesh to compute postprocessor on");
+      "mesh", getNekMeshEnum(), "NekRS mesh to compute postprocessor on");
 
   return params;
 }
@@ -35,7 +34,7 @@ NekPostprocessor::validParams()
 NekPostprocessor::NekPostprocessor(const InputParameters & parameters)
   : GeneralPostprocessor(parameters),
     _mesh(_subproblem.mesh()),
-    _pp_mesh(getParam<MooseEnum>("mesh"))
+    _pp_mesh(getParam<MooseEnum>("mesh").getEnum<nek_mesh::NekMeshEnum>())
 {
   _nek_problem = dynamic_cast<const NekRSProblemBase *>(&_fe_problem);
   if (!_nek_problem)
@@ -47,10 +46,6 @@ NekPostprocessor::NekPostprocessor(const InputParameters & parameters)
                " to a Nek-wrapped problem.\n\n"
                "options: 'NekRSProblem', 'NekRSSeparateDomainProblem', 'NekRSStandaloneProblem'");
   }
-
-  if (_pp_mesh=="solid")
-    mooseError("Cardinal cannot operate solely on the NekRS solid mesh, but this capability will\n"
-               "be added in the future. Please use 'fluid' or 'all' until then.");
 
   // NekRSProblem enforces that we then use NekRSMesh, so we don't need to check that
   // this pointer isn't NULL

--- a/src/postprocessors/NekPressureSurfaceForce.C
+++ b/src/postprocessors/NekPressureSurfaceForce.C
@@ -36,7 +36,7 @@ NekPressureSurfaceForce::NekPressureSurfaceForce(const InputParameters & paramet
 {
   _direction = geom_utility::unitVector(getParam<Point>("direction"), "direction");
 
-  if (_pp_mesh != "fluid")
+  if (_pp_mesh != nek_mesh::fluid)
     mooseError("The 'NekPressureSurfaceForce' postprocessor can only be applied to the fluid mesh boundaries!\n"
       "Please change 'mesh' to 'fluid'.");
 }

--- a/test/tests/nek_separatedomain/invalid_params/tests
+++ b/test/tests/nek_separatedomain/invalid_params/tests
@@ -56,20 +56,4 @@
                   "to an ID not contained in NekRS boundary IDs."
     required_objects = 'NekRSSeparateDomainProblem'
   []
-  [invalid_nek_mesh_solid]
-    type = RunException
-    input = nek.i
-    cli_args = 'Problem/nek_mesh="solid"'
-    expect_err = "NekRSSeparateDomainProblem should only act on the Nek fluid mesh."
-    requirement = "The system shall throw an error if this class tries to act on a non-fluid mesh."
-    required_objects = 'NekRSSeparateDomainProblem'
-  []
-  [invalid_nek_mesh_all]
-    type = RunException
-    input = nek.i
-    cli_args = 'Problem/nek_mesh="all"'
-    expect_err = "NekRSSeparateDomainProblem should only act on the Nek fluid mesh."
-    requirement = "The system shall throw an error if this class tries to act on a non-fluid mesh."
-    required_objects = 'NekRSSeparateDomainProblem'
-  []
 []

--- a/test/tests/nek_standalone/conj_ht/tests
+++ b/test/tests/nek_standalone/conj_ht/tests
@@ -13,8 +13,7 @@
     type = RunException
     input = nek.i
     cli_args = 'Postprocessors/Area_BC3_flow/mesh="solid"'
-    expect_err = "Cardinal cannot operate solely on the NekRS solid mesh, but this capability will\n"
-                 "be added in the future. Please use 'fluid' or 'all' until then."
+    expect_err = "This object does not support operations on the solid part of the NekRS mesh!"
     requirement = "The system shall throw an error if trying to act on only the NekRS solid mesh."
     required_objects = 'NekRSProblem'
   []


### PR DESCRIPTION
If the `nek_mesh` parameter can only ever take a single valid value for `NekRSSeparateDomainProblem`, it may be confusing for users to see it in the documentation (which implies they could set some other value besides "fluid").