### PR TITLE
Rename tensor mechanics module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ NAVIER_STOKES       := yes
 REACTOR             := yes
 SOLID_PROPERTIES    := yes
 STOCHASTIC_TOOLS    := yes
-TENSOR_MECHANICS    := yes
+SOLID_MECHANICS     := yes
 THERMAL_HYDRAULICS  := yes
 
 # Perform various checks on the dependencies
@@ -273,7 +273,7 @@ ifneq ($(SAM_CONTENT),)
   libmesh_CXXFLAGS    += -DENABLE_SAM_COUPLING
   APPLICATION_DIR     := $(SAM_DIR)
   APPLICATION_NAME    := sam
-  TENSOR_MECHANICS    := yes
+  SOLID_MECHANICS     := yes
   include             $(FRAMEWORK_DIR)/app.mk
 endif
 

--- a/doc/content/index.md
+++ b/doc/content/index.md
@@ -69,7 +69,7 @@ Multiphysics model of a Heat Pipe Microreactor using OpenMC-MOOSE-Sockeye [!cite
 Multiphysics model of a 7-pin SFR fuel bundle using NekRS-OpenMC-MOOSE [!cite](novak2022); figure shows fluid temperature predicted by a momentum source NekRS model with solid duct temperature predicted by BISON.
 
 !card media/pts.png title=Pressurized Thermal Shock
-Coupled NekRS [!ac](CFD) simulations with the MOOSE tensor mechanics module for predicting stress-strain response in [!ac](LWR) reactor vessels [!cite](yu_2022). Figure shows the fluid velocity and temperature predicted by NekRS, which are then fed to a solid mechanics model.
+Coupled NekRS [!ac](CFD) simulations with the MOOSE solid mechanics module for predicting stress-strain response in [!ac](LWR) reactor vessels [!cite](yu_2022). Figure shows the fluid velocity and temperature predicted by NekRS, which are then fed to a solid mechanics model.
 
 !card media/sam_nek.png title=Systems Analysis
 Coupled NekRS [!ac](CFD) simulations with systems-level feedback from SAM, for predicting tracer concentration in a loop with a double T-junction [!cite](huxford2023).

--- a/doc/content/news/december2022.md
+++ b/doc/content/news/december2022.md
@@ -1,6 +1,6 @@
 # December 2022 News
 
-- Added interface to NekRS's mesh elasticity solver, which allows coupled NekRS-MOOSE tensor mechanics simulations. Mesh deformations computed by MOOSE can be applied to a fluid boundary, and NekRS will then solve an elasticity problem to deform the mesh throughout the entire fluid domain. Tutorials will be coming soon. In the meantime, you can explore [this test](https://github.com/neams-th-coe/cardinal/tree/devel/test/tests/deformation/mesh-velocity-areas).
+- Added interface to NekRS's mesh elasticity solver, which allows coupled NekRS-MOOSE solid mechanics simulations. Mesh deformations computed by MOOSE can be applied to a fluid boundary, and NekRS will then solve an elasticity problem to deform the mesh throughout the entire fluid domain. Tutorials will be coming soon. In the meantime, you can explore [this test](https://github.com/neams-th-coe/cardinal/tree/devel/test/tests/deformation/mesh-velocity-areas).
 - Added a [new tutorial](https://cardinal.cels.anl.gov/tutorials/pincell_multiphysics.html) that couples OpenMC, NekRS, and MOOSE heat conduction for a pincell. This tutorial is fast-running and should be accessible to all users.
 - Added a new NekRS mesh mirror option that will "exactly" rebuild the spectral element mesh. To use, simply set `exact = true` for the mesh. For more documentation, look [here](https://cardinal.cels.anl.gov/source/mesh/NekRSMesh.html).
 

--- a/doc/content/tutorials/nekrs_outputs.md
+++ b/doc/content/tutorials/nekrs_outputs.md
@@ -56,7 +56,7 @@ to use a time history of the NekRS solution as a boundary condition/source
 term in another MOOSE application.
 For instance, for thermal striping applications, it is often a reasonable
 approximation to solve a NekRS CFD simulation as a standalone case, and then
-apply a time history of NekRS's wall temperature as a boundary condition to a tensor mechanics solve.
+apply a time history of NekRS's wall temperature as a boundary condition to a solid mechanics solve.
 Cardinal allows you to
 write the NekRS solution to an Exodus file that can then be loaded to provide
 a time history of the CFD solution to another application. In this example, we will
@@ -114,7 +114,7 @@ Finally, we "run" this application by specifying a [Transient](https://moosefram
 executioner. The time stepping scheme we specify here just indicates at which time
 step the data in the `nek_out.e` file should be interpolated to. For instance, if you ran
 NekRS with a time step of 1e-3 seconds, but only want to couple NekRS's temperature to a
-tensor mechanics solve on a resolution of 1e-2 seconds, then simply set the time step size
+solid mechanics solve on a resolution of 1e-2 seconds, then simply set the time step size
 in this file to `dt = 1e-2`. Finally, we specify a Exodus output in this file, which you can
 use to see that the temperature from `nek_out.e` was correctly loaded (`nek_temp` in
 `load_nek_out.e` matches `temp` in `nek_out.e`).

--- a/test/tests/bison_coupling/bison_master/bison.i
+++ b/test/tests/bison_coupling/bison_master/bison.i
@@ -48,7 +48,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = false
     strain = SMALL

--- a/test/tests/bison_coupling/bison_sub/bison_sub.i
+++ b/test/tests/bison_coupling/bison_sub/bison_sub.i
@@ -48,7 +48,7 @@
   []
 []
 
-[Modules/TensorMechanics/Master]
+[Physics/SolidMechanics/QuasiStatic]
   [all]
     add_variables = false
     strain = SMALL


### PR DESCRIPTION
refs https://github.com/idaholab/moose/issues/25584

for the heat conduction -> heat transfer commit, I did this change:
"MOOSE heat conduction" -> "MOOSE heat transfer"

if this is still too much (as you often just refer to the actual heat conduction equation, and not the module), I can narrow it down a bit, or drop the commit. it s not really a priority