### PR TITLE
Change internal class names to prepare for upcoming density-only feedback

### DIFF
--- a/doc/content/tutorials/cht2.md
+++ b/doc/content/tutorials/cht2.md
@@ -20,10 +20,6 @@ Please download the files from the `sfr_7pin` folder
 and place these files within the same directory structure in
 `tutorials/sfr_7pin`.
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-!alert-end!
-
 ## Geometry and Computational Model
 
 The geometry

--- a/doc/content/tutorials/cht5.md
+++ b/doc/content/tutorials/cht5.md
@@ -10,10 +10,6 @@ To access this tutorial,
 cd cardinal/tutorials/pebble_1
 ```
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-!alert-end!
-
 ## Geometry and Computational Model
 
 The domain consists of a single pebble within a rectangular box; the pebble

--- a/doc/content/tutorials/convergence.md
+++ b/doc/content/tutorials/convergence.md
@@ -13,10 +13,6 @@ cd cardinal/tutorials/gas_compact
 cardinal-opt -i mesh.i --mesh-only
 ```
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-!alert-end!
-
 This tutorial provides a description of several helper scripts
 available in the `cardinal/scripts` directory that can be used for:
 

--- a/doc/content/tutorials/dagmc.md
+++ b/doc/content/tutorials/dagmc.md
@@ -10,11 +10,7 @@ To access this tutorial,
 cd cardinal/tutorials/dagmc
 ```
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-For testing purposes, you may choose to decrease the number of particles to
-solve faster.
-
+!alert! note title=DAGMC build
 To run this tutorial,
 you need to have built Cardinal with DAGMC support enabled, by setting
 `export ENABLE_DAGMC=true`.

--- a/doc/content/tutorials/gas_compact.md
+++ b/doc/content/tutorials/gas_compact.md
@@ -12,12 +12,6 @@ To access this tutorial,
 cd cardinal/tutorials/gas_compact
 ```
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-For testing purposes, you may choose to decrease the number of particles to
-solve faster.
-!alert-end!
-
 Cardinal contains convenient features for applying multiphysics
 feedback to heterogeneous domains, when a coupled physics application (such as the MOOSE
 heat transfer module) might *not* also resolve the heterogeneities. For instance, the

--- a/doc/content/tutorials/msfr.md
+++ b/doc/content/tutorials/msfr.md
@@ -18,7 +18,6 @@ Please download the files from the `msfr` folder [here](https://anl.app.box.com/
 !alert! note title=Computing Needs
 This tutorial requires [!ac](HPC) for running the NekRS model. You will be able to run
 the OpenMC model without [!ac](HPC) resources.
-You may choose to decrease the number of particles to solve faster.
 Note that you need to have built Cardinal with DAGMC support enabled, by setting
 `export ENABLE_DAGMC=true`.
 !alert-end!

--- a/doc/content/tutorials/nek_intro.md
+++ b/doc/content/tutorials/nek_intro.md
@@ -12,10 +12,6 @@ To access this tutorial,
 cd cardinal/tutorials/pebble_1
 ```
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-!alert-end!
-
 ## Geometry and Computational Model
 
 The domain consists of a single pebble of diameter $d=3$ cm within a rectangular box; the pebble

--- a/doc/content/tutorials/nekrs_outputs.md
+++ b/doc/content/tutorials/nekrs_outputs.md
@@ -16,10 +16,6 @@ of NekRS via [NekRSStandaloneProblem](/problems/NekRSStandaloneProblem.md) -
 however, all features shown here can also be used in a coupled sense via
 [NekRSProblem](/problems/NekRSProblem.md).
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-!alert-end!
-
 ## Viewing the NekRS Mesh
 
 NekRS uses a custom mesh format (with the `.re2` extension). This file cannot

--- a/doc/content/tutorials/nekrs_standalone.md
+++ b/doc/content/tutorials/nekrs_standalone.md
@@ -6,10 +6,6 @@ In this tutorial, you will learn how to:
 - Run a thinly-wrapped NekRS simulation without any physics coupling, to leverage
   Cardinal's postprocessing and I/O features
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-!alert-end!
-
 ## Standalone Simulations
   id=standalone
 

--- a/doc/content/tutorials/nekrs_stochastic.md
+++ b/doc/content/tutorials/nekrs_stochastic.md
@@ -35,10 +35,6 @@ perturb an arbitrary number of parameters. Other notable features include:
 Before reading this tutorial, we recommend reading through [Examples 1 through 3](https://mooseframework.inl.gov/modules/stochastic_tools/)
  on the [!ac](STM) page to familiarize yourself with the basic syntax for stochastic simulations.
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-!alert-end!
-
 To access this tutorial,
 
 ```

--- a/doc/content/tutorials/openmc_fluid.md
+++ b/doc/content/tutorials/openmc_fluid.md
@@ -19,12 +19,6 @@ an OpenMC XML file from Box. Please download the files from the
 and place these files within the same directory structure
 in `tutorials/gas_assembly`.
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-For testing purposes, you may choose to decrease the number of particles to
-solve faster, or decrease the resolution of the solid mesh.
-!alert-end!
-
 In this tutorial, we couple OpenMC to the MOOSE heat transfer module
 and the [Thermal Hydraulics Module (THM)](https://mooseframework.inl.gov/modules/thermal_hydraulics/index.html)
 , a set of 1-D systems-level thermal-hydraulics kernels.

--- a/doc/content/tutorials/other_apps.md
+++ b/doc/content/tutorials/other_apps.md
@@ -10,10 +10,6 @@ To access this tutorial,
 cd cardinal/tutorials/other_apps
 ```
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-!alert-end!
-
 For convenience purposes, Cardinal contains several other MOOSE applications
 as submodules - Sockeye and SAM, allowing you to simply build those
 applications in tandem with Cardinal and even run Sockeye/SAM input files

--- a/doc/content/tutorials/pincell1.md
+++ b/doc/content/tutorials/pincell1.md
@@ -12,12 +12,6 @@ To access this tutorial,
 cd cardinal/tutorials/lwr_solid
 ```
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-For testing purposes, you may choose to decrease the number of particles to
-solve faster.
-!alert-end!
-
 At a high level, Cardinal's wrapping of OpenMC consists of two major stages - first, establishing
 the mapping between OpenMC's geometry and the [MooseMesh](https://mooseframework.inl.gov/source/mesh/MooseMesh.html)
 with which OpenMC communicates. This stage consists of:

--- a/doc/content/tutorials/pincell_multiphysics.md
+++ b/doc/content/tutorials/pincell_multiphysics.md
@@ -13,11 +13,6 @@ To access this tutorial,
 cd cardinal/tutorials/pincell_multiphysics
 ```
 
-!alert! note title=Computing Needs
-This tutorial does not require any special computing needs.
-For testing purposes, you may choose to decrease the number of particles to solve faster.
-!alert-end!
-
 ## Geometry and Computational Model
 
 The geometry consists of a single pincell, cooled by sodium. The dimensions and assumed operating conditions

--- a/doc/content/tutorials/restart_nek_moose.md
+++ b/doc/content/tutorials/restart_nek_moose.md
@@ -12,10 +12,6 @@ To access this tutorial,
 cd cardinal/tutorials/restart_nek_and_moose
 ```
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-!alert-end!
-
 ## Creating checkpoint files
 
 NekRS checkpoint file output is controlled

--- a/doc/content/tutorials/transfers.md
+++ b/doc/content/tutorials/transfers.md
@@ -10,10 +10,6 @@ To access this tutorial,
 cd cardinal/tutorials/transfers
 ```
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-!alert-end!
-
 The MOOSE [Transfer system](https://mooseframework.inl.gov/syntax/Transfers/index.html)
 is used to send data between applications. In Cardinal, these transfers are used to
 communicate fields between NekRS, OpenMC, and MOOSE. When using Cardinal, we are most often

--- a/doc/content/tutorials/triso.md
+++ b/doc/content/tutorials/triso.md
@@ -13,12 +13,6 @@ To access this tutorial,
 cd cardinal/tutorials/pebbles
 ```
 
-!alert! note title=Computing Needs
-No special computing needs are required for this tutorial.
-For testing purposes, you may choose to decrease the number of particles to
-solve faster.
-!alert-end!
-
 ## Geometry and Computational Models
 
 The geometry and

--- a/doc/content/tutorials/triso_multiphysics.md
+++ b/doc/content/tutorials/triso_multiphysics.md
@@ -21,7 +21,6 @@ these within the same directory structure in `tutorials/gas_compact_multiphysics
 !alert! note title=Computing Needs
 This tutorial requires [!ac](HPC) resources to run the NekRS cases.
 You will be able to run the OpenMC-THM-MOOSE files without any special resources.
-For testing purposes, you may choose to decrease the number of particles.
 !alert-end!
 
 In this tutorial, we couple OpenMC to the MOOSE heat transfer module, with fluid

--- a/doc/content/tutorials/volumetric.md
+++ b/doc/content/tutorials/volumetric.md
@@ -1,4 +1,0 @@
-# Volumetric Heat Source Coupling of NekRS and MOOSE
-
-!alert note
-This capability is available, and a tutorial will be added in the near future.

--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -881,7 +881,7 @@ protected:
   std::map<cellInfo, coupling::CouplingFields> _cell_phase;
 
   /// Number of elements in the MOOSE mesh that exclusively provide temperature feedback
-  int _n_moose_solid_elems;
+  int _n_moose_temp_elems;
 
   /// Number of elements in the MOOSE mesh which provide temperature+density feedback
   int _n_moose_fluid_elems;
@@ -1063,10 +1063,10 @@ protected:
   const SymmetryPointGenerator * _symmetry;
 
   /// Number of temperature-only feedback elements in each mapped OpenMC cell (global)
-  std::map<cellInfo, int> _n_solid;
+  std::map<cellInfo, int> _n_temp;
 
   /// Number of temperature+density feedback elements in each mapped OpenMC cell (global)
-  std::map<cellInfo, int> _n_fluid;
+  std::map<cellInfo, int> _n_temp_rho;
 
   /// Number of none elements in each mapped OpenMC cell (global)
   std::map<cellInfo, int> _n_none;

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1151,11 +1151,11 @@ OpenMCCellAverageProblem::storeElementPhase()
   for (const auto & f : _density_blocks)
     _n_moose_fluid_elems += numElemsInSubdomain(f);
 
-  _n_moose_solid_elems = 0;
+  _n_moose_temp_elems = 0;
   for (const auto & s : _exclusive_temp_blocks)
-    _n_moose_solid_elems += numElemsInSubdomain(s);
+    _n_moose_temp_elems += numElemsInSubdomain(s);
 
-  _n_moose_none_elems = _mesh.nElem() - _n_moose_fluid_elems - _n_moose_solid_elems;
+  _n_moose_none_elems = _mesh.nElem() - _n_moose_fluid_elems - _n_moose_temp_elems;
 }
 
 void
@@ -1237,43 +1237,26 @@ OpenMCCellAverageProblem::cellCouplingFields(const cellInfo & cell_info) const
 void
 OpenMCCellAverageProblem::getCellMappedPhase()
 {
-  std::vector<int> cells_n_solid;
-  std::vector<int> cells_n_fluid;
+  std::vector<int> cells_n_temp;
+  std::vector<int> cells_n_temp_rho;
   std::vector<int> cells_n_none;
 
   // whether each cell maps to a single phase
   for (const auto & c : _local_cell_to_elem)
   {
-    int n_solid = 0, n_fluid = 0, n_none = 0;
+    std::vector<int> f(3 /* number of coupling options */, 0);
 
+    // we are looping over local elements, so no need to check for nullptr
     for (const auto & e : c.second)
-    {
-      // we are looping over local elements, so no need to check for nullptr
-      const Elem * elem = _mesh.queryElemPtr(globalElemID(e));
+      f[elemFeedback(_mesh.queryElemPtr(globalElemID(e)))]++;
 
-      switch (elemFeedback(elem))
-      {
-        case coupling::temperature:
-          n_solid++;
-          break;
-        case coupling::density_and_temperature:
-          n_fluid++;
-          break;
-        case coupling::none:
-          n_none++;
-          break;
-        default:
-          mooseError("Unhandled CouplingFieldsEnum in OpenMCCellAverageProblem!");
-      }
-    }
-
-    cells_n_solid.push_back(n_solid);
-    cells_n_fluid.push_back(n_fluid);
-    cells_n_none.push_back(n_none);
+    cells_n_temp.push_back(f[coupling::temperature]);
+    cells_n_temp_rho.push_back(f[coupling::density_and_temperature]);
+    cells_n_none.push_back(f[coupling::none]);
   }
 
-  gatherCellSum(cells_n_solid, _n_solid);
-  gatherCellSum(cells_n_fluid, _n_fluid);
+  gatherCellSum(cells_n_temp, _n_temp);
+  gatherCellSum(cells_n_temp_rho, _n_temp_rho);
   gatherCellSum(cells_n_none, _n_none);
 }
 
@@ -1305,8 +1288,8 @@ OpenMCCellAverageProblem::checkCellMappedPhase()
   for (const auto & c : _cell_to_elem)
   {
     auto cell_info = c.first;
-    int n_solid = _n_solid[cell_info];
-    int n_fluid = _n_fluid[cell_info];
+    int n_solid = _n_temp[cell_info];
+    int n_fluid = _n_temp_rho[cell_info];
     int n_none = _n_none[cell_info];
 
     std::ostringstream vol;
@@ -1760,15 +1743,15 @@ OpenMCCellAverageProblem::initializeElementToCellMapping()
 
   VariadicTable<std::string, int, int, int, int> vt(
       {"", "# T Elems", "# rho Elems", "# T+rho Elems", "# Uncoupled Elems"});
-  vt.addRow("MOOSE mesh", _n_moose_solid_elems, 0, _n_moose_fluid_elems, _n_moose_none_elems);
+  vt.addRow("MOOSE mesh", _n_moose_temp_elems, 0, _n_moose_fluid_elems, _n_moose_none_elems);
   vt.addRow("OpenMC cells", _n_mapped_solid_elems, 0, _n_mapped_fluid_elems, _n_mapped_none_elems);
   vt.print(_console);
   _console << std::endl;
 
   if (_needs_to_map_cells)
   {
-    if (_n_moose_solid_elems && (_n_mapped_solid_elems != _n_moose_solid_elems))
-      mooseWarning("The [Mesh] has " + Moose::stringify(_n_moose_solid_elems) +
+    if (_n_moose_temp_elems && (_n_mapped_solid_elems != _n_moose_temp_elems))
+      mooseWarning("The [Mesh] has " + Moose::stringify(_n_moose_temp_elems) +
                    " elements providing temperature feedback (the elements in "
                    "'temperature_blocks'), but only " +
                    Moose::stringify(_n_mapped_solid_elems) + " got mapped to OpenMC cells.");
@@ -1779,7 +1762,7 @@ OpenMCCellAverageProblem::initializeElementToCellMapping()
                    "intersection of 'temperature_blocks' and 'density_blocks'), but only " +
                    Moose::stringify(_n_mapped_fluid_elems) + " got mapped to OpenMC cells.");
 
-    if (_n_mapped_none_elems)
+    if (_n_mapped_none_elems && (_specified_temperature_feedback || _specified_density_feedback))
       mooseWarning("Skipping OpenMC multiphysics feedback from " +
                    Moose::stringify(_n_mapped_none_elems) +
                    " [Mesh] elements, which occupy a volume of: " +


### PR DESCRIPTION
Historically, we designed the feedback into OpenMC for solids (temperature only) and fluids (temperature and density). However, the code could be cleaner and easier to understand if we also allowed density-only feedback. This PR just makes some 1:1 internal member variable name changes to remove the notion of solid vs. fluid.