### PR TITLE
Remove table print of fractional power values.

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -351,40 +351,41 @@ protected:
    * @param[in] var_num variable name to write
    * @param[in] tally tally values to write
    * @param[in] score tally score
-   * @param[in] print_table whether to print the diagnostic table showing tally values by bin
    * @return sum of the tally
    */
   Real getCellTally(const unsigned int & var_num,
                     const std::vector<xt::xtensor<double, 1>> & tally,
-                    const unsigned int & score,
-                    const bool & print_table);
+                    const unsigned int & score);
 
   /**
    * Read from an OpenMC mesh tally and write into an elemental aux variable
    * @param[in] var_num variable name to write
    * @param[in] tally tally values to write
    * @param[in] score tally score
-   * @param[in] print_table whether to print the diagnostic table showing tally values by bin
    * @return sum of the tally
    */
   Real getMeshTally(const unsigned int & var_num,
                     const std::vector<xt::xtensor<double, 1>> & tally,
-                    const unsigned int & score,
-                    const bool & print_table);
+                    const unsigned int & score);
 
   /**
-   * Extract the (cell or mesh) tally from OpenMC and then apply to the corresponding MOOSE
-   * elements. We also check that the tally normalization gives a total tally sum of 1.0 (when
-   * normalized against the total tally value).
+   * Extract the tally from OpenMC and then apply to the corresponding MOOSE elements.
    * @param[in] var_num variable name to write
    * @param[in] tally tally values to write
    * @param[in] score tally score
-   * @param[in] print_table whether to print the diagnostic table showing tally values by bin
+   * @return sum sum of the tally
    */
-  void getTally(const unsigned int & var_num,
+  Real getTally(const unsigned int & var_num,
                 const std::vector<xt::xtensor<double, 1>> & tally,
-                const unsigned int & score,
-                const bool & print_table);
+                const unsigned int & score);
+
+  /**
+   * Check that the tally normalization gives a total tally sum of 1.0 (when normalized
+   * against the total tally value).
+   * @param[in] sum sum of the tally
+   * @param[in] score tally score
+   */
+  void checkNormalization(const Real & sum, const unsigned int & score) const;
 
   /**
    * Get the mesh filter(s) for tallies automatically constructed by Cardinal.

--- a/src/base/CardinalApp.C
+++ b/src/base/CardinalApp.C
@@ -76,6 +76,7 @@ CardinalApp::validParams()
       "nekrs_device_id", "--nekrs-device-id", "NekRS device ID");
 
   params.set<bool>("use_legacy_material_output") = false;
+  params.set<bool>("use_legacy_initial_residual_evaluation_bahavior") = false;
   params.set<bool>("error_unused") = false;
   params.set<bool>("allow_unused") = true;
   return params;

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -2915,7 +2915,8 @@ OpenMCCellAverageProblem::dufekGudowskiParticleUpdate()
 
 Real
 OpenMCCellAverageProblem::getTally(const unsigned int & var_num,
-  const std::vector<xt::xtensor<double, 1>> & tally, const unsigned int & score)
+                                   const std::vector<xt::xtensor<double, 1>> & tally,
+                                   const unsigned int & score)
 {
   switch (_tally_type)
   {
@@ -2939,7 +2940,8 @@ OpenMCCellAverageProblem::checkNormalization(const Real & sum, const unsigned in
 
 Real
 OpenMCCellAverageProblem::getCellTally(const unsigned int & var_num,
-  const std::vector<xt::xtensor<double, 1>> & tally, const unsigned int & score)
+                                       const std::vector<xt::xtensor<double, 1>> & tally,
+                                       const unsigned int & score)
 {
   Real total = 0.0;
 
@@ -2967,7 +2969,8 @@ OpenMCCellAverageProblem::getCellTally(const unsigned int & var_num,
 
 Real
 OpenMCCellAverageProblem::getMeshTally(const unsigned int & var_num,
-  const std::vector<xt::xtensor<double, 1>> & tally, const unsigned int & score)
+                                       const std::vector<xt::xtensor<double, 1>> & tally,
+                                       const unsigned int & score)
 {
   Real total = 0.0;
 


### PR DESCRIPTION
For legacy reasons, we had a table print of the fractional power values of the tallies added by Cardinal. I think the additional code complexity here is no longer worth it (this was really added mostly to help with debugging the tally coding when Cardinal was first being developed). 

Arguments in favor of removing this code:

- The fractional power values can be obtained through alternate input file syntax in MOOSE
- These tables can be extremely long for most realistic OpenMC models, desensitizing the user to the console output
- We had to have some additional logic to decide _which_ tallies to output this for, since there's not a natural analog to a fractional "flux" (and this is one score we support)