### PR TITLE
sawtooth docs extra info and launch script adjustment

### DIFF
--- a/doc/content/hpc.md
+++ b/doc/content/hpc.md
@@ -193,6 +193,12 @@ export PYTHONPATH=$MOOSE_DIR/python:${PYTHONPATH}
 
 [Sawtooth](https://nsuf.inl.gov/Page/computing_resources)
  is an [!ac](HPC) system at [!ac](INL) with 99,792 cores (48 cores per node).
+ The max number of cores a job can run is 80,000, resulting in a max number of
+ nodes of 1666. Every job should use `ncpus=48` to maximize the power of each
+ node requested. The below script requests 1 node (`select=1`). In order to
+ maximizie performance on the node, always use `ncpus = mpiprocs * ompthreads = 48`,
+ and make sure that `--n-threads` in the job launch equals the same value as
+ `ompthreads`.
 
 !listing! language=bash caption=Sample `~/.bashrc` for Sawtooth id=st1
 if [ -f /etc/bashrc ]; then

--- a/scripts/job_sawtooth
+++ b/scripts/job_sawtooth
@@ -1,23 +1,24 @@
 #!/bin/bash
 
-# Usage:
+# Launch your job by entering the following into the terminal:
 # qsub job_sawtooth
 
 #PBS -l select=1:ncpus=48:mpiprocs=24:ompthreads=2
-#PBS -l walltime=5:00
+#PBS -l walltime=5:00 # HH:MM:SS
 #PBS -m ae
 #PBS -N cardinal
 #PBS -j oe
 #PBS -P moose
+#PBS -V
 
 module purge
 module load use.moose
 module load moose-tools
 module load openmpi/4.1.5_ucx1.14.1
-module load cmake/3.27.7-oneapi-2023.2.1-4uzb
 
 # Revise for your repository location
 export CARDINAL_DIR=$HOME/cardinal
+export OMP_PROC_BIND=true
 
 # Run an OpenMC case
 cd $CARDINAL_DIR/test/tests/neutronics/feedback/lattice


### PR DESCRIPTION
Closes #876. Open to feedback on the docs comments/submit script.

Also, is there a reason we load `cmake` in the job launch script? Does the cardinal executable need `cmake` to execute the job? I'd think no, but I am not an expert in that department