### PR TITLE
Consolidate extreme value postprocessors

### DIFF
--- a/include/base/NekInterface.h
+++ b/include/base/NekInterface.h
@@ -568,42 +568,26 @@ void gradient(const int offset, const double * f, double * grad_f,
               const nek_mesh::NekMeshEnum pp_mesh);
 
 /**
- * Find the minimum of a given field over the entire nekRS domain
+ * Find the extreme value of a given field over the entire nekRS domain
  * @param[in] field field to find the minimum value of
  * @param[in] pp_mesh which NekRS mesh to operate on
- * @return minimum value of field in volume
+ * @param[in] max whether to take the maximum (or if false, the minimum)
+ * @return max or min value of field in volume
  */
-double volumeMinValue(const field::NekFieldEnum & field,
-                      const nek_mesh::NekMeshEnum pp_mesh);
+double volumeExtremeValue(const field::NekFieldEnum & field,
+                          const nek_mesh::NekMeshEnum pp_mesh,
+                          const bool max);
 
 /**
- * Find the maximum of a given field over the entire nekRS domain
- * @param[in] field field to find the minimum value of
- * @param[in] pp_mesh which NekRS mesh to operate on
- * @return maximum value of field in volume
- */
-double volumeMaxValue(const field::NekFieldEnum & field,
-                      const nek_mesh::NekMeshEnum pp_mesh);
-
-/**
- * Find the minimum of a given field over a set of boundary IDs
- * @param[in] boundary_id nekRS boundary IDs for which to find the extreme value
- * @param[in] field field to find the minimum value of
- * @param[in] pp_mesh which NekRS mesh to operate on
- * @return minimum value of field on boundary
- */
-double sideMinValue(const std::vector<int> & boundary_id, const field::NekFieldEnum & field,
-                    const nek_mesh::NekMeshEnum pp_mesh);
-
-/**
- * Find the maximum of a given field over a set of boundary IDs
+ * Find the extreme of a given field over a set of boundary IDs
  * @param[in] boundary_id nekRS boundary IDs for which to find the extreme value
  * @param[in] field field to find the maximum value of
  * @param[in] pp_mesh which NekRS mesh to operate on
- * @return maximum value of field on boundary
+ * @param[in] max whether to take the maximum (or if false, the minimum)
+ * @return max or min value of field on boundary
  */
-double sideMaxValue(const std::vector<int> & boundary_id, const field::NekFieldEnum & field,
-                    const nek_mesh::NekMeshEnum pp_mesh);
+double sideExtremeValue(const std::vector<int> & boundary_id, const field::NekFieldEnum & field,
+                        const nek_mesh::NekMeshEnum pp_mesh, const bool max);
 
 /**
  * Number of faces per element; because NekRS only supports HEX20, this should be 6

--- a/src/postprocessors/NekPostprocessor.C
+++ b/src/postprocessors/NekPostprocessor.C
@@ -27,7 +27,6 @@ NekPostprocessor::validParams()
 
   params.addParam<MooseEnum>(
       "mesh", getNekMeshEnum(), "NekRS mesh to compute postprocessor on");
-
   return params;
 }
 
@@ -50,6 +49,10 @@ NekPostprocessor::NekPostprocessor(const InputParameters & parameters)
   // NekRSProblem enforces that we then use NekRSMesh, so we don't need to check that
   // this pointer isn't NULL
   _nek_mesh = dynamic_cast<const NekRSMesh *>(&_mesh);
+
+  if (isParamSetByUser("use_displaced_mesh"))
+    mooseWarning("'use_displaced_mesh' is unused, because this postprocessor acts directly\n"
+      "on the NekRS internal mesh");
 }
 
 #endif

--- a/src/postprocessors/NekSideExtremeValue.C
+++ b/src/postprocessors/NekSideExtremeValue.C
@@ -49,10 +49,10 @@ NekSideExtremeValue::getValue()
   switch (_type)
   {
     case operation::max:
-      return nekrs::sideMaxValue(_boundary, _field, _pp_mesh);
+      return nekrs::sideExtremeValue(_boundary, _field, _pp_mesh, true /* max */);
       break;
     case operation::min:
-      return nekrs::sideMinValue(_boundary, _field, _pp_mesh);
+      return nekrs::sideExtremeValue(_boundary, _field, _pp_mesh, false /* min */);
       break;
     default:
       mooseError("Unhandled 'OperationEnum'!");

--- a/src/postprocessors/NekVolumeExtremeValue.C
+++ b/src/postprocessors/NekVolumeExtremeValue.C
@@ -49,10 +49,10 @@ NekVolumeExtremeValue::getValue()
   switch (_type)
   {
     case operation::max:
-      return nekrs::volumeMaxValue(_field, _pp_mesh);
+      return nekrs::volumeExtremeValue(_field, _pp_mesh, true /* max */);
       break;
     case operation::min:
-      return nekrs::volumeMinValue(_field, _pp_mesh);
+      return nekrs::volumeExtremeValue(_field, _pp_mesh, false /* min */);
       break;
     default:
       mooseError("Unhandled 'OperationEnum'!");

--- a/tutorials/fhr_reflector/cht/solid.i
+++ b/tutorials/fhr_reflector/cht/solid.i
@@ -23,13 +23,13 @@ core_heat_flux = 5e3
 [Functions]
   [nek_temp_ic]
     type = ParsedFunction
-    value = 923.0-50.0*(r-3.348)
+    expression = 923.0-50.0*(r-3.348)
     symbol_names = 'r'
     symbol_values = 'r'
   []
   [r]
     type = ParsedFunction
-    value = sqrt(x*x+y*y)
+    expression = sqrt(x*x+y*y)
   []
 []
 

--- a/tutorials/fhr_reflector/conduction/solid.i
+++ b/tutorials/fhr_reflector/conduction/solid.i
@@ -29,7 +29,7 @@ core_heat_flux = 5e3
   []
   [r]
     type = ParsedFunction
-    value = sqrt(x*x+y*y)
+    expression = sqrt(x*x+y*y)
   []
 []
 


### PR DESCRIPTION
This consolidates the `sideMinValue` and `sideMaxValue` postprocessors in NekRS together into a single extreme-value postprocessor. A similar consolidation is done for the volume-based postprocessors.

Also added some minor documentation enhancements to the FHR reflector block tutorial.