### PR TITLE
Replace MultiAppUO with MultiAppGeneralFieldUO to permit distributed mesh

### DIFF
--- a/doc/content/tutorials/cht3.md
+++ b/doc/content/tutorials/cht3.md
@@ -407,7 +407,7 @@ Because THM is a 1-D code, we must perform an averaging operation on the surface
 heat flux computed by MOOSE before it is sent to THM. This requires us to use
 slightly different MOOSE transfers to couple THM and MOOSE. Instead of sending
 a 2-D surface flux distribution, we now compute the wall average heat flux in layers
-and send to THM with a [MultiAppUserObjectTransfer](https://mooseframework.inl.gov/source/transfers/MultiAppUserObjectTransfer.html).
+and send to THM with a [MultiAppGeneralFieldUserObjectTransfer](https://mooseframework.inl.gov/source/transfers/MultiAppGeneralFieldUserObjectTransfer.html).
 To receive temperature from THM, we use the same
 [MultiAppNearestNodeTransfer](https://mooseframework.inl.gov/source/transfers/MultiAppNearestNodeTransfer.html)
 that we used when coupling to NekRS - but now, we are coupling a 1-D model to a 3-D model

--- a/doc/content/tutorials/openmc_fluid.md
+++ b/doc/content/tutorials/openmc_fluid.md
@@ -549,7 +549,7 @@ to MOOSE heat conduction, we use four transfers:
 
 To couple OpenMC to [!ac](THM), we require three transfers:
 
-- [MultiAppUserObjectTransfer](https://mooseframework.inl.gov/source/transfers/MultiAppUserObjectTransfer.html)
+- [MultiAppGeneralFieldUserObjectTransfer](https://mooseframework.inl.gov/source/transfers/MultiAppGeneralFieldUserObjectTransfer.html)
   to send the layer-averaged wall heat flux from OpenMC (which computes the layered-average heat flux from the heat
   flux received from MOOSE heat conduction) to [!ac](THM)
 - [MultiAppNearestNodeTransfer](https://mooseframework.inl.gov/source/transfers/MultiAppNearestNodeTransfer.html)

--- a/test/tests/conduction/identical_volume/cube/tests
+++ b/test/tests/conduction/identical_volume/cube/tests
@@ -10,7 +10,7 @@
                   "temperature distribution when a heat source is applied to the nekRS problem. "
                   "A reference MOOSE standalone problem (in moose.i) solves the equation "
                   "k*nabla(T)=7*T, i.e. the 'heat source' is 7*T. This surrogate problem is then "
-                  "replicated with Cardinal, where nekRS solves the k*nabla(T)=q, where q is a "
+                  "repeated with Cardinal, where nekRS solves the k*nabla(T)=q, where q is a "
                   "heat source 'computed' by MOOSE to be 7*T_n, where T_n is the temperature from "
                   "nekRS. This problem does not really represent any interesting physical case, but "
                   "is solely intended to show that nekRS correctly solves the heat equation with a "

--- a/test/tests/conduction/nonidentical_volume/cylinder/tests
+++ b/test/tests/conduction/nonidentical_volume/cylinder/tests
@@ -9,7 +9,7 @@
                   "and when the meshes do not perfectly line up (i.e. the volumes are different). "
                   "A reference MOOSE standalone problem (in moose.i) solves the equation "
                   "k*nabla(T)=7*T, i.e. the 'heat source' is f(T,x,z). This surrogate problem is then "
-                  "replicated with Cardinal, where nekRS solves the k*nabla(T)=q, where q is a "
+                  "repeated with Cardinal, where nekRS solves the k*nabla(T)=q, where q is a "
                   "heat source 'computed' by MOOSE to be f(T_n,x,z), where T_n is the temperature from "
                   "nekRS. This problem does not really represent any interesting physical case, but "
                   "is solely intended to show that nekRS correctly solves the heat equation with a "

--- a/test/tests/nek_standalone/ethier/tests
+++ b/test/tests/nek_standalone/ethier/tests
@@ -4,7 +4,6 @@
     input = nek.i
     csvdiff = nek_out.csv
     min_parallel = 2
-    mesh_mode = 'replicated'
     requirement = "Cardinal shall be able to run the ethier NekRS example with a thin wrapper. "
                   "We add postprocessors to let us compare min/max values printed to the screen by NekRS."
     required_objects = 'NekRSProblem'

--- a/test/tests/userobjects/gap/dimensional/nek.i
+++ b/test/tests/userobjects/gap/dimensional/nek.i
@@ -1,7 +1,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]
@@ -140,37 +139,37 @@
 
 [Transfers]
   [uo1_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_T
     to_multi_app = subchannel
     variable = avg_T
   []
   [uo2_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_p
     to_multi_app = subchannel
     variable = avg_p
   []
   [uo3_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_v
     to_multi_app = subchannel
     variable = avg_v
   []
   [uo4_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = integral_T
     to_multi_app = subchannel
     variable = integral_T
   []
   [uo5_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = integral_p
     to_multi_app = subchannel
     variable = integral_p
   []
   [uo6_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = integral_v
     to_multi_app = subchannel
     variable = integral_v

--- a/test/tests/userobjects/gap/dimensional/nek.i
+++ b/test/tests/userobjects/gap/dimensional/nek.i
@@ -140,37 +140,37 @@
 [Transfers]
   [uo1_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_T
+    source_user_object = avg_T
     to_multi_app = subchannel
     variable = avg_T
   []
   [uo2_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_p
+    source_user_object = avg_p
     to_multi_app = subchannel
     variable = avg_p
   []
   [uo3_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_v
+    source_user_object = avg_v
     to_multi_app = subchannel
     variable = avg_v
   []
   [uo4_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = integral_T
+    source_user_object = integral_T
     to_multi_app = subchannel
     variable = integral_T
   []
   [uo5_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = integral_p
+    source_user_object = integral_p
     to_multi_app = subchannel
     variable = integral_p
   []
   [uo6_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = integral_v
+    source_user_object = integral_v
     to_multi_app = subchannel
     variable = integral_v
   []

--- a/test/tests/userobjects/gap/nondimensional/nek.i
+++ b/test/tests/userobjects/gap/nondimensional/nek.i
@@ -1,7 +1,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
   scaling = 7.646e-3
 []
 
@@ -135,37 +134,37 @@
 
 [Transfers]
   [uo1_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_T
     to_multi_app = subchannel
     variable = avg_T
   []
   [uo2_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_p
     to_multi_app = subchannel
     variable = avg_p
   []
   [uo3_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_v
     to_multi_app = subchannel
     variable = avg_v
   []
   [uo4_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = integral_T
     to_multi_app = subchannel
     variable = integral_T
   []
   [uo5_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = integral_p
     to_multi_app = subchannel
     variable = integral_p
   []
   [uo6_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = integral_v
     to_multi_app = subchannel
     variable = integral_v

--- a/test/tests/userobjects/gap/nondimensional/nek.i
+++ b/test/tests/userobjects/gap/nondimensional/nek.i
@@ -135,37 +135,37 @@
 [Transfers]
   [uo1_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_T
+    source_user_object = avg_T
     to_multi_app = subchannel
     variable = avg_T
   []
   [uo2_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_p
+    source_user_object = avg_p
     to_multi_app = subchannel
     variable = avg_p
   []
   [uo3_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_v
+    source_user_object = avg_v
     to_multi_app = subchannel
     variable = avg_v
   []
   [uo4_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = integral_T
+    source_user_object = integral_T
     to_multi_app = subchannel
     variable = integral_T
   []
   [uo5_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = integral_p
+    source_user_object = integral_p
     to_multi_app = subchannel
     variable = integral_p
   []
   [uo6_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = integral_v
+    source_user_object = integral_v
     to_multi_app = subchannel
     variable = integral_v
   []

--- a/test/tests/userobjects/hexagonal_gap_layered/nek.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/nek.i
@@ -76,13 +76,13 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
 [Transfers]
   [uo1_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = gap_avg
+    source_user_object = gap_avg
     to_multi_app = subchannel
     variable = gap_avg
   []
   [uo2_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = gap_area
+    source_user_object = gap_area
     to_multi_app = subchannel
     variable = gap_area
   []

--- a/test/tests/userobjects/hexagonal_gap_layered/nek.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/nek.i
@@ -3,7 +3,6 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]
@@ -76,13 +75,13 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
 
 [Transfers]
   [uo1_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = gap_avg
     to_multi_app = subchannel
     variable = gap_avg
   []
   [uo2_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = gap_area
     to_multi_app = subchannel
     variable = gap_area

--- a/test/tests/userobjects/hexagonal_gap_layered/nek_axial.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/nek_axial.i
@@ -76,13 +76,13 @@ gap_thickness = ${fparse 0.1 * 7.646e-3}
 [Transfers]
   [uo1_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = gap_avg
+    source_user_object = gap_avg
     to_multi_app = subchannel
     variable = gap_avg
   []
   [uo2_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = gap_area
+    source_user_object = gap_area
     to_multi_app = subchannel
     variable = gap_area
   []

--- a/test/tests/userobjects/hexagonal_gap_layered/nek_axial.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/nek_axial.i
@@ -3,7 +3,6 @@ gap_thickness = ${fparse 0.1 * 7.646e-3}
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]
@@ -76,13 +75,13 @@ gap_thickness = ${fparse 0.1 * 7.646e-3}
 
 [Transfers]
   [uo1_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = gap_avg
     to_multi_app = subchannel
     variable = gap_avg
   []
   [uo2_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = gap_area
     to_multi_app = subchannel
     variable = gap_area

--- a/test/tests/userobjects/hexagonal_gap_layered/normals/nek.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/normals/nek.i
@@ -3,7 +3,6 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]
@@ -84,7 +83,7 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
 
 [Transfers]
   [uo1_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_velocity_component
     to_multi_app = subchannel
     variable = avg_velocity_component

--- a/test/tests/userobjects/hexagonal_gap_layered/normals/nek.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/normals/nek.i
@@ -84,7 +84,7 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
 [Transfers]
   [uo1_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_velocity_component
+    source_user_object = avg_velocity_component
     to_multi_app = subchannel
     variable = avg_velocity_component
   []

--- a/test/tests/userobjects/hexagonal_gap_layered/normals/nek_axial.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/normals/nek_axial.i
@@ -3,7 +3,6 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]

--- a/test/tests/userobjects/hexagonal_gap_layered/type_error.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/type_error.i
@@ -1,7 +1,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]

--- a/test/tests/userobjects/hexagonal_gap_layered/user_component.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/user_component.i
@@ -3,7 +3,6 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]
@@ -95,7 +94,7 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
 
 [Transfers]
   [uo1_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_velocity_component
     to_multi_app = subchannel
     variable = avg_velocity_component

--- a/test/tests/userobjects/hexagonal_gap_layered/user_component.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/user_component.i
@@ -95,7 +95,7 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
 [Transfers]
   [uo1_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_velocity_component
+    source_user_object = avg_velocity_component
     to_multi_app = subchannel
     variable = avg_velocity_component
   []

--- a/test/tests/userobjects/side/dimensional/nek.i
+++ b/test/tests/userobjects/side/dimensional/nek.i
@@ -5,7 +5,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]

--- a/test/tests/userobjects/side/nondimensional/nek.i
+++ b/test/tests/userobjects/side/nondimensional/nek.i
@@ -5,7 +5,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
   scaling = 7.646e-3
 []
 

--- a/test/tests/userobjects/sideset_layered/tests
+++ b/test/tests/userobjects/sideset_layered/tests
@@ -10,7 +10,6 @@
     type = Exodiff
     input = z_bins.i
     exodiff = z_bins_out.e
-    mesh_mode = 'replicated'
     requirement = "The system shall correctly integrate over a sideset in the NekRS domain when mapping space by the quadrature point"
     required_objects = 'NekRSProblem'
   []

--- a/test/tests/userobjects/sideset_layered/tests
+++ b/test/tests/userobjects/sideset_layered/tests
@@ -10,6 +10,7 @@
     type = Exodiff
     input = z_bins.i
     exodiff = z_bins_out.e
+    rel_err = 5e-4
     requirement = "The system shall correctly integrate over a sideset in the NekRS domain when mapping space by the quadrature point"
     required_objects = 'NekRSProblem'
   []

--- a/test/tests/userobjects/sideset_layered/z_bins.i
+++ b/test/tests/userobjects/sideset_layered/z_bins.i
@@ -6,7 +6,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]

--- a/test/tests/userobjects/subchannel_layered/nek.i
+++ b/test/tests/userobjects/subchannel_layered/nek.i
@@ -106,13 +106,13 @@
 [Transfers]
   [uo1_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = vol_avg
+    source_user_object = vol_avg
     to_multi_app = subchannel
     variable = vol_avg
   []
   [uo2_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = vol_integral
+    source_user_object = vol_integral
     to_multi_app = subchannel
     variable = vol_integral
   []

--- a/test/tests/userobjects/subchannel_layered/nek.i
+++ b/test/tests/userobjects/subchannel_layered/nek.i
@@ -1,7 +1,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]
@@ -106,13 +105,13 @@
 
 [Transfers]
   [uo1_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = vol_avg
     to_multi_app = subchannel
     variable = vol_avg
   []
   [uo2_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = vol_integral
     to_multi_app = subchannel
     variable = vol_integral

--- a/test/tests/userobjects/subchannel_layered/tests
+++ b/test/tests/userobjects/subchannel_layered/tests
@@ -65,7 +65,6 @@
     type = CSVDiff
     input = pin_1d.i
     csvdiff = pin_1d_out_from_uo_0002.csv
-    mesh_mode = 'replicated'
     requirement = "A pin-centered subchannel bin shall give correct results for side averages of temperature."
     required_objects = 'NekRSProblem'
   []

--- a/test/tests/userobjects/subchannel_layered/user_component.i
+++ b/test/tests/userobjects/subchannel_layered/user_component.i
@@ -1,7 +1,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]
@@ -91,7 +90,7 @@
 
 [Transfers]
   [uo1_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = vol_avg
     to_multi_app = subchannel
     variable = vol_avg

--- a/test/tests/userobjects/subchannel_layered/user_component.i
+++ b/test/tests/userobjects/subchannel_layered/user_component.i
@@ -91,7 +91,7 @@
 [Transfers]
   [uo1_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = vol_avg
+    source_user_object = vol_avg
     to_multi_app = subchannel
     variable = vol_avg
   []

--- a/test/tests/userobjects/subchannel_layered/wrong_type.i
+++ b/test/tests/userobjects/subchannel_layered/wrong_type.i
@@ -1,7 +1,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]

--- a/test/tests/userobjects/volume/dimensional/nek.i
+++ b/test/tests/userobjects/volume/dimensional/nek.i
@@ -1,7 +1,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]
@@ -126,37 +125,37 @@
 
 [Transfers]
   [uo1_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_T
     to_multi_app = subchannel
     variable = avg_T
   []
   [uo2_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_p
     to_multi_app = subchannel
     variable = avg_p
   []
   [uo3_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_v
     to_multi_app = subchannel
     variable = avg_v
   []
   [uo4_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = integral_T
     to_multi_app = subchannel
     variable = integral_T
   []
   [uo5_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = integral_p
     to_multi_app = subchannel
     variable = integral_p
   []
   [uo6_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = integral_v
     to_multi_app = subchannel
     variable = integral_v

--- a/test/tests/userobjects/volume/dimensional/nek.i
+++ b/test/tests/userobjects/volume/dimensional/nek.i
@@ -126,37 +126,37 @@
 [Transfers]
   [uo1_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_T
+    source_user_object = avg_T
     to_multi_app = subchannel
     variable = avg_T
   []
   [uo2_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_p
+    source_user_object = avg_p
     to_multi_app = subchannel
     variable = avg_p
   []
   [uo3_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_v
+    source_user_object = avg_v
     to_multi_app = subchannel
     variable = avg_v
   []
   [uo4_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = integral_T
+    source_user_object = integral_T
     to_multi_app = subchannel
     variable = integral_T
   []
   [uo5_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = integral_p
+    source_user_object = integral_p
     to_multi_app = subchannel
     variable = integral_p
   []
   [uo6_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = integral_v
+    source_user_object = integral_v
     to_multi_app = subchannel
     variable = integral_v
   []

--- a/test/tests/userobjects/volume/nondimensional/nek.i
+++ b/test/tests/userobjects/volume/nondimensional/nek.i
@@ -1,7 +1,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
   scaling = 7.646e-3
 []
 
@@ -135,37 +134,37 @@
 
 [Transfers]
   [uo1_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_T
     to_multi_app = subchannel
     variable = avg_T
   []
   [uo2_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_p
     to_multi_app = subchannel
     variable = avg_p
   []
   [uo3_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_v
     to_multi_app = subchannel
     variable = avg_v
   []
   [uo4_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = integral_T
     to_multi_app = subchannel
     variable = integral_T
   []
   [uo5_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = integral_p
     to_multi_app = subchannel
     variable = integral_p
   []
   [uo6_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = integral_v
     to_multi_app = subchannel
     variable = integral_v

--- a/test/tests/userobjects/volume/nondimensional/nek.i
+++ b/test/tests/userobjects/volume/nondimensional/nek.i
@@ -135,37 +135,37 @@
 [Transfers]
   [uo1_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_T
+    source_user_object = avg_T
     to_multi_app = subchannel
     variable = avg_T
   []
   [uo2_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_p
+    source_user_object = avg_p
     to_multi_app = subchannel
     variable = avg_p
   []
   [uo3_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_v
+    source_user_object = avg_v
     to_multi_app = subchannel
     variable = avg_v
   []
   [uo4_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = integral_T
+    source_user_object = integral_T
     to_multi_app = subchannel
     variable = integral_T
   []
   [uo5_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = integral_p
+    source_user_object = integral_p
     to_multi_app = subchannel
     variable = integral_p
   []
   [uo6_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = integral_v
+    source_user_object = integral_v
     to_multi_app = subchannel
     variable = integral_v
   []

--- a/tutorials/gas_assembly/openmc.i
+++ b/tutorials/gas_assembly/openmc.i
@@ -307,7 +307,7 @@ num_layers_for_THM = 50      # number of elements in the THM model; for the conv
   []
 
   [q_wall_to_thm]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     variable = q_wall
     to_multi_app = thm
     user_object = q_wall_avg

--- a/tutorials/gas_assembly/openmc.i
+++ b/tutorials/gas_assembly/openmc.i
@@ -310,7 +310,7 @@ num_layers_for_THM = 50      # number of elements in the THM model; for the conv
     type = MultiAppGeneralFieldUserObjectTransfer
     variable = q_wall
     to_multi_app = thm
-    user_object = q_wall_avg
+    source_user_object = q_wall_avg
   []
   [T_wall_from_thm]
     type = MultiAppNearestNodeTransfer

--- a/tutorials/gas_compact_cht/solid_thm.i
+++ b/tutorials/gas_compact_cht/solid_thm.i
@@ -140,7 +140,7 @@ q0 = ${fparse unit_cell_power / (4.0 * unit_cell_height * compact_diameter * com
     type = MultiAppGeneralFieldUserObjectTransfer
     variable = q_wall
     to_multi_app = thm
-    user_object = q_wall_avg
+    source_user_object = q_wall_avg
   []
   [T_wall_from_thm]
     type = MultiAppNearestNodeTransfer

--- a/tutorials/gas_compact_cht/solid_thm.i
+++ b/tutorials/gas_compact_cht/solid_thm.i
@@ -137,7 +137,7 @@ q0 = ${fparse unit_cell_power / (4.0 * unit_cell_height * compact_diameter * com
 
 [Transfers]
   [q_wall_to_thm]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     variable = q_wall
     to_multi_app = thm
     user_object = q_wall_avg

--- a/tutorials/gas_compact_multiphysics/openmc_thm.i
+++ b/tutorials/gas_compact_multiphysics/openmc_thm.i
@@ -210,7 +210,7 @@ unit_cell_power = ${fparse power / (n_bundles * n_coolant_channels_per_block) * 
     type = MultiAppGeneralFieldUserObjectTransfer
     variable = q_wall
     to_multi_app = thm
-    user_object = q_wall_avg
+    source_user_object = q_wall_avg
   []
   [T_wall_from_thm]
     type = MultiAppNearestNodeTransfer

--- a/tutorials/gas_compact_multiphysics/openmc_thm.i
+++ b/tutorials/gas_compact_multiphysics/openmc_thm.i
@@ -207,7 +207,7 @@ unit_cell_power = ${fparse power / (n_bundles * n_coolant_channels_per_block) * 
   []
 
   [q_wall_to_thm]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     variable = q_wall
     to_multi_app = thm
     user_object = q_wall_avg

--- a/tutorials/pincell_multiphysics/tests
+++ b/tutorials/pincell_multiphysics/tests
@@ -26,7 +26,6 @@
   [fluid_mesh_to_hex20]
     type = RunApp
     input = convert.i
-    mesh_mode = 'replicated'
     cli_args = '--mesh-only'
     requirement = "The system shall be able to convert a HEX27 fluid mesh into a HEX20 mesh suitable for Nek."
     prereq = fluid_mesh

--- a/tutorials/pincell_multiphysics/tests
+++ b/tutorials/pincell_multiphysics/tests
@@ -27,6 +27,7 @@
     type = RunApp
     input = convert.i
     cli_args = '--mesh-only'
+    parallel_type = 'replicated' # for NekMeshGenerator
     requirement = "The system shall be able to convert a HEX27 fluid mesh into a HEX20 mesh suitable for Nek."
     prereq = fluid_mesh
   []

--- a/tutorials/pincell_multiphysics/tests
+++ b/tutorials/pincell_multiphysics/tests
@@ -27,7 +27,7 @@
     type = RunApp
     input = convert.i
     cli_args = '--mesh-only'
-    parallel_type = 'replicated' # for NekMeshGenerator
+    mesh_mode = 'replicated' # for NekMeshGenerator
     requirement = "The system shall be able to convert a HEX27 fluid mesh into a HEX20 mesh suitable for Nek."
     prereq = fluid_mesh
   []

--- a/tutorials/standalone/nek.i
+++ b/tutorials/standalone/nek.i
@@ -84,7 +84,7 @@
   [uo_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
     to_multi_app = sub
-    user_object = volume_averages
+    source_user_object = volume_averages
     variable = avg_velocity
   []
 []

--- a/tutorials/standalone/nek.i
+++ b/tutorials/standalone/nek.i
@@ -82,7 +82,7 @@
 
 [Transfers]
   [uo_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     to_multi_app = sub
     user_object = volume_averages
     variable = avg_velocity

--- a/tutorials/standalone/tests
+++ b/tutorials/standalone/tests
@@ -10,7 +10,6 @@
     input = nek.i
     min_parallel = 4
     requirement = 'Cardinal shall be able to run a NekRS standalone simulation.'
-    mesh_mode = 'replicated'
     required_objects = 'NekRSProblem'
   []
 []

--- a/tutorials/subchannel/nek.i
+++ b/tutorials/subchannel/nek.i
@@ -110,19 +110,19 @@
 [Transfers]
   [uo_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = average_T
+    source_user_object = average_T
     to_multi_app = subchannel
     variable = average_T
   []
   [uo_to_sub2]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = average_T_gaps
+    source_user_object = average_T_gaps
     to_multi_app = subchannel_gap
     variable = average_T
   []
   [uo1_to_sub]
     type = MultiAppGeneralFieldUserObjectTransfer
-    user_object = avg_gap_velocity
+    source_user_object = avg_gap_velocity
     to_multi_app = subchannel_gap
     variable = avg_gap_velocity
   []

--- a/tutorials/subchannel/nek.i
+++ b/tutorials/subchannel/nek.i
@@ -1,7 +1,6 @@
 [Mesh]
   type = NekRSMesh
   volume = true
-  parallel_type = replicated
 []
 
 [Problem]
@@ -110,19 +109,19 @@
 
 [Transfers]
   [uo_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = average_T
     to_multi_app = subchannel
     variable = average_T
   []
   [uo_to_sub2]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = average_T_gaps
     to_multi_app = subchannel_gap
     variable = average_T
   []
   [uo1_to_sub]
-    type = MultiAppUserObjectTransfer
+    type = MultiAppGeneralFieldUserObjectTransfer
     user_object = avg_gap_velocity
     to_multi_app = subchannel_gap
     variable = avg_gap_velocity

--- a/tutorials/transfers/tests
+++ b/tutorials/transfers/tests
@@ -14,6 +14,7 @@
   [volume]
     type = RunApp
     input = main.i
+    parallel_type = 'replicated' # for MultiAppGeometricInterpolationTransfer
     requirement = "The system shall be able to transfer fields between two volume meshes in several different ways."
     prereq = 'mesh1 mesh2'
   []

--- a/tutorials/transfers/tests
+++ b/tutorials/transfers/tests
@@ -14,7 +14,7 @@
   [volume]
     type = RunApp
     input = main.i
-    parallel_type = 'replicated' # for MultiAppGeometricInterpolationTransfer
+    mesh_mode = 'replicated' # for MultiAppGeometricInterpolationTransfer
     requirement = "The system shall be able to transfer fields between two volume meshes in several different ways."
     prereq = 'mesh1 mesh2'
   []

--- a/tutorials/transfers/tests
+++ b/tutorials/transfers/tests
@@ -14,7 +14,6 @@
   [volume]
     type = RunApp
     input = main.i
-    mesh_mode = 'replicated'
     requirement = "The system shall be able to transfer fields between two volume meshes in several different ways."
     prereq = 'mesh1 mesh2'
   []


### PR DESCRIPTION
The `MultiAppGeneralFieldUserObjectTransfer` supports distributed mesh, so we should replace the `MultiAppUserObjectTransfer` with this to get better coverage in our test suite.