### PR TITLE
Remove fixed_mesh from postprocessors

### DIFF
--- a/include/postprocessors/NekPostprocessor.h
+++ b/include/postprocessors/NekPostprocessor.h
@@ -43,9 +43,6 @@ protected:
   /// Base mesh this postprocessor acts on
   const MooseMesh & _mesh;
 
-  /// Whether the mesh this postprocessor operates on is fixed, allowing caching of volumes and areas
-  bool _fixed_mesh;
-
   /// Underlying NekRSMesh, if present
   const NekRSMesh * _nek_mesh;
 

--- a/src/postprocessors/NekPostprocessor.C
+++ b/src/postprocessors/NekPostprocessor.C
@@ -52,8 +52,6 @@ NekPostprocessor::NekPostprocessor(const InputParameters & parameters)
     mooseError("Cardinal cannot operate solely on the NekRS solid mesh, but this capability will\n"
                "be added in the future. Please use 'fluid' or 'all' until then.");
 
-  _fixed_mesh = !(nekrs::hasMovingMesh());
-
   // NekRSProblem enforces that we then use NekRSMesh, so we don't need to check that
   // this pointer isn't NULL
   _nek_mesh = dynamic_cast<const NekRSMesh *>(&_mesh);

--- a/src/postprocessors/NekSideAverage.C
+++ b/src/postprocessors/NekSideAverage.C
@@ -32,15 +32,13 @@ NekSideAverage::validParams()
 
 NekSideAverage::NekSideAverage(const InputParameters & parameters) : NekSideIntegral(parameters)
 {
-  if (_fixed_mesh)
-    _area = nekrs::area(_boundary, _pp_mesh);
 }
 
 Real
 NekSideAverage::getValue()
 {
-  Real area = _fixed_mesh ? _area : nekrs::area(_boundary, _pp_mesh);
-  return NekSideIntegral::getValue() / area;
+  _area = nekrs::area(_boundary, _pp_mesh);
+  return NekSideIntegral::getValue() / _area;
 }
 
 #endif

--- a/src/postprocessors/NekSideIntegral.C
+++ b/src/postprocessors/NekSideIntegral.C
@@ -38,7 +38,6 @@ NekSideIntegral::NekSideIntegral(const InputParameters & parameters)
 Real
 NekSideIntegral::getValue()
 {
-
   if (_field == field::velocity_component)
   {
     Real vx = nekrs::sideIntegral(_boundary, field::velocity_x, _pp_mesh);
@@ -46,7 +45,6 @@ NekSideIntegral::getValue()
     Real vz = nekrs::sideIntegral(_boundary, field::velocity_z, _pp_mesh);
     Point velocity(vx, vy, vz);
     return _velocity_direction * velocity;
-    ;
   }
 
   return nekrs::sideIntegral(_boundary, _field, _pp_mesh);

--- a/src/postprocessors/NekVolumeIntegral.C
+++ b/src/postprocessors/NekVolumeIntegral.C
@@ -33,15 +33,12 @@ NekVolumeIntegral::validParams()
 NekVolumeIntegral::NekVolumeIntegral(const InputParameters & parameters)
   : NekFieldPostprocessor(parameters)
 {
-  if (_fixed_mesh)
-    _volume = nekrs::volume(_pp_mesh);
 }
 
 Real
 NekVolumeIntegral::getValue()
 {
-  if (!_fixed_mesh)
-    _volume = nekrs::volume(_pp_mesh);
+  _volume = nekrs::volume(_pp_mesh);
 
   if (_field == field::velocity_component)
   {

--- a/src/postprocessors/ReynoldsNumber.C
+++ b/src/postprocessors/ReynoldsNumber.C
@@ -45,20 +45,17 @@ ReynoldsNumber::ReynoldsNumber(const InputParameters & parameters)
   }
   else
     checkUnusedParam(parameters, "L_ref", "running NekRS in non-dimensional form");
-
-  if (_fixed_mesh)
-    _area = nekrs::area(_boundary, _pp_mesh);
 }
 
 Real
 ReynoldsNumber::getValue()
 {
-  Real area = _fixed_mesh ? _area : nekrs::area(_boundary, _pp_mesh);
+  _area = nekrs::area(_boundary, _pp_mesh);
   Real mdot = std::abs(nekrs::sideMassFluxWeightedIntegral(_boundary, field::unity, _pp_mesh));
   Real mu = nekrs::viscosity();
   Real L = _nek_problem->nondimensional() ? _nek_problem->L_ref() : *_L_ref;
 
-  return mdot * L / (area * mu);
+  return mdot * L / (_area * mu);
 }
 
 #endif


### PR DESCRIPTION
This removes `_fixed_mesh` for simplicity - the cost savings from this is negligible, so it's not worth the extra code complexity.