### PR TITLE
display block name in errors

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -87,7 +87,9 @@ public:
    * @param[in] ids block IDs to check
    * @param[in] names block subdomain names for throwing an error
    */
-  void checkBlocksInMesh(const std::string name, const std::vector<SubdomainID> & ids, const std::vector<SubdomainName> & names) const;
+  void checkBlocksInMesh(const std::string name,
+                         const std::vector<SubdomainID> & ids,
+                         const std::vector<SubdomainName> & names) const;
 
   /// Initialize the mapping of OpenMC to the MooseMesh and perform additional setup actions
   void setupProblem();

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -81,6 +81,14 @@ public:
                              std::vector<std::vector<SubdomainName>> & names,
                              std::vector<SubdomainID> & flattened_ids);
 
+  /**
+   * Check that the specified blocks are in the mesh
+   * @param[in] name name for throwing an error
+   * @param[in] ids block IDs to check
+   * @param[in] names block subdomain names for throwing an error
+   */
+  void checkBlocksInMesh(const std::string name, const std::vector<SubdomainID> & ids, const std::vector<SubdomainName> & names) const;
+
   /// Initialize the mapping of OpenMC to the MooseMesh and perform additional setup actions
   void setupProblem();
 

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -421,9 +421,8 @@ protected:
    * Read the block parameters based on user settings
    * @param[in] name name of input parameter representing a vector of subdomain names
    * @param[in] blocks list of block ids to write
-   * @param[out] names subdomain names
    */
-  void readBlockParameters(const std::string name, std::unordered_set<SubdomainID> & blocks, std::vector<SubdomainName> & names);
+  void readBlockParameters(const std::string name, std::unordered_set<SubdomainID> & blocks);
 
   /**
    * Cache the material cells contained within each coupling cell;

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1077,7 +1077,9 @@ OpenMCCellAverageProblem::readBlockParameters(const std::string name,
 }
 
 void
-OpenMCCellAverageProblem::checkBlocksInMesh(const std::string name, const std::vector<SubdomainID> & ids, const std::vector<SubdomainName> & names) const
+OpenMCCellAverageProblem::checkBlocksInMesh(const std::string name,
+                                            const std::vector<SubdomainID> & ids,
+                                            const std::vector<SubdomainName> & names) const
 {
   const auto & subdomains = _mesh.meshSubdomains();
   for (std::size_t b = 0; b < names.size(); ++b)

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1079,8 +1079,7 @@ OpenMCCellAverageProblem::readBlockParameters(const std::string name,
     const auto & subdomains = _mesh.meshSubdomains();
     for (std::size_t b = 0; b < names.size(); ++b)
       if (subdomains.find(b_ids[b]) == subdomains.end())
-        mooseError("Block '" + names[b] + "' specified in '" + name + "' " +
-                   "not found in mesh!");
+        mooseError("Block '" + names[b] + "' specified in '" + name + "' " + "not found in mesh!");
   }
 }
 
@@ -1109,10 +1108,10 @@ OpenMCCellAverageProblem::read2DBlockParameters(const std::string name,
     flattened_ids = _mesh.getSubdomainIDs(flattened_names);
     const auto & subdomains = _mesh.meshSubdomains();
     for (const auto & i : flattened_ids)
-    for (std::size_t i = 0; i < flattened_ids.size(); ++i)
-      if (subdomains.find(flattened_ids[i]) == subdomains.end())
-        mooseError("Block '" + flattened_names[i] + "' specified in '" + name + "' " +
-                   "not found in mesh!");
+      for (std::size_t i = 0; i < flattened_ids.size(); ++i)
+        if (subdomains.find(flattened_ids[i]) == subdomains.end())
+          mooseError("Block '" + flattened_names[i] + "' specified in '" + name + "' " +
+                     "not found in mesh!");
 
     // should not be any duplicate blocks
     std::set<SubdomainName> n;

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -578,7 +578,11 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
       else
       {
          if (std::abs(_scaling - 1.0) > 1e-6)
-           mooseError("Directly tallying on the [Mesh] is only supported for 'scaling' of unity. Instead, please make a file containing your tally mesh and set it with 'mesh_template'. You can generate a mesh file corresponding to the [Mesh] by running:\n\ncardinal-opt -i " + _app.getFileName() + " --mesh-only");
+           mooseError("Directly tallying on the [Mesh] is only supported for 'scaling' of unity. "
+                      "Instead, please make a file containing your tally mesh and set it with "
+                      "'mesh_template'. You can generate a mesh file corresponding to the [Mesh] "
+                      "by running:\n\ncardinal-opt -i " +
+                      _app.getFileName() + " --mesh-only");
 
          // for distributed meshes, each rank only owns a portion of the mesh information, but
          // OpenMC wants the entire mesh to be available on every rank. We might be able to add

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -578,7 +578,7 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
       else
       {
          if (std::abs(_scaling - 1.0) > 1e-6)
-           mooseError("Directly tallying on the [Mesh] is only supported for 'scaling' of unity, because we multiply the [Mesh] by 'scaling' when tallying on it in OpenMC.\n\nInstead, please make a file containing your tally mesh and use 'mesh_template = <your_mesh_file>.e'. You can quickly generate a mesh file corresponding to the [Mesh] by running\n\ncardinal-opt -i " + _app.getOutputFileBase() + " --mesh-only");
+           mooseError("Directly tallying on the [Mesh] is only supported for 'scaling' of unity. Instead, please make a file containing your tally mesh and set it with 'mesh_template'. You can generate a mesh file corresponding to the [Mesh] by running:\n\ncardinal-opt -i " + _app.getFileName() + " --mesh-only");
 
          // for distributed meshes, each rank only owns a portion of the mesh information, but
          // OpenMC wants the entire mesh to be available on every rank. We might be able to add

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -578,8 +578,7 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
       else
       {
          if (std::abs(_scaling - 1.0) > 1e-6)
-           mooseError("Directly tallying on the [Mesh] is only supported for 'scaling' of unity,\n"
-             "because we multiply the [Mesh] by 'scaling' when tallying on it in OpenMC.");
+           mooseError("Directly tallying on the [Mesh] is only supported for 'scaling' of unity, because we multiply the [Mesh] by 'scaling' when tallying on it in OpenMC.\n\nInstead, please make a file containing your tally mesh and use 'mesh_template = <your_mesh_file>.e'. You can quickly generate a mesh file corresponding to the [Mesh] by running\n\ncardinal-opt -i " + _app.getOutputFileBase() + " --mesh-only");
 
          // for distributed meshes, each rank only owns a portion of the mesh information, but
          // OpenMC wants the entire mesh to be available on every rank. We might be able to add

--- a/src/userobjects/OpenMCVolumeCalculation.C
+++ b/src/userobjects/OpenMCVolumeCalculation.C
@@ -149,8 +149,12 @@ OpenMCVolumeCalculation::cellVolume(const unsigned int & index, Real & volume, R
   auto calc_index = _index_to_calc_index.at(index);
   auto n_instances = openmc::model::cells[index]->n_instances_;
   if (n_instances > 1)
-    mooseDoOnce(
-    mooseWarning("OpenMC's stochastic volume calculation cannot individually measure volumes of cell INSTANCES. We assume that no cell instances are clipped by other cells (e.g. they are all identical) so that the volume of an individual instance is equal to the cell volume divided by number of instances. For most cases, this is correct - but if you have any instances which only partially exist in the geometry, this will give INCORRECT volumes."));
+    mooseDoOnce(mooseWarning(
+        "OpenMC's stochastic volume calculation cannot individually measure volumes of cell "
+        "INSTANCES. We assume that no cell instances are clipped by other cells (e.g. they are all "
+        "identical) so that the volume of an individual instance is equal to the cell volume "
+        "divided by number of instances. For most cases, this is correct - but if you have any "
+        "instances which only partially exist in the geometry, this will give INCORRECT volumes."));
 
   // means add
   volume = _results[calc_index].volume[0] / (_scaling * _scaling * _scaling) / n_instances;

--- a/src/userobjects/OpenMCVolumeCalculation.C
+++ b/src/userobjects/OpenMCVolumeCalculation.C
@@ -150,11 +150,7 @@ OpenMCVolumeCalculation::cellVolume(const unsigned int & index, Real & volume, R
   auto n_instances = openmc::model::cells[index]->n_instances_;
   if (n_instances > 1)
     mooseDoOnce(
-    mooseWarning("OpenMC's stochastic volume calculation cannot individually measure volumes of cell INSTANCES.\n"
-                 "We assume that no cell instances are clipped by other cells (e.g. they are all identical) so\n"
-                 "that the volume of an individual instance is equal to the cell volume divided by number of \n"
-                 "instances. For most cases, this is correct - but if you have any instances which only partially\n"
-                 "exist in the geometry, this will give INCORRECT volumes."));
+    mooseWarning("OpenMC's stochastic volume calculation cannot individually measure volumes of cell INSTANCES. We assume that no cell instances are clipped by other cells (e.g. they are all identical) so that the volume of an individual instance is equal to the cell volume divided by number of instances. For most cases, this is correct - but if you have any instances which only partially exist in the geometry, this will give INCORRECT volumes."));
 
   // means add
   volume = _results[calc_index].volume[0] / (_scaling * _scaling * _scaling) / n_instances;

--- a/test/tests/neutronics/mesh_tally/tests
+++ b/test/tests/neutronics/mesh_tally/tests
@@ -42,6 +42,14 @@
                   "distributed, since all meshes are always replicated in OpenMC."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [scaling]
+    type = RunException
+    input = one_mesh_no_input_file.i
+    cli_args = 'Problem/scaling=2.0'
+    expect_err = "Directly tallying on the \[Mesh\] is only supported for 'scaling' of unity."
+    requirement = "The system shall error if attempting to directly tally on a MOOSE mesh that has a scaling not equal to 1.0."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
   [one_mesh_global]
     type = Exodiff
     input = one_mesh_global.i

--- a/test/tests/openmc_errors/block_mappings/no_blocks.i
+++ b/test/tests/openmc_errors/block_mappings/no_blocks.i
@@ -1,21 +1,7 @@
-# This input tests that an error should be produced if there is zero overlap
-# between the MOOSE and OpenMC domains.
-
 [Mesh]
   [sphere]
-    # Mesh of a single pebble with outer radius of 1.5 (cm)
     type = FileMeshGenerator
     file = ../../neutronics/meshes/sphere.e
-  []
-  [solid]
-    type = CombinerGenerator
-    inputs = sphere
-    positions = '100 100 100'
-  []
-  [solid_ids]
-    type = SubdomainIDGenerator
-    input = solid
-    subdomain_id = '100'
   []
 []
 
@@ -23,9 +9,9 @@
   type = OpenMCCellAverageProblem
   power = 70.0
 
-  # we added tally blocks, but forgot to add the fluid blocks
-  tally_blocks = '100'
+  tally_blocks = 'who'
   tally_type = cell
+  cell_level = 0
 []
 
 [Executioner]

--- a/test/tests/openmc_errors/block_mappings/tests
+++ b/test/tests/openmc_errors/block_mappings/tests
@@ -2,7 +2,7 @@
   [nonexistent_block]
     type = RunException
     input = nonexistent_block.i
-    expect_err = "Block 500 specified in 'tally_blocks' not found in mesh!"
+    expect_err = "Block '500' specified in 'tally_blocks' not found in mesh!"
     requirement = "The system shall error if the user specifies a block ID for coupling that does not exist."
     required_objects = 'OpenMCCellAverageProblem'
   []
@@ -65,6 +65,13 @@
                  " cell id 1, instance 0 \(of 1\) maps to a volume of 13.2213 \(cm3\)\n"
                  " cell id 2, instance 0 \(of 1\) maps to a volume of 10.6346 \(cm3\)."
     requirement = "The system shall error if the user enforces equal mapped tally volumes but the mapped volumes are not identical across tally bins"
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+  [no_blocks]
+    type = RunException
+    input = no_blocks.i
+    expect_err = "Block 'who' specified in 'tally_blocks' not found in mesh!"
+    requirement = "The system shall error with the nonexistent block name if specified value does not exist in the mesh."
     required_objects = 'OpenMCCellAverageProblem'
   []
 []


### PR DESCRIPTION
If a user accidentally typed in a block name which does not exist in the mesh, we used to try to convert that back to a subdomain ID before printing an error message, but this ends up giving some error code in MOOSE (665335) for the subdomain name because (of course) the block didn't exist in the first place and therefore didn't have a valid ID to begin with.

Now, we print the block name instead, for better debugging.