### PR TITLE
Only create 2nd order mesh if not already 2nd order

### DIFF
--- a/src/mesh/NekRSMesh.C
+++ b/src/mesh/NekRSMesh.C
@@ -708,9 +708,13 @@ NekRSMesh::faceVertices()
   {
     // Create a duplicate of the solution mesh, but with the desired order of the mesh
     // interpolation. Then we can just read the coordinates of the GLL points to find the libMesh
-    // node positions.
-    mesh =
-        createMesh(platform->comm.mpiComm, _order + 1, 1 /* dummy */, nrs->cht, *(nrs->kernelInfo));
+    // node positions. We only need to do this if the NekRS mesh is not already order 2.
+    if (_nek_internal_mesh->N == 2)
+      mesh = _nek_internal_mesh;
+    else
+      mesh =
+          createMesh(platform->comm.mpiComm, _order + 1, 1 /* dummy */, nrs->cht, *(nrs->kernelInfo));
+
     Nfp_mirror = mesh->Nfp;
   }
 
@@ -792,7 +796,11 @@ NekRSMesh::volumeVertices()
   {
     // Create a duplicate of the solution mesh, but with the desired order of the mesh interpolation.
     // Then we can just read the coordinates of the GLL points to find the libMesh node positions.
-    mesh = createMesh(platform->comm.mpiComm, _order + 1, 1 /* dummy */, nrs->cht, *(nrs->kernelInfo));
+    // We only need to do this if the mesh is not already N = 2.
+    if (_nek_internal_mesh->N == 2)
+      mesh = _nek_internal_mesh;
+    else
+      mesh = createMesh(platform->comm.mpiComm, _order + 1, 1 /* dummy */, nrs->cht, *(nrs->kernelInfo));
     Np_mirror = mesh->Np;
   }
 

--- a/test/tests/nek_separatedomain/transfers_temperature/cardinal_sub.i
+++ b/test/tests/nek_separatedomain/transfers_temperature/cardinal_sub.i
@@ -5,49 +5,23 @@
   ny = 3
 []
 
-[Variables]
-  [./u]
-  [../]
-[]
-
-[Kernels]
-  [./diff]
-    type = Diffusion
-    variable = u
-  [../]
-[]
-
-[BCs]
-  [./left]
-    type = DirichletBC
-    variable = u
-    boundary = 'left'
-    value = 0
-  [../]
-  [./right]
-    type = DirichletBC
-    variable = u
-    boundary = 'right'
-    value = 1
-  [../]
+[Problem]
+  type = FEProblem
+  solve = false
 []
 
 [Postprocessors]
-  [./toNekRS_velocity]
+  [toNekRS_velocity]
     type = Receiver
     default = 0.1
-  [../]
-  [./toNekRS_temperature]
+  []
+  [toNekRS_temperature]
     type = Receiver
     default = 1.0
-  [../]
+  []
 []
-
 
 [Executioner]
   type = Transient
   num_steps = 1
-  petsc_options_iname = '-pc_type -pc_hypre_type'
-  petsc_options_value = 'hypre boomeramg'
-  nl_abs_tol = 1e-10
 []


### PR DESCRIPTION
We do not need to call `createMesh` if the internal nekRS mesh is already second-order, so we can save some effort.