### PR TITLE
Add extra info about unused interpretation

### DIFF
--- a/src/base/NekRSProblemBase.C
+++ b/src/base/NekRSProblemBase.C
@@ -572,9 +572,11 @@ NekRSProblemBase::initialSetup()
   {
     _console << "\n ===================>     MAPPING FROM MOOSE TO NEKRS      <===================\n" << std::endl;
     _console <<   "          Slice:  entry in NekRS scratch space" << std::endl;
-    _console <<   "       Quantity:  physical meaning or name of data in this slice. If 'unused',\n" << std::endl;
-    _console <<   "                  this means that the space has been allocated, but Cardinal\n" << std::endl;
-    _console <<   "                  is not otherwise using it for coupling\n" << std::endl;
+    _console << "       Quantity:  physical meaning or name of data in this slice. If 'unused',\n"
+             << std::endl;
+    _console << "                  this means that the space has been allocated, but Cardinal\n"
+             << std::endl;
+    _console << "                  is not otherwise using it for coupling\n" << std::endl;
     _console <<   "  How to Access:  C++ code to use in NekRS files; for the .udf instructions," << std::endl;
     _console <<   "                  'n' indicates a loop variable over GLL points\n" << std::endl;
     vt.print(_console);

--- a/src/base/NekRSProblemBase.C
+++ b/src/base/NekRSProblemBase.C
@@ -572,7 +572,9 @@ NekRSProblemBase::initialSetup()
   {
     _console << "\n ===================>     MAPPING FROM MOOSE TO NEKRS      <===================\n" << std::endl;
     _console <<   "          Slice:  entry in NekRS scratch space" << std::endl;
-    _console <<   "       Quantity:  physical meaning or name of data in this slice" << std::endl;
+    _console <<   "       Quantity:  physical meaning or name of data in this slice. If 'unused',\n" << std::endl;
+    _console <<   "                  this means that the space has been allocated, but Cardinal\n" << std::endl;
+    _console <<   "                  is not otherwise using it for coupling\n" << std::endl;
     _console <<   "  How to Access:  C++ code to use in NekRS files; for the .udf instructions," << std::endl;
     _console <<   "                  'n' indicates a loop variable over GLL points\n" << std::endl;
     vt.print(_console);


### PR DESCRIPTION
A user was recently confused on what "unused" meant in the usrwrk scratch space table that Cardinal prints out. This adds clarification that the space has indeed been allocated, but Cardinal isn't already using it.