### PR TITLE
Fix tritium score for TallyRelativeError

### DIFF
--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -101,7 +101,14 @@ public:
    * @param[in] score MOOSE-type enum string
    * @return OpenMC tally score string
    */
-  std::string tallyScore(const std::string & score) const;
+  std::string enumToTallyScore(const std::string & score) const;
+
+  /**
+   * Convert into a MOOSE-type enum from a valid OpenMC tally score string
+   * @param[in] score OpenMC tally score string
+   * @return MOOSE-type enum string
+   */
+  std::string tallyScoreToEnum(const std::string & score) const;
 
   /**
    * Find the geometry type in the OpenMC model

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -116,7 +116,7 @@ OpenMCCellAverageProblem::validParams()
                              "Score to use for computing the "
                              "particle source rate (source/sec) for a certain tallies in "
                              "eigenvalue mode. In other words, the "
-                             "source/sec is computed as power /<the global value of this tally>");
+                             "source/sec is computed as (power divided by the global value of this tally)");
 
   params.addParam<std::vector<std::string>>(
       "tally_name", "Auxiliary variable name(s) to use for OpenMC tallies. "
@@ -374,7 +374,7 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
   {
     const auto & scores = getParam<MultiMooseEnum>("tally_score");
     for (const auto & score : scores)
-      _tally_score.push_back(tallyScore(score));
+      _tally_score.push_back(enumToTallyScore(score));
   }
   else
     _tally_score = {"kappa-fission"};
@@ -417,19 +417,18 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
 
     // If the score is already in tally_score, no need to do anything special.
     // Otherwise, we need to add that score.
-    std::string n = norm;
-    std::replace(n.begin(), n.end(), '_', '-');
+    std::string n = enumToTallyScore(norm);
     auto it = std::find(_tally_score.begin(), _tally_score.end(), n);
     if (it != _tally_score.end())
       _source_rate_index = it - _tally_score.begin();
     else
     {
-      _tally_score.push_back(tallyScore(n));
+      _tally_score.push_back(n);
       _source_rate_index = _tally_score.size() - 1;
 
       if (isParamValid("tally_name"))
         mooseError("When specifying 'tally_name', the score indicated in 'source_rate_normalization' must be\n"
-          "listed in 'tally_score' so that we know what you want to name that score (", tallyScore(n), ")");
+          "listed in 'tally_score' so that we know what you want to name that score (", norm, ")");
     }
   }
   else

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -544,17 +544,32 @@ OpenMCProblemBase::tallyMeanAcrossBins(std::vector<openmc::Tally *> tally, const
 }
 
 std::string
-OpenMCProblemBase::tallyScore(const std::string & score) const
+OpenMCProblemBase::enumToTallyScore(const std::string & score) const
 {
+  // the MultiMooseEnum is all caps, but the MooseEnum is already the correct case,
+  // so we need to treat these as separate
   std::string s = score;
-  std::transform(s.begin(), s.end(), s.begin(),
-    [](unsigned char c){ return std::tolower(c); });
+  if (std::all_of(s.begin(), s.end(), [](unsigned char c){ return !std::isalpha(c) || std::isupper(c); }))
+  {
+    std::transform(s.begin(), s.end(), s.begin(),
+      [](unsigned char c){ return std::tolower(c); });
 
-  // we need to revert back to some letters being uppercase for certain scores
-  if (s == "h3_production")
-    s = "H3_production";
+    // we need to revert back to some letters being uppercase for certain scores
+    if (s == "h3_production")
+      s = "H3_production";
+  }
 
+  // MOOSE enums use underscores, OpenMC uses dashes
   std::replace(s.begin(), s.end(), '_', '-');
+  return s;
+}
+
+std::string
+OpenMCProblemBase::tallyScoreToEnum(const std::string & score) const
+{
+  // MOOSE enums use underscores, OpenMC uses dashes
+  std::string s = score;
+  std::replace(s.begin(), s.end(), '-', '_');
   return s;
 }
 

--- a/src/postprocessors/TallyRelativeError.C
+++ b/src/postprocessors/TallyRelativeError.C
@@ -60,16 +60,13 @@ TallyRelativeError::TallyRelativeError(const InputParameters & parameters)
           "Can only specify a single tally score per postprocessor, but you have specified " +
               std::to_string(tally_score.size()));
 
-    std::string score = _openmc_problem->tallyScore(tally_score[0]);
-    std::transform(score.begin(), score.end(), score.begin(),
-      [](unsigned char c){ return std::tolower(c); });
-    std::replace(score.begin(), score.end(), '_', '-');
+    std::string score = _openmc_problem->enumToTallyScore(tally_score[0]);
 
     auto it = std::find(added_scores.begin(), added_scores.end(), score);
     if (it != added_scores.end())
       _tally_index = it - added_scores.begin();
     else
-      mooseError("To extract the relative error of the '" + std::string(score) +
+      mooseError("To extract the relative error of the '" + std::string(tally_score[0]) +
                  "' score,"
                  "that score must be included in the\n'tally_score' parameter of '" +
                  _openmc_problem->type() + "'!");

--- a/tutorials/dagmc/solid.i
+++ b/tutorials/dagmc/solid.i
@@ -72,7 +72,7 @@
 
 [Transfers]
   [heat_source_from_openmc]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = openmc
     variable = heat_source
     source_variable = heat_source
@@ -80,7 +80,7 @@
     to_postprocessors_to_be_preserved = source_integral
   []
   [temp_to_openmc]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     to_multi_app = openmc
     variable = temp
     source_variable = temp

--- a/tutorials/fhr_reflector/cht/solid.i
+++ b/tutorials/fhr_reflector/cht/solid.i
@@ -137,7 +137,7 @@ core_heat_flux = 5e3
     to_multi_app = nek
     variable = avg_flux
     fixed_meshes = true
-    source_boundary = 'fluid_solid_interface'
+    from_boundaries = 'fluid_solid_interface'
   []
   [flux_integral]
     type = MultiAppPostprocessorTransfer

--- a/tutorials/fhr_reflector/conduction/solid.i
+++ b/tutorials/fhr_reflector/conduction/solid.i
@@ -132,7 +132,7 @@ core_heat_flux = 5e3
     to_multi_app = nek
     variable = avg_flux
     fixed_meshes = true
-    source_boundary = 'fluid_solid_interface'
+    from_boundaries = 'fluid_solid_interface'
   []
   [flux_integral_to_nek]
     type = MultiAppPostprocessorTransfer

--- a/tutorials/gas_assembly/openmc.i
+++ b/tutorials/gas_assembly/openmc.i
@@ -209,13 +209,13 @@ num_layers_for_THM = 50      # number of elements in the THM model; for the conv
     source_variable = flux
     variable = flux
     from_multi_app = bison
-    source_boundary = 'fluid_solid_interface'
-    target_boundary = 'fluid_solid_interface'
+    from_boundaries = 'fluid_solid_interface'
+    to_boundaries = 'fluid_solid_interface'
     from_postprocessors_to_be_preserved = flux_integral
     to_postprocessors_to_be_preserved = flux_integral
   []
   [source_to_bison]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     source_variable = heat_source
     variable = power
     to_multi_app = bison
@@ -241,7 +241,7 @@ num_layers_for_THM = 50      # number of elements in the THM model; for the conv
     from_multi_app = thm
     variable = thm_temp_wall
     fixed_meshes = true
-    target_boundary = 'fluid_solid_interface'
+    to_boundaries = 'fluid_solid_interface'
   []
   [T_bulk_from_thm]
     type = MultiAppGeneralFieldNearestLocationTransfer

--- a/tutorials/gas_compact/openmc.i
+++ b/tutorials/gas_compact/openmc.i
@@ -65,7 +65,7 @@ mdot = 0.011                             # fluid mass flowrate (kg/s)
 
 [Transfers]
   [heat_source_to_solid]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     to_multi_app = solid
     variable = power
     source_variable = heat_source
@@ -73,7 +73,7 @@ mdot = 0.011                             # fluid mass flowrate (kg/s)
     to_postprocessors_to_be_preserved = power
   []
   [temperature_to_openmc]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = solid
     variable = temp
     source_variable = T

--- a/tutorials/gas_compact_cht/solid_nek.i
+++ b/tutorials/gas_compact_cht/solid_nek.i
@@ -185,8 +185,8 @@ nek_dt = 6e-3
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = flux
     variable = avg_flux
-    source_boundary = 'fluid_solid_interface'
-    target_boundary = '3'
+    from_boundaries = 'fluid_solid_interface'
+    to_boundaries = '3'
     to_multi_app = nek
     fixed_meshes = true
   []
@@ -200,8 +200,8 @@ nek_dt = 6e-3
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = temp
     variable = fluid_temp
-    source_boundary = '3'
-    target_boundary = 'fluid_solid_interface'
+    from_boundaries = '3'
+    to_boundaries = 'fluid_solid_interface'
     from_multi_app = nek
     fixed_meshes = true
   []

--- a/tutorials/gas_compact_multiphysics/openmc_nek.i
+++ b/tutorials/gas_compact_multiphysics/openmc_nek.i
@@ -139,7 +139,7 @@ N = 1000
     from_multi_app = bison
   []
   [source_to_bison]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     source_variable = heat_source
     variable = power
     to_multi_app = bison
@@ -147,7 +147,7 @@ N = 1000
     to_postprocessors_to_be_preserved = power
   []
   [temp_from_nek]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     source_variable = nek_bulk_temp
     from_multi_app = bison
     variable = nek_temp

--- a/tutorials/gas_compact_multiphysics/openmc_thm.i
+++ b/tutorials/gas_compact_multiphysics/openmc_thm.i
@@ -155,17 +155,16 @@ unit_cell_power = ${fparse power / (n_bundles * n_coolant_channels_per_block) * 
   []
   [heat_flux_to_openmc]
     type = MultiAppGeneralFieldNearestLocationTransfer
-    fixed_meshes = true
     source_variable = flux
     variable = flux
     from_multi_app = bison
-    source_boundary = 'fluid_solid_interface'
-    target_boundary = 'fluid_solid_interface'
+    from_boundaries = 'fluid_solid_interface'
+    to_boundaries = 'fluid_solid_interface'
     from_postprocessors_to_be_preserved = flux_integral
     to_postprocessors_to_be_preserved = flux_integral
   []
   [source_to_bison]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     source_variable = heat_source
     variable = power
     to_multi_app = bison
@@ -190,14 +189,12 @@ unit_cell_power = ${fparse power / (n_bundles * n_coolant_channels_per_block) * 
     source_variable = T_wall
     from_multi_app = thm
     variable = thm_temp_wall
-    fixed_meshes = true
   []
   [T_bulk_from_thm]
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = T
     from_multi_app = thm
     variable = thm_temp
-    fixed_meshes = true
   []
 []
 

--- a/tutorials/gas_compact_multiphysics/solid_nek.i
+++ b/tutorials/gas_compact_multiphysics/solid_nek.i
@@ -206,8 +206,8 @@ nek_dt = 6e-3
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = flux
     variable = avg_flux
-    source_boundary = 'fluid_solid_interface'
-    target_boundary = '3'
+    from_boundaries = 'fluid_solid_interface'
+    to_boundaries = '3'
     to_multi_app = nek
     fixed_meshes = true
   []
@@ -221,8 +221,8 @@ nek_dt = 6e-3
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = temp
     variable = nek_temp
-    source_boundary = '3'
-    target_boundary = 'fluid_solid_interface'
+    from_boundaries = '3'
+    to_boundaries = 'fluid_solid_interface'
     from_multi_app = nek
     fixed_meshes = true
   []

--- a/tutorials/lwr_solid/solid.i
+++ b/tutorials/lwr_solid/solid.i
@@ -122,7 +122,7 @@ T_fluid = ${fparse 280.0 + 273.15}
 
 [Transfers]
   [heat_source_from_openmc]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = openmc
     variable = heat_source
     source_variable = heat_source
@@ -130,7 +130,7 @@ T_fluid = ${fparse 280.0 + 273.15}
     to_postprocessors_to_be_preserved = source_integral
   []
   [temp_to_openmc]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     to_multi_app = openmc
     variable = temp
     source_variable = temp

--- a/tutorials/lwr_solid/solid_um.i
+++ b/tutorials/lwr_solid/solid_um.i
@@ -122,7 +122,7 @@ T_fluid = ${fparse 280.0 + 273.15}
 
 [Transfers]
   [heat_source_from_openmc]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     from_multi_app = openmc
     variable = heat_source
     source_variable = heat_source
@@ -130,7 +130,7 @@ T_fluid = ${fparse 280.0 + 273.15}
     to_postprocessors_to_be_preserved = source_integral
   []
   [temp_to_openmc]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     to_multi_app = openmc
     variable = temp
     source_variable = temp

--- a/tutorials/nek_stochastic/ht.i
+++ b/tutorials/nek_stochastic/ht.i
@@ -113,7 +113,7 @@
     source_variable = flux
     to_multi_app = nek
     variable = avg_flux
-    source_boundary = 'right'
+    from_boundaries = 'right'
   []
   [flux_integral]
     type = MultiAppPostprocessorTransfer

--- a/tutorials/pebbles/solid.i
+++ b/tutorials/pebbles/solid.i
@@ -84,7 +84,7 @@ T_fluid = ${fparse 650.0 + 273.15}
     to_postprocessors_to_be_preserved = source_integral
   []
   [temp_to_openmc]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     to_multi_app = openmc
     variable = temp
     source_variable = temp

--- a/tutorials/pebbles/solid_um.i
+++ b/tutorials/pebbles/solid_um.i
@@ -90,7 +90,7 @@ T_fluid = ${fparse 650.0 + 273.15}
     to_postprocessors_to_be_preserved = source_integral
   []
   [temp_to_openmc]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     to_multi_app = openmc
     variable = temp
     source_variable = temp

--- a/tutorials/pincell_multiphysics/bison.i
+++ b/tutorials/pincell_multiphysics/bison.i
@@ -136,15 +136,13 @@ dT = ${fparse power / mdot / Cp}
     source_variable = temp
     from_multi_app = nek
     variable = nek_temp
-    fixed_meshes = true
   []
   [flux]
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = flux
     to_multi_app = nek
     variable = avg_flux
-    source_boundary = '5'
-    fixed_meshes = true
+    from_boundaries = '5'
   []
   [flux_integral]
     type = MultiAppPostprocessorTransfer

--- a/tutorials/pincell_multiphysics/openmc.i
+++ b/tutorials/pincell_multiphysics/openmc.i
@@ -146,7 +146,7 @@ dT = ${fparse power / mdot / Cp}
 
 [Transfers]
   [solid_temp_to_openmc]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     source_variable = T
     variable = solid_temp
     from_multi_app = bison
@@ -158,7 +158,7 @@ dT = ${fparse power / mdot / Cp}
     to_multi_app = bison
   []
   [temp_from_nek]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     source_variable = nek_temp
     from_multi_app = bison
     variable = nek_temp

--- a/tutorials/transfers/main.i
+++ b/tutorials/transfers/main.i
@@ -45,7 +45,7 @@
     to_multi_app = sub
   []
   [mesh_function]
-    type = MultiAppShapeEvaluationTransfer
+    type = MultiAppGeneralFieldShapeEvaluationTransfer
     source_variable = u
     variable = u_mesh_function
     to_multi_app = sub


### PR DESCRIPTION
When we recently added the enumeration to the `TallyRelativeError`, I didn't notice that `MultiMooseEnum` get input as all caps, but `MooseEnum` are lower case. So we had the conversion wrong going from the tritium score `H3_production` because the logic was still based on the assumption the incoming field was all caps.

Also added some deprecated syntax updates in the tutorials, which are unrelated to the error fix.