### PR TITLE
Tutorial improvements

### DIFF
--- a/doc/content/tutorials/cht.md
+++ b/doc/content/tutorials/cht.md
@@ -13,7 +13,7 @@ These types of calculations are referred to as *conjugate heat transfer*.
 Cardinal uses a general formulation that allows NekRS to couple via conjugate
 heat transfer to *any* MOOSE application that can compute a heat flux. This
 is shown schematically in [cardinal_cht]. All tutorials in this section couple
-NekRS to the MOOSE heat conduction module, but the concepts extend equally to
+NekRS to the MOOSE heat transfer module, but the concepts extend equally to
 coupling NekRS to any of these other MOOSE thermal-fluid codes.
 
 !media cardinal_cht.png

--- a/doc/content/tutorials/cht1.md
+++ b/doc/content/tutorials/cht1.md
@@ -88,7 +88,7 @@ computational domain is shown outlined with a red dotted line in [top_down].
 
 ### Heat Conduction Model
 
-The MOOSE heat conduction module is used to solve for
+The MOOSE heat transfer module is used to solve for
 [energy conservation in the solid](theory/heat_eqn.md).
 A fixed heat flux of 5 kW/m$^2$ is imposed on the block surface facing the pebble bed.
 On the surface of the barrel, a heat convection boundary condition is imposed,
@@ -256,7 +256,7 @@ All input files for this stage are present in the
 
 ### Solid Input Files
 
-The solid phase is solved with the MOOSE heat conduction module, and is described in the `solid.i` input.
+The solid phase is solved with the MOOSE heat transfer module, and is described in the `solid.i` input.
 At the top of this file, the core heat flux is defined as a variable local to the file.
 
 !listing /tutorials/fhr_reflector/conduction/solid.i
@@ -269,7 +269,7 @@ specified by pointing to the Exodus mesh.
   start=Mesh
   end=Variables
 
-The heat conduction module will solve for temperature, which is defined as a nonlinear
+The heat transfer module will solve for temperature, which is defined as a nonlinear
 variable.
 
 !listing /tutorials/fhr_reflector/conduction/solid.i
@@ -328,7 +328,7 @@ in the graphite and steel.
 Next, the [MultiApps](https://mooseframework.inl.gov/syntax/MultiApps/index.html)
  and [Transfers](https://mooseframework.inl.gov/syntax/Transfers/index.html)
 blocks describe the interaction between Cardinal
-and MOOSE. The MOOSE heat conduction module is here run as the main application, with
+and MOOSE. The MOOSE heat transfer module is here run as the main application, with
 the NekRS wrapping run as the sub-application. We specify that MOOSE will run first on each
 time step.
 
@@ -534,7 +534,7 @@ conduction case in [#part1].
 
 ### Solid Input Files
 
-The solid phase is again solved with the MOOSE heat conduction module; the input file
+The solid phase is again solved with the MOOSE heat transfer module; the input file
 is largely the same except that the simulation is run for 400 time steps.
 
 !listing /tutorials/fhr_reflector/cht/solid.i

--- a/doc/content/tutorials/cht2.md
+++ b/doc/content/tutorials/cht2.md
@@ -46,7 +46,7 @@ Relevant dimensions are summarized in
 
 ### Heat Conduction Model
 
-The MOOSE heat conduction module is used to solve for [energy conservation in the solid](theory/heat_eqn.md).
+The MOOSE heat transfer module is used to solve for [energy conservation in the solid](theory/heat_eqn.md).
 The outer surface of the duct and the tops and bottoms of the
 pins and ducts are insulated. At fluid-solid interfaces, the solid temperature
 is imposed as a Dirichlet condition (computed by NekRS).
@@ -153,7 +153,7 @@ In this section, NekRS and MOOSE are coupled for [!ac](CHT).
 
 ### Solid Input Files
 
-The solid phase is solved with the MOOSE heat conduction module, and is described
+The solid phase is solved with the MOOSE heat transfer module, and is described
 in the `solid.i` input file. At the top of this file, various problem parameters
 are defined as file-local variables to help with setting up the uniform heat
 source in the fuel.
@@ -169,7 +169,7 @@ generator objects are customizing the sideset names.
 !listing tutorials/sfr_7pin/solid.i
   block=Mesh
 
-The heat conduction module will solve for temperature, which is defined as a nonlinear
+The heat transfer module will solve for temperature, which is defined as a nonlinear
 variable.
 
 !listing tutorials/sfr_7pin/solid.i
@@ -225,7 +225,7 @@ the surface temperature computed by NekRS.
 Next, the [MultiApps](https://mooseframework.inl.gov/syntax/MultiApps/index.html)
  and [Transfers](https://mooseframework.inl.gov/syntax/Transfers/index.html)
 blocks describe the interaction between Cardinal
-and MOOSE. The MOOSE heat conduction module is here run as the main application, with
+and MOOSE. The MOOSE heat transfer module is here run as the main application, with
 the NekRS wrapping run as the sub-application.
 Three transfers are required to couple Cardinal and MOOSE; the first is a transfer
 of surface temperature from Cardinal to MOOSE.

--- a/doc/content/tutorials/cht3.md
+++ b/doc/content/tutorials/cht3.md
@@ -67,7 +67,7 @@ Heat is produced in the [!ac](TRISO) particles to yield a total power of 38 kW.
 
 ### Heat Conduction Model
 
-The MOOSE heat conduction module is used to solve for [energy conservation in the solid](theory/heat_eqn.md),
+The MOOSE heat transfer module is used to solve for [energy conservation in the solid](theory/heat_eqn.md),
 with the time derivative neglected in order to more quickly approach steady state.
 The solid mesh is shown in [solid_mesh].
 The [!ac](TRISO) particles are homogenized into
@@ -257,7 +257,7 @@ In this section, we describe the coupling of MOOSE and NekRS.
 
 #### Solid Input Files
 
-The solid phase is solved with the MOOSE heat conduction module, and is described in
+The solid phase is solved with the MOOSE heat transfer module, and is described in
 the `solid_nek.i` input. We define a number of constants at the beginning of
 the file and set up the mesh.
 
@@ -271,10 +271,10 @@ boundary conditions we will apply.
   start=Variables
   end=Functions
 
-The MOOSE heat conduction module will receive a wall temperature from NekRS in
+The MOOSE heat transfer module will receive a wall temperature from NekRS in
 the form of an [AuxVariable](https://mooseframework.inl.gov/syntax/AuxVariables/index.html),
 so we define a receiver variable for the temperature, as `fluid_temp`. The MOOSE
-heat conduction module will also send heat flux to NekRS, which we compute as
+heat transfer module will also send heat flux to NekRS, which we compute as
 another [AuxVariable](https://mooseframework.inl.gov/syntax/AuxVariables/index.html)
 named `flux`, which we compute with a
 [DiffusionFluxAux](https://mooseframework.inl.gov/source/auxkernels/DiffusionFluxAux.html)
@@ -442,7 +442,7 @@ In this section, we describe the coupling of MOOSE and THM, a lower-order fluid 
 
 #### Solid Input Files
 
-The solid phase is again solved with the MOOSE heat conduction module, and
+The solid phase is again solved with the MOOSE heat transfer module, and
 is described in the `solid_thm.i` input.
 The solid input file is almost exactly the same as the heat conduction model used
 for coupling to NekRS that has already been described, so we only focus on the differences.
@@ -506,7 +506,7 @@ as "material properties."
   block=Materials
 
 THM computes the wall temperature to apply a boundary condition in the MOOSE
-heat conduction module. To convert the `T_wall` material into an
+heat transfer module. To convert the `T_wall` material into an
 auxiliary variable, we use the [ADMaterialRealAux](https://mooseframework.inl.gov/source/auxkernels/MaterialRealAux.html).
 
 !listing /tutorials/gas_compact_cht/thm.i

--- a/doc/content/tutorials/cht4.md
+++ b/doc/content/tutorials/cht4.md
@@ -51,7 +51,7 @@ number is based on the pebble diameter.
 
 ### Heat Conduction Model
 
-The MOOSE heat conduction module is used to solve for [energy conservation in the solid](theory/heat_eqn.md),
+The MOOSE heat transfer module is used to solve for [energy conservation in the solid](theory/heat_eqn.md),
 with the time derivative neglected in order to more quickly approach steady state.
 The solid mesh is shown in [pebble_solid_mesh]; the outer surface of the pebbles is sideset 0.
 
@@ -189,7 +189,7 @@ In this section, MOOSE and NekRS are coupled for [!ac](CHT).
 
 ### Solid Input Files
 
-The solid phase is solved with the MOOSE heat conduction module, and is described in
+The solid phase is solved with the MOOSE heat transfer module, and is described in
 the `moose.i` input. First we set up the mesh using a [SphereMeshGenerator](https://mooseframework.inl.gov/source/meshgenerators/SphereMeshGenerator.html) for each pebble and then repeating it 67 times
 at each pebble location.
 
@@ -203,10 +203,10 @@ boundary conditions we will apply.
   start=Variables
   end=Functions
 
-The MOOSE heat conduction module will receive a wall temperature from NekRS in
+The MOOSE heat transfer module will receive a wall temperature from NekRS in
 the form of an [AuxVariable](https://mooseframework.inl.gov/syntax/AuxVariables/index.html),
 so we define a receiver variable for the temperature, as `nek_temp`. The MOOSE
-heat conduction module will also send heat flux to NekRS, which we compute as
+heat transfer module will also send heat flux to NekRS, which we compute as
 another [AuxVariable](https://mooseframework.inl.gov/syntax/AuxVariables/index.html)
 named `flux`, which we compute with a
 [DiffusionFluxAux](https://mooseframework.inl.gov/source/auxkernels/DiffusionFluxAux.html)

--- a/doc/content/tutorials/cht5.md
+++ b/doc/content/tutorials/cht5.md
@@ -34,7 +34,7 @@ NekRS shall solve for laminar flow over this pebble. Details on the problem
 specifications are given in [table1]. The inlet velocity is specified such that
 the Reynolds number is $Re=50$.
 
-The MOOSE heat conduction module shall be used to solve for the solid temperature.
+The MOOSE heat transfer module shall be used to solve for the solid temperature.
 NekRS and MOOSE will be coupled through boundary conditions on the pebble surface;
 NekRS shall compute a pebble surface temperature to be applied as a Dirichlet condition
 to MOOSE, while MOOSE shall compute a pebble surface heat flux to be applied
@@ -188,7 +188,7 @@ You will see `temp`, `avg_flux`, and `flux_integral` referred to in the solid in
 
 ### Solid Input Files
 
-The MOOSE heat conduction module is used to solve for
+The MOOSE heat transfer module is used to solve for
 [energy conservation in the solid](theory/heat_eqn.md).
 
 First, a local variable, `pebble_diameter` is used to conveniently be able to
@@ -231,7 +231,7 @@ The surface of the pebble is sideset 0.
   caption=Mesh used for the solid heat conduction.
   style=width:30%;margin-left:auto;margin-right:auto;halign:center
 
-The heat conduction module will solve for temperature, which is defined as a nonlinear
+The heat transfer module will solve for temperature, which is defined as a nonlinear
 variable.
 
 !listing /tutorials/pebble_1/solid.i
@@ -267,7 +267,7 @@ a monomial field due to the nature of how MOOSE computes material properties.
 Next, the [MultiApps](https://mooseframework.inl.gov/syntax/MultiApps/index.html)
  and [Transfers](https://mooseframework.inl.gov/syntax/Transfers/index.html)
 blocks describe the interaction between Cardinal
-and MOOSE. The MOOSE heat conduction module is here run as the main application, with
+and MOOSE. The MOOSE heat transfer module is here run as the main application, with
 the NekRS wrapping run as the sub-application. We specify that MOOSE will run first on each
 time step. Allowing sub-cycling means that, if the MOOSE time step is 0.05 seconds, but
 the NekRS time step set in the `.par` file is 0.02 seconds, that for every MOOSE time step, NekRS will perform

--- a/doc/content/tutorials/dagmc.md
+++ b/doc/content/tutorials/dagmc.md
@@ -70,7 +70,7 @@ The surface of the pincell is simply set to a constant value, $T_s=500$.
 Because heat transfer and fluid flow in the borated water is not modeled in this example,
 The top and bottom of the solid pincell
 are assumed insulated.
-In this example, the MOOSE heat conduction module will run first. The initial
+In this example, the MOOSE heat transfer module will run first. The initial
 solid temperature is 500&deg;C and the initial power is zero.
 
 ### OpenMC Model
@@ -102,7 +102,7 @@ The following sub-sections describe these files.
 
 ### Solid Input Files
 
-The solid phase is solved with the MOOSE heat conduction module, and is
+The solid phase is solved with the MOOSE heat transfer module, and is
 described in the `solid.i` input. The solid mesh is created using mesh generators
 in the `mesh.i` input:
 
@@ -114,7 +114,7 @@ We generate the mesh by running `cardinal-opt -i mesh.i --mesh-only` to create t
 !listing /tutorials/dagmc/solid.i
   end=Variables
 
-The heat conduction module will solve for temperature, with the heat equation.
+The heat transfer module will solve for temperature, with the heat equation.
 The variables, kernels, and boundary conditions are shown below.
 
 !listing /tutorials/dagmc/solid.i

--- a/doc/content/tutorials/gas_compact.md
+++ b/doc/content/tutorials/gas_compact.md
@@ -20,7 +20,7 @@ solve faster.
 
 Cardinal contains convenient features for applying multiphysics
 feedback to heterogeneous domains, when a coupled physics application (such as the MOOSE
-heat conduction module) might *not* also resolve the heterogeneities. For instance, the
+heat transfer module) might *not* also resolve the heterogeneities. For instance, the
 fuel pebble model in Pronghorn
 [!cite](novak2021b) uses the Heat Source Decomposition method to predict pebble
 interior temperatures, which does not explicitly resolve the [!ac](TRISO) particles
@@ -188,7 +188,7 @@ describe these files.
 
 ### Solid Input Files
 
-The solid phase is solved with the MOOSE heat conduction module, and is described in
+The solid phase is solved with the MOOSE heat transfer module, and is described in
 the `solid.i` input. We define a number of constants at the beginning of the file and
 set up the mesh from a file.
 
@@ -202,7 +202,7 @@ boundary conditions we will apply.
   start=Variables
   end=AuxVariables
 
-The MOOSE heat conduction module will receive power from OpenMC in the form of
+The MOOSE heat transfer module will receive power from OpenMC in the form of
 an [AuxVariable](https://mooseframework.inl.gov/syntax/AuxVariables/index.html),
 so we define a receiver variable for the fission power, as `power`. We also define
 a variable `fluid_temp`, that we will use a [FunctionIC](https://mooseframework.inl.gov/source/ics/FunctionIC.html)

--- a/doc/content/tutorials/openmc_fluid.md
+++ b/doc/content/tutorials/openmc_fluid.md
@@ -25,11 +25,11 @@ For testing purposes, you may choose to decrease the number of particles to
 solve faster, or decrease the resolution of the solid mesh.
 !alert-end!
 
-In this tutorial, we couple OpenMC to the MOOSE heat conduction module
+In this tutorial, we couple OpenMC to the MOOSE heat transfer module
 and the [Thermal Hydraulics Module (THM)](https://mooseframework.inl.gov/modules/thermal_hydraulics/index.html)
 , a set of 1-D systems-level thermal-hydraulics kernels.
 OpenMC will receive temperature feedback from both
-the MOOSE heat conduction module (for the solid regions) and from THM
+the MOOSE heat transfer module (for the solid regions) and from THM
 (for the fluid regions). Density feedback will be provided by THM
 for the fluid regions.
 This tutorial models a full-height [!ac](TRISO)-fueled prismatic gas reactor
@@ -209,7 +209,7 @@ OpenMC receives on each axial plane a total of 721 temperatures and 108 densitie
 210\underbrace{\text{ fuel compacts}}_{\substack{\textup{1 TRISO compact (\textit{rainbow})}\\\textup{1 matrix region (\textit{purple})}}}\ \ +\ \ \ 108\underbrace{\text{ coolant channels}}_{\substack{\textup{1 coolant region (\textit{various})}\\\textup{1 matrix region (\textit{various})}}}\ \ +\ \ \ 6\underbrace{\text{ poison compacts}}_{\substack{\textup{1 poison region (\textit{brown})}\\\textup{1 matrix region (\textit{blue})}}}\ \ +\ \ \ 73\underbrace{\text{ graphite fillers}}_\text{1 matrix region (\textit{mustard})}
 \end{equation*}
 
-The solid temperature is provided by the MOOSE heat conduction module,
+The solid temperature is provided by the MOOSE heat transfer module,
 while the fluid temperature and density are provided by [!ac](THM).
 Because we will run OpenMC second, the initial fluid temperature is
 set to the same initial condition that is imposed in the MOOSE solid model.
@@ -254,7 +254,7 @@ A summary of the data transfers between the three applications is shown in
 
 ### Solid Input Files
 
-The solid phase is solved with the MOOSE heat conduction module, and is described
+The solid phase is solved with the MOOSE heat transfer module, and is described
 in the `solid.i` input. We define a number of constants at the beginning of the file
 and set up the mesh from a file.
 
@@ -268,12 +268,12 @@ and boundary conditions we will apply.
   start=Variables
   end=Functions
 
-The MOOSE heat conduction module will receive power from OpenMC in the form of an
+The MOOSE heat transfer module will receive power from OpenMC in the form of an
 [AuxVariable](https://mooseframework.inl.gov/syntax/AuxVariables/index.html),
 so we define a receiver variable for the fission power, as `power`. The MOOSE heat
 conduction module will also receive a fluid wall temperature from [!ac](THM)
 as another [AuxVariable](https://mooseframework.inl.gov/syntax/AuxVariables/index.html)
-which we name `thm_temp`. Finally, the MOOSE heat conduction module will send the heat
+which we name `thm_temp`. Finally, the MOOSE heat transfer module will send the heat
 flux to [!ac](THM), so we add a variable named `flux` that we will use to compute
 the heat flux using the [DiffusionFluxAux](https://mooseframework.inl.gov/source/auxkernels/DiffusionFluxAux.html)
 auxiliary kernel.
@@ -357,7 +357,7 @@ is not always used to represent quantities traditionally thought of as "material
   block=Materials
 
 [!ac](THM) computes the wall temperature to apply a boundary condition in
-the MOOSE heat conduction module. To convert the `T_wall` material into an auxiliary
+the MOOSE heat transfer module. To convert the `T_wall` material into an auxiliary
 variable, we use the [ADMaterialRealAux](https://mooseframework.inl.gov/source/auxkernels/MaterialRealAux.html).
 
 !listing /tutorials/gas_assembly/thm.i

--- a/doc/content/tutorials/openmc_solid.md
+++ b/doc/content/tutorials/openmc_solid.md
@@ -14,7 +14,7 @@ This is shown schematically in [cardinal_openmc_solid]. Pay special attention to
 "NekRS" bubble - OpenMC can couple via Cardinal to NekRS in the same manner
 as any of these other codes.
 All tutorials in this
-section couple OpenMC to the MOOSE heat conduction module, but the concepts
+section couple OpenMC to the MOOSE heat transfer module, but the concepts
 extend equally to coupling OpenMC to any of these other MOOSE thermal-fluid codes.
 
 !media cardinal_openmc_solid.png

--- a/doc/content/tutorials/pincell1.md
+++ b/doc/content/tutorials/pincell1.md
@@ -114,7 +114,7 @@ are assumed insulated.
 
 !include radiation_gap.md
 
-In this example, the MOOSE heat conduction module will run first. The initial
+In this example, the MOOSE heat transfer module will run first. The initial
 solid temperature is 280&deg;C and the initial power is zero.
 
 ### OpenMC Model
@@ -220,7 +220,7 @@ The following sub-sections describe these files.
 
 ### Solid Input Files
 
-The solid phase is solved with the MOOSE heat conduction module, and is
+The solid phase is solved with the MOOSE heat transfer module, and is
 described in the `solid.i` input. The solid mesh is created using mesh generators
 in the `mesh.i` input:
 
@@ -238,7 +238,7 @@ MOOSE is dimension-agnostic, and the same physics model can be set up in any
 length unit provided proper scalings are applied to material properties, source terms,
 and the mesh. In this example, we set up the solid input file in length units of centimeters.
 
-The heat conduction module will solve for temperature, which we define
+The heat transfer module will solve for temperature, which we define
 as a nonlinear variable and apply a simple uniform initial condition.
 
 !listing /tutorials/lwr_solid/solid.i

--- a/doc/content/tutorials/pincell_multiphysics.md
+++ b/doc/content/tutorials/pincell_multiphysics.md
@@ -121,7 +121,7 @@ python pincell.py
 
 ### Heat Conduction Model
 
-The MOOSE heat conduction module is used to solve for [energy conservation in the solid](theory/heat_eqn.md).
+The MOOSE heat transfer module is used to solve for [energy conservation in the solid](theory/heat_eqn.md).
 The solid mesh is shown in [solid_mesh]. This mesh is generated using MOOSE's
 [reactor module](https://mooseframework.inl.gov/modules/reactor/index.html), which can be used to make
 sophisticated meshes of typical reactor geometries such as pin lattices, ducts, and reactor vessels.
@@ -290,7 +290,7 @@ Finally, we will use a [Transient](https://mooseframework.inl.gov/source/executi
 ### Solid Input Files
   id=solid_model
 
-The conservation of solid energy is solved using the MOOSE heat conduction module. The input
+The conservation of solid energy is solved using the MOOSE heat transfer module. The input
 file for this portion of the physics is `bison.i`. We begin by defining a
 number of constants and setting the mesh.
 

--- a/doc/content/tutorials/steady_hc.md
+++ b/doc/content/tutorials/steady_hc.md
@@ -1,4 +1,4 @@
-The MOOSE heat conduction module is used to solve for steady-state heat conduction,
+The MOOSE heat transfer module is used to solve for steady-state heat conduction,
 
 \begin{equation}
 \label{eq:hc}

--- a/doc/content/tutorials/triso.md
+++ b/doc/content/tutorials/triso.md
@@ -64,7 +64,7 @@ q^{''}=h\left(T-T_\infty\right)
 
 where $h=1000$ W/m$^2$/K and $T_\infty$ is set to a function linearly ranging
 from 650&deg;C at $z=0$ cm to 750&deg;C at $z=10$ cm. In this example, the MOOSE
-heat conduction module will be run first. The initial solid temperature is set to
+heat transfer module will be run first. The initial solid temperature is set to
 650&deg;C and the heat source to zero.
 
 ### OpenMC Model
@@ -108,7 +108,7 @@ and the FLiBe region is represented as:
 - Cell ID 2, instance 1
 - Cell ID 2, instance 2
 
-Because OpenMC runs after the MOOSE heat conduction module, initial conditions are
+Because OpenMC runs after the MOOSE heat transfer module, initial conditions are
 only required for the FLiBe temperature, which is set to 650&deg;C. Because there is
 no density feedback in this example, the densities initially imposed in the OpenMC
 model remain fixed at the values set in the OpenMC input files.
@@ -127,7 +127,7 @@ The following sub-sections describe these files.
 
 ### Solid Input Files
 
-The solid phase is solved with the MOOSE heat conduction module, and is described in the
+The solid phase is solved with the MOOSE heat transfer module, and is described in the
 `solid.i` input. We set up the mesh using the [CombinerGenerator](https://mooseframework.inl.gov/source/meshgenerators/CombinerGenerator.html) to translate a single sphere mesh to multiple locations.
 
 !listing /tutorials/pebbles/solid.i

--- a/tutorials/gas_assembly/assembly.py
+++ b/tutorials/gas_assembly/assembly.py
@@ -69,7 +69,7 @@ def coolant_temp(t_in, t_out, l, z):
 
 def coolant_density(t):
   """
-  Computes the helium density from temperature assuming a fixed operating pressure.
+  Computes the helium density (kg/m3) from temperature assuming a fixed operating pressure.
 
   Parameters
   ----------
@@ -82,8 +82,8 @@ def coolant_density(t):
     float or 1-D numpy array of float depending on t
   """
 
-  p_in_bar = specs.outlet_P * 1.0e-5;
-  return 48.14 * p_in_bar / (t + 0.4446 * p_in_bar / math.pow(t, 0.2));
+  p_in_bar = specs.outlet_P * 1.0e-5
+  return 48.14 * p_in_bar / (t + 0.4446 * p_in_bar / math.pow(t, 0.2))
 
 # -------------- Unit Conversions: OpenMC requires cm -----------
 m = 100.0
@@ -190,8 +190,7 @@ def assembly(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
 
     # reflector is 40 percent helium by volume (arbitrary assumption), with helium
     # at the inlet conditions
-    rho = coolant_density(specs.inlet_T)
-    matrix_density = 1700
+    rho = coolant_density(specs.inlet_T) # kg/m3
     reflector_porosity = 0.40
     n_helium = reflector_porosity * rho / 4.002602
     n_carbon = (1.0 - reflector_porosity) * matrix_density / 12.0107

--- a/tutorials/gas_compact/unit_cell.py
+++ b/tutorials/gas_compact/unit_cell.py
@@ -93,7 +93,7 @@ def coolant_density(t):
     value here in case you want to run these files in standalone mode (i.e. with
     the "openmc" executable).
 
-  Computes the helium density from temperature assuming a fixed operating pressure.
+  Computes the helium density (kg/m3) from temperature assuming a fixed operating pressure.
 
   Parameters
   ----------
@@ -106,8 +106,8 @@ def coolant_density(t):
     float or 1-D numpy array of float depending on t
   """
 
-  p_in_bar = outlet_P * 1.0e-5;
-  return 48.14 * p_in_bar / (t + 0.4446 * p_in_bar / math.pow(t, 0.2));
+  p_in_bar = outlet_P * 1.0e-5
+  return 48.14 * p_in_bar / (t + 0.4446 * p_in_bar / math.pow(t, 0.2))
 
 # -------------- Unit Conversions: OpenMC requires cm -----------
 m = 100.0

--- a/tutorials/gas_compact_multiphysics/unit_cell.py
+++ b/tutorials/gas_compact_multiphysics/unit_cell.py
@@ -64,7 +64,7 @@ def coolant_density(t):
     value here in case you want to run these files in standalone mode (i.e. with
     the "openmc" executable).
 
-  Computes the helium density from temperature assuming a fixed operating pressure.
+  Computes the helium density (kg/m3) from temperature assuming a fixed operating pressure.
 
   Parameters
   ----------
@@ -77,8 +77,8 @@ def coolant_density(t):
     float or 1-D numpy array of float depending on t
   """
 
-  p_in_bar = specs.outlet_P * 1.0e-5;
-  return 48.14 * p_in_bar / (t + 0.4446 * p_in_bar / math.pow(t, 0.2));
+  p_in_bar = specs.outlet_P * 1.0e-5
+  return 48.14 * p_in_bar / (t + 0.4446 * p_in_bar / math.pow(t, 0.2))
 
 # -------------- Unit Conversions: OpenMC requires cm -----------
 m = 100.0


### PR DESCRIPTION
Closes #831. I also noticed that MOOSE renamed the Heat Conduction Module to Heat Transfer Module, so I changed all the instances in the tutorial docs so we're up to date with MOOSE.