### PR TITLE
Update hexagonal_prism

### DIFF
--- a/test/tests/neutronics/feedback/triso/cache/unit_cell.py
+++ b/test/tests/neutronics/feedback/triso/cache/unit_cell.py
@@ -87,7 +87,7 @@ settings.temperature['range'] = (294.0, 1500.0)
 settings.temperature['tolerance'] = 200.0
 
 source_dist = openmc.stats.Box((-l/2., -l/2., 0.0), (l/2., l/2., h))
-source = openmc.Source(space=source_dist)
+source = openmc.IndependentSource(space=source_dist)
 settings.source = source
 
 model.settings = settings

--- a/test/tests/neutronics/feedback/triso/different_fill_univs/unit_cell.py
+++ b/test/tests/neutronics/feedback/triso/different_fill_univs/unit_cell.py
@@ -148,7 +148,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active):
     hex_lattice.outer = inf_graphite_univ
 
     # hexagonal bounding cell
-    hex = openmc.hexagonal_prism(cell_edge_length, hex_orientation, boundary_type='periodic')
+    hex = openmc.model.HexagonalPrism(cell_edge_length, hex_orientation, boundary_type='periodic')
 
     # create additional axial regions
     axial_planes = [openmc.ZPlane(z0=coord) for coord in axial_coords]
@@ -160,7 +160,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active):
     max_z.boundary_type = 'reflective'
 
     # fill the unit cell with the hex lattice
-    hex_cell = openmc.Cell(region=hex & +min_z & -max_z, fill=hex_lattice)
+    hex_cell = openmc.Cell(region=-hex & +min_z & -max_z, fill=hex_lattice)
 
     model.geometry = openmc.Geometry([hex_cell])
 

--- a/test/tests/neutronics/feedback/triso/different_fill_univs/unit_cell.py
+++ b/test/tests/neutronics/feedback/triso/different_fill_univs/unit_cell.py
@@ -178,7 +178,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active):
     lower_left = (-cell_edge_length, -hexagon_half_flat, reactor_bottom)
     upper_right = (cell_edge_length, hexagon_half_flat, reactor_top)
     source_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
-    source = openmc.Source(space=source_dist)
+    source = openmc.IndependentSource(space=source_dist)
     settings.source = source
 
     model.settings = settings

--- a/test/tests/neutronics/feedback/triso/missing_triso_fill/unit_cell.py
+++ b/test/tests/neutronics/feedback/triso/missing_triso_fill/unit_cell.py
@@ -213,7 +213,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active):
     lower_left = (-cell_edge_length, -hexagon_half_flat, reactor_bottom)
     upper_right = (cell_edge_length, hexagon_half_flat, reactor_top)
     source_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
-    source = openmc.Source(space=source_dist)
+    source = openmc.IndependentSource(space=source_dist)
     settings.source = source
 
     model.settings = settings

--- a/test/tests/neutronics/feedback/triso/missing_triso_fill/unit_cell.py
+++ b/test/tests/neutronics/feedback/triso/missing_triso_fill/unit_cell.py
@@ -182,7 +182,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active):
     hex_lattice.outer = inf_graphite_univ
 
     # hexagonal bounding cell
-    hex = openmc.hexagonal_prism(cell_edge_length, hex_orientation, boundary_type='periodic')
+    hex = openmc.model.HexagonalPrism(cell_edge_length, hex_orientation, boundary_type='periodic')
 
     hex_cell_vol = 6.0 * (math.sqrt(3) / 4.0) * cell_edge_length**2 * reactor_height
 
@@ -195,7 +195,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active):
     max_z.boundary_type = 'reflective'
 
     # fill the unit cell with the hex lattice
-    hex_cell = openmc.Cell(region=hex & +min_z & -max_z, fill=hex_lattice)
+    hex_cell = openmc.Cell(region=-hex & +min_z & -max_z, fill=hex_lattice)
 
     model.geometry = openmc.Geometry([hex_cell])
 

--- a/test/tests/neutronics/feedback/triso/unit_cell.py
+++ b/test/tests/neutronics/feedback/triso/unit_cell.py
@@ -213,7 +213,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active):
     lower_left = (-cell_edge_length, -hexagon_half_flat, reactor_bottom)
     upper_right = (cell_edge_length, hexagon_half_flat, reactor_top)
     source_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
-    source = openmc.Source(space=source_dist)
+    source = openmc.IndependentSource(space=source_dist)
     settings.source = source
 
     model.settings = settings

--- a/test/tests/neutronics/feedback/triso/unit_cell.py
+++ b/test/tests/neutronics/feedback/triso/unit_cell.py
@@ -182,7 +182,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active):
     hex_lattice.outer = inf_graphite_univ
 
     # hexagonal bounding cell
-    hex = openmc.hexagonal_prism(cell_edge_length, hex_orientation, boundary_type='periodic')
+    hex = openmc.model.HexagonalPrism(cell_edge_length, hex_orientation, boundary_type='periodic')
 
     hex_cell_vol = 6.0 * (math.sqrt(3) / 4.0) * cell_edge_length**2 * reactor_height
 
@@ -195,7 +195,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active):
     max_z.boundary_type = 'reflective'
 
     # fill the unit cell with the hex lattice
-    hex_cell = openmc.Cell(region=hex & +min_z & -max_z, fill=hex_lattice)
+    hex_cell = openmc.Cell(region=-hex & +min_z & -max_z, fill=hex_lattice)
 
     model.geometry = openmc.Geometry([hex_cell])
 

--- a/test/tests/neutronics/symmetry/assembly.py
+++ b/test/tests/neutronics/symmetry/assembly.py
@@ -252,8 +252,8 @@ def assembly(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
 
     # fill the unit cell with the hex lattice
     symmetry_plane = openmc.Plane(a=-math.sqrt(3.0)/2.0, b=0.5, c=0.0, d=0.0, boundary_type='reflective')
-    hex_prism = openmc.hexagonal_prism(bundle_pitch / math.sqrt(3.0), 'x', boundary_type='vacuum')
-    outer_cell = openmc.Cell(region=hex_prism & +min_z & -max_z & -symmetry_plane, fill=hex_lattice)
+    hex_prism = openmc.model.HexagonalPrism(bundle_pitch / math.sqrt(3.0), 'x', boundary_type='vacuum')
+    outer_cell = openmc.Cell(region=-hex_prism & +min_z & -max_z & -symmetry_plane, fill=hex_lattice)
 
     model.geometry = openmc.Geometry([outer_cell])
 

--- a/test/tests/neutronics/symmetry/assembly.py
+++ b/test/tests/neutronics/symmetry/assembly.py
@@ -270,7 +270,7 @@ def assembly(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
     lower_left = (-l, -l, reactor_bottom)
     upper_right = (l, l, reactor_top)
     source_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
-    source = openmc.Source(space=source_dist)
+    source = openmc.IndependentSource(space=source_dist)
     settings.source = source
 
     if (add_entropy_mesh):

--- a/test/tests/neutronics/symmetry/rotational/assembly.py
+++ b/test/tests/neutronics/symmetry/rotational/assembly.py
@@ -271,7 +271,7 @@ def assembly(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
     lower_left = (-l, -l, reactor_bottom)
     upper_right = (l, l, reactor_top)
     source_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
-    source = openmc.Source(space=source_dist)
+    source = openmc.IndependentSource(space=source_dist)
     settings.source = source
 
     if (add_entropy_mesh):

--- a/test/tests/neutronics/symmetry/rotational/assembly.py
+++ b/test/tests/neutronics/symmetry/rotational/assembly.py
@@ -253,8 +253,8 @@ def assembly(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
     # fill the unit cell with the hex lattice
     symmetry_plane = openmc.Plane(a=-math.sqrt(3.0)/2.0, b=0.5, c=0.0, d=0.0, boundary_type='reflective')
     symmetry_plane_2 = openmc.YPlane(boundary_type='reflective')
-    hex_prism = openmc.hexagonal_prism(bundle_pitch / math.sqrt(3.0), 'x', boundary_type='vacuum')
-    outer_cell = openmc.Cell(region=hex_prism & +min_z & -max_z & -symmetry_plane & +symmetry_plane_2, fill=hex_lattice)
+    hex_prism = openmc.model.HexagonalPrism(bundle_pitch / math.sqrt(3.0), 'x', boundary_type='vacuum')
+    outer_cell = openmc.Cell(region=-hex_prism & +min_z & -max_z & -symmetry_plane & +symmetry_plane_2, fill=hex_lattice)
 
     model.geometry = openmc.Geometry([outer_cell])
 

--- a/test/tests/neutronics/symmetry/triso/assembly.py
+++ b/test/tests/neutronics/symmetry/triso/assembly.py
@@ -216,7 +216,7 @@ def assembly(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
     lower_left = (0, -l, reactor_bottom)
     upper_right = (l, l, reactor_top)
     source_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
-    source = openmc.Source(space=source_dist)
+    source = openmc.IndependentSource(space=source_dist)
     settings.source = source
 
     if (add_entropy_mesh):

--- a/test/tests/neutronics/symmetry/triso/assembly.py
+++ b/test/tests/neutronics/symmetry/triso/assembly.py
@@ -197,8 +197,8 @@ def assembly(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
     symmetry_plane = openmc.XPlane(x0=0, boundary_type='reflective')
 
     # fill the unit cell with the hex lattice
-    hex_prism = openmc.hexagonal_prism(bundle_pitch / math.sqrt(3.0), 'x', boundary_type='reflective')
-    outer_cell = openmc.Cell(region=hex_prism & +min_z & -max_z & +symmetry_plane, fill=hex_lattice)
+    hex_prism = openmc.model.HexagonalPrism(bundle_pitch / math.sqrt(3.0), 'x', boundary_type='reflective')
+    outer_cell = openmc.Cell(region=-hex_prism & +min_z & -max_z & +symmetry_plane, fill=hex_lattice)
 
     model.geometry = openmc.Geometry([outer_cell])
 

--- a/tutorials/dagmc/make_model.py
+++ b/tutorials/dagmc/make_model.py
@@ -33,7 +33,7 @@ settings.temperature = {'default': 500.0,
 
 settings.export_to_xml()
 
-settings.source = openmc.Source(space=openmc.stats.Box([-4., -4., -4.],
+settings.source = openmc.IndependentSource(space=openmc.stats.Box([-4., -4., -4.],
                                                        [ 4.,  4.,  4.]))
 settings.export_to_xml()
 

--- a/tutorials/gas_assembly/assembly.py
+++ b/tutorials/gas_assembly/assembly.py
@@ -327,8 +327,8 @@ def assembly(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
     max_z = axial_planes[-1]
 
     # fill the unit cell with the hex lattice
-    hex_prism = openmc.hexagonal_prism(bundle_pitch / math.sqrt(3.0), 'x', boundary_type='periodic')
-    outer_cell = openmc.Cell(region=hex_prism & +min_z & -max_z, fill=hex_lattice)
+    hex_prism = openmc.model.HexagonalPrism(bundle_pitch / math.sqrt(3.0), 'x', boundary_type='periodic')
+    outer_cell = openmc.Cell(region=-hex_prism & +min_z & -max_z, fill=hex_lattice)
 
     # add the top and bottom reflector
     top_refl_z = reactor_height + top_reflector_height
@@ -336,8 +336,8 @@ def assembly(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
     bottom_refl_z = -bottom_reflector_height
     bottom_refl = openmc.ZPlane(z0=bottom_refl_z, boundary_type='vacuum')
 
-    top_refl_cell = openmc.Cell(region=hex_prism & +max_z & -top_refl, fill=m_reflector)
-    bottom_refl_cell = openmc.Cell(region=hex_prism & -min_z & +bottom_refl, fill=m_reflector)
+    top_refl_cell = openmc.Cell(region=-hex_prism & +max_z & -top_refl, fill=m_reflector)
+    bottom_refl_cell = openmc.Cell(region=-hex_prism & -min_z & +bottom_refl, fill=m_reflector)
     top_refl_cell.temperature = specs.inlet_T
     bottom_refl_cell.temperature = coolant_outlet_temp
 

--- a/tutorials/gas_assembly/assembly.py
+++ b/tutorials/gas_assembly/assembly.py
@@ -356,7 +356,7 @@ def assembly(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
     lower_left = (-l, -l, reactor_bottom)
     upper_right = (l, l, reactor_top)
     source_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
-    source = openmc.Source(space=source_dist)
+    source = openmc.IndependentSource(space=source_dist)
     settings.source = source
 
     if (add_entropy_mesh):

--- a/tutorials/gas_compact/unit_cell.py
+++ b/tutorials/gas_compact/unit_cell.py
@@ -287,7 +287,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
     hex_lattice.outer = inf_graphite_univ
 
     # hexagonal bounding cell
-    hex = openmc.hexagonal_prism(cell_edge_length, hex_orientation, boundary_type='periodic')
+    hex = openmc.model.HexagonalPrism(cell_edge_length, hex_orientation, boundary_type='periodic')
 
     hex_cell_vol = 6.0 * (math.sqrt(3) / 4.0) * cell_edge_length**2 * reactor_height
 
@@ -300,7 +300,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
     max_z.boundary_type = 'vacuum'
 
     # fill the unit cell with the hex lattice
-    hex_cell = openmc.Cell(region=hex & +min_z & -max_z, fill=hex_lattice)
+    hex_cell = openmc.Cell(region=-hex & +min_z & -max_z, fill=hex_lattice)
 
     model.geometry = openmc.Geometry([hex_cell])
 

--- a/tutorials/gas_compact/unit_cell.py
+++ b/tutorials/gas_compact/unit_cell.py
@@ -322,7 +322,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active, add_entropy_mesh=False):
     lower_left = (-cell_edge_length, -hexagon_half_flat, reactor_bottom)
     upper_right = (cell_edge_length, hexagon_half_flat, reactor_top)
     source_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
-    source = openmc.Source(space=source_dist)
+    source = openmc.IndependentSource(space=source_dist)
     settings.source = source
 
     if (add_entropy_mesh):

--- a/tutorials/gas_compact_multiphysics/unit_cell.py
+++ b/tutorials/gas_compact_multiphysics/unit_cell.py
@@ -248,7 +248,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active):
     lower_left = (-cell_edge_length, -hexagon_half_flat, reactor_bottom)
     upper_right = (cell_edge_length, hexagon_half_flat, reactor_top)
     source_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
-    source = openmc.Source(space=source_dist)
+    source = openmc.IndependentSource(space=source_dist)
     settings.source = source
 
     model.settings = settings

--- a/tutorials/gas_compact_multiphysics/unit_cell.py
+++ b/tutorials/gas_compact_multiphysics/unit_cell.py
@@ -213,7 +213,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active):
     hex_lattice.outer = inf_graphite_univ
 
     # hexagonal bounding cell
-    hex = openmc.hexagonal_prism(cell_edge_length, hex_orientation, boundary_type='periodic')
+    hex = openmc.model.HexagonalPrism(cell_edge_length, hex_orientation, boundary_type='periodic')
 
     hex_cell_vol = 6.0 * (math.sqrt(3) / 4.0) * cell_edge_length**2 * reactor_height
 
@@ -226,7 +226,7 @@ def unit_cell(n_ax_zones, n_inactive, n_active):
     max_z.boundary_type = 'vacuum'
 
     # fill the unit cell with the hex lattice
-    hex_cell = openmc.Cell(region=hex & +min_z & -max_z, fill=hex_lattice)
+    hex_cell = openmc.Cell(region=-hex & +min_z & -max_z, fill=hex_lattice)
 
     model.geometry = openmc.Geometry([hex_cell])
 


### PR DESCRIPTION
@Ethan-xj noticed that some of our OpenMC python scripts are out of date with respect to the `hexagonal_prism` utility function, which has now instead been encapsulated in a class (and also replaces a "region" by a composite surface). This updates our tests and tutorials to be compatible with the latest OpenMC.

Also updating other soon-to-be-deprecated syntax, `openmc.Source` -> `openmc.IndependentSource`.