### PR TITLE
minor fix for non-dimensional cases

### DIFF
--- a/src/userobjects/NekBinnedPlaneIntegral.C
+++ b/src/userobjects/NekBinnedPlaneIntegral.C
@@ -171,7 +171,7 @@ NekBinnedPlaneIntegral::executeUserObject()
 
   // correct the values to areas
   for (unsigned int i = 0; i < _n_bins; ++i)
-    _bin_values[i] /= _gap_thickness;
+    _bin_values[i] /= (_gap_thickness * nekrs::referenceLength() );
 }
 
 #endif


### PR DESCRIPTION
Small fix that dimensionalises the `_gap_width` parameter for use with non-dimensional cases. Without it, the volume integral from the bins gets multiplied by `L_ref^3`, resulting in incorrect scaling for a userobject that should ultimately yield an area (for an appropriate `gap_width`).