### PR TITLE
Add help message about properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 # any of these unless you want to use non-submodule third-party dependencies:
 
 # * CONTRIB_DIR      : Dir with third-party dependencies (default: contrib)
-# * MOOSE_SUBMODULE  : Top-level MOOSE dir (default: $(CONTRIB_DIR)/moose)
+# * MOOSE_DIR        : Top-level MOOSE dir (default: $(CONTRIB_DIR)/moose)
 # * NEKRS_DIR        : Top-level NekRS dir (default: $(CONTRIB_DIR)/nekRS)
 # * OPENMC_DIR       : Top-level OpenMC dir (default: $(CONTRIB_DIR)/openmc)
 # * DAGMC_DIR        : Top-level DagMC dir (default: $(CONTRIB_DIR)/DAGMC)
@@ -32,7 +32,7 @@
 #                       libraries from $(HDF5_ROOT)/lib.
 # * HDF5_INCLUDE_DIR  : Top-level HDF5 header dir (default: $(HDF5_ROOT)/include)
 # * HDF5_LIBDIR       : Top-level HDF5 lib dir (default: $(HDF5_ROOT)/lib)
-# * PETSC_DIR         : Top-level PETSc dir (default: $(MOOSE_SUBMODULE)/petsc)
+# * PETSC_DIR         : Top-level PETSc dir (default: $(MOOSE_DIR)/petsc)
 # * PETSC_ARCH        : PETSc architecture (default: arch-moose)
 # ======================================================================================
 
@@ -47,14 +47,22 @@ ENABLE_DAGMC        ?= no
 
 CARDINAL_DIR        := $(abspath $(dir $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))))
 CONTRIB_DIR         := $(CARDINAL_DIR)/contrib
+
+# Use the MOOSE submodule if it exists and MOOSE_DIR is not set
 MOOSE_SUBMODULE     ?= $(CONTRIB_DIR)/moose
+ifneq ($(wildcard $(MOOSE_SUBMODULE)/framework/Makefile),)
+	MOOSE_DIR        ?= $(MOOSE_SUBMODULE)
+else
+	MOOSE_DIR        ?= $(shell dirname `pwd`)/moose
+endif
+
 NEKRS_DIR           ?= $(CONTRIB_DIR)/nekRS
 OPENMC_DIR          ?= $(CONTRIB_DIR)/openmc
 DAGMC_DIR           ?= $(CONTRIB_DIR)/DAGMC
 MOAB_DIR            ?= $(CONTRIB_DIR)/moab
-PETSC_DIR           ?= $(MOOSE_SUBMODULE)/petsc
+PETSC_DIR           ?= $(MOOSE_DIR)/petsc
 PETSC_ARCH          ?= arch-moose
-LIBMESH_DIR         ?= $(MOOSE_SUBMODULE)/libmesh/installed/
+LIBMESH_DIR         ?= $(MOOSE_DIR)/libmesh/installed/
 CONTRIB_INSTALL_DIR ?= $(CARDINAL_DIR)/install
 BISON_DIR           ?= $(CONTRIB_DIR)/bison
 SAM_DIR             ?= $(CONTRIB_DIR)/SAM
@@ -202,13 +210,6 @@ endif
 # ======================================================================================
 # MOOSE core objects
 # ======================================================================================
-
-# Use the MOOSE submodule if it exists and MOOSE_DIR is not set
-ifneq ($(wildcard $(MOOSE_SUBMODULE)/framework/Makefile),)
-	MOOSE_DIR        ?= $(MOOSE_SUBMODULE)
-else
-	MOOSE_DIR        ?= $(shell dirname `pwd`)/moose
-endif
 
 # framework
 FRAMEWORK_DIR      := $(MOOSE_DIR)/framework

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -377,7 +377,14 @@ OpenMCProblemBase::setCellTemperature(const int32_t & index,
                                       const cellInfo & cell_info) const
 {
   int err = openmc_cell_set_temperature(index, T, &instance, false);
-  catchOpenMCError(err, "set cell " + printCell(cell_info) + " to temperature " + Moose::stringify(T) + " (K)");
+  if (err)
+  {
+    std::string descriptor = "set cell " + printCell(cell_info) + " to temperature " + Moose::stringify(T) + " (K)";
+    mooseError("In attempting to ", descriptor, ", OpenMC reported:\n\n",
+      std::string(openmc_err_msg) + "\n\n" +
+      "If you are trying to debug a model setup, you can set 'initial_properties = xml' to\n"
+      "use the initial temperature and density in the OpenMC XML files for OpenMC's first run");
+  }
 }
 
 std::vector<int32_t>
@@ -442,9 +449,16 @@ OpenMCProblemBase::setCellDensity(const Real & density, const cellInfo & cell_in
   int err = openmc_material_set_density(
       material_index, density * _density_conversion_factor, units);
 
-  catchOpenMCError(err, "set material with index " +
+  if (err)
+  {
+    std::string descriptor = "set material with index " +
                Moose::stringify(material_index) + " to density " +
-               Moose::stringify(density) + " (kg/m3)");
+               Moose::stringify(density) + " (kg/m3)";
+    mooseError("In attempting to ", descriptor, ", OpenMC reported:\n\n",
+      std::string(openmc_err_msg) + "\n\n" +
+      "If you are trying to debug a model setup, you can set 'initial_properties = xml' to\n"
+      "use the initial temperature and density in the OpenMC XML files for OpenMC's first run");
+  }
 }
 
 std::string

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -379,11 +379,16 @@ OpenMCProblemBase::setCellTemperature(const int32_t & index,
   int err = openmc_cell_set_temperature(index, T, &instance, false);
   if (err)
   {
-    std::string descriptor = "set cell " + printCell(cell_info) + " to temperature " + Moose::stringify(T) + " (K)";
-    mooseError("In attempting to ", descriptor, ", OpenMC reported:\n\n",
-      std::string(openmc_err_msg) + "\n\n" +
-      "If you are trying to debug a model setup, you can set 'initial_properties = xml' to\n"
-      "use the initial temperature and density in the OpenMC XML files for OpenMC's first run");
+    std::string descriptor =
+        "set cell " + printCell(cell_info) + " to temperature " + Moose::stringify(T) + " (K)";
+    mooseError(
+        "In attempting to ",
+        descriptor,
+        ", OpenMC reported:\n\n",
+        std::string(openmc_err_msg) + "\n\n" +
+            "If you are trying to debug a model setup, you can set 'initial_properties = xml' to\n"
+            "use the initial temperature and density in the OpenMC XML files for OpenMC's first "
+            "run");
   }
 }
 
@@ -451,13 +456,16 @@ OpenMCProblemBase::setCellDensity(const Real & density, const cellInfo & cell_in
 
   if (err)
   {
-    std::string descriptor = "set material with index " +
-               Moose::stringify(material_index) + " to density " +
-               Moose::stringify(density) + " (kg/m3)";
-    mooseError("In attempting to ", descriptor, ", OpenMC reported:\n\n",
-      std::string(openmc_err_msg) + "\n\n" +
-      "If you are trying to debug a model setup, you can set 'initial_properties = xml' to\n"
-      "use the initial temperature and density in the OpenMC XML files for OpenMC's first run");
+    std::string descriptor = "set material with index " + Moose::stringify(material_index) +
+                             " to density " + Moose::stringify(density) + " (kg/m3)";
+    mooseError(
+        "In attempting to ",
+        descriptor,
+        ", OpenMC reported:\n\n",
+        std::string(openmc_err_msg) + "\n\n" +
+            "If you are trying to debug a model setup, you can set 'initial_properties = xml' to\n"
+            "use the initial temperature and density in the OpenMC XML files for OpenMC's first "
+            "run");
   }
 }
 


### PR DESCRIPTION
When debugging a model, users sometimes forget to set ICs for properties in the `.i` MOOSE file. This adds an extra string to error messages to point them towards a good debugging option.