### PR TITLE
Enforce collision estimator for photon heating.

### DIFF
--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -335,7 +335,8 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
   else
     _tally_score = {"kappa-fission"};
 
-  bool heating = std::find(_tally_score.begin(), _tally_score.end(), "heating") != _tally_score.end();
+  bool heating =
+      std::find(_tally_score.begin(), _tally_score.end(), "heating") != _tally_score.end();
 
   if (isParamValid("tally_estimator"))
   {
@@ -348,7 +349,8 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
         mooseError("Tracklength estimators are currently incompatible with mesh tallies!");
 
       if (openmc::settings::photon_transport && heating)
-        mooseError("Tracklength estimators are currently incompatible with photon transport and heating scores! For more information: https://tinyurl.com/3wre3kwt");
+        mooseError("Tracklength estimators are currently incompatible with photon transport and "
+                   "heating scores! For more information: https://tinyurl.com/3wre3kwt");
     }
 
     _tally_estimator = tallyEstimator(estimator);
@@ -364,13 +366,14 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
   }
 
   if (heating && !openmc::settings::photon_transport)
-    mooseWarning("When using the 'heating' score with photon transport disabled, energy deposition\n"
-      "from photons is neglected unless you specifically ran NJOY to produce MT=301 with\n"
-      "photon energy deposited locally (not true for any pre-packaged OpenMC data libraries\n"
-      "on openmc.org).\n\n"
-      "If you did NOT specifically run NJOY yourself with this customization, we recommend\n"
-      "using the 'heating_local' score instead, which will capture photon energy deposition.\n"
-      "Otherwise, you will underpredict the true energy deposition.");
+    mooseWarning(
+        "When using the 'heating' score with photon transport disabled, energy deposition\n"
+        "from photons is neglected unless you specifically ran NJOY to produce MT=301 with\n"
+        "photon energy deposited locally (not true for any pre-packaged OpenMC data libraries\n"
+        "on openmc.org).\n\n"
+        "If you did NOT specifically run NJOY yourself with this customization, we recommend\n"
+        "using the 'heating_local' score instead, which will capture photon energy deposition.\n"
+        "Otherwise, you will underpredict the true energy deposition.");
 
   // need some special treatment for non-heating scores, in eigenvalue mode
   bool has_non_heating_score = false;

--- a/test/tests/neutronics/photon/geometry.xml
+++ b/test/tests/neutronics/photon/geometry.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='utf-8'?>
+<geometry>
+  <cell id="1" material="1" name="Fuel" region="-2" universe="1" />
+  <cell id="2" material="3" name="Clad" region="2 -1" universe="1" />
+  <cell id="3" material="2 4 5 6 7 8 9 10 11 12" name="Water" region="1 -3" universe="1" />
+  <cell id="4" material="2" name="Outside" region="1 -3" universe="2" />
+  <cell fill="3" id="5" region="-3 5 -4" universe="4" />
+  <lattice id="3">
+    <pitch>1.28 1.28 1.0</pitch>
+    <outer>2</outer>
+    <dimension>1 1 10</dimension>
+    <lower_left>-0.64 -0.64 0</lower_left>
+    <universes>
+1 
+
+1 
+
+1 
+
+1 
+
+1 
+
+1 
+
+1 
+
+1 
+
+1 
+
+1 </universes>
+  </lattice>
+  <surface coeffs="0.0 0.0 0.485" id="1" name="Pincell outer radius" type="z-cylinder" />
+  <surface coeffs="0.0 0.0 0.4125" id="2" name="Pellet outer radius" type="z-cylinder" />
+  <surface boundary="white" coeffs="0.0 0.0 0.64" id="3" name="Water surface" type="z-cylinder" />
+  <surface boundary="vacuum" coeffs="10.0" id="4" type="z-plane" />
+  <surface boundary="vacuum" coeffs="0.0" id="5" type="z-plane" />
+</geometry>

--- a/test/tests/neutronics/photon/materials.xml
+++ b/test/tests/neutronics/photon/materials.xml
@@ -1,0 +1,98 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material depletable="true" id="1" name="UO2">
+    <density units="g/cm3" value="10.29769" />
+    <nuclide ao="0.05" name="U235" />
+    <nuclide ao="0.95" name="U238" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material id="2" name="water0">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="3" name="Zircaloy">
+    <density units="g/cm3" value="6.55" />
+    <nuclide ao="0.5145" name="Zr90" />
+    <nuclide ao="0.1122" name="Zr91" />
+    <nuclide ao="0.1715" name="Zr92" />
+    <nuclide ao="0.1738" name="Zr94" />
+    <nuclide ao="0.028" name="Zr96" />
+  </material>
+  <material id="4" name="water1">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="5" name="water2">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="6" name="water3">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="7" name="water4">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="8" name="water5">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="9" name="water6">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="10" name="water7">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="11" name="water8">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="12" name="water9">
+    <density units="g/cm3" value="0.7213448127316942" />
+    <nuclide ao="1.99968852" name="H1" />
+    <nuclide ao="0.00031148" name="H2" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+</materials>

--- a/test/tests/neutronics/photon/openmc.i
+++ b/test/tests/neutronics/photon/openmc.i
@@ -1,0 +1,19 @@
+[Mesh]
+  type = FileMesh
+  file = ../meshes/pincell.e
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 500.0
+
+  cell_level = 1
+  tally_type = cell
+  tally_blocks = '1'
+  tally_score = 'heating'
+  tally_estimator = tracklength
+[]
+
+[Executioner]
+  type = Transient
+[]

--- a/test/tests/neutronics/photon/settings.xml
+++ b/test/tests/neutronics/photon/settings.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<settings>
+  <run_mode>eigenvalue</run_mode>
+  <particles>1000</particles>
+  <batches>5</batches>
+  <inactive>2</inactive>
+  <source strength="1.0">
+    <space type="fission">
+      <parameters>-1.28 -1.28 0.0 1.28 1.28 10.0</parameters>
+    </space>
+  </source>
+  <photon_transport>true</photon_transport>
+  <temperature_default>573.0</temperature_default>
+  <temperature_method>nearest</temperature_method>
+  <temperature_range>294.0 3000.0</temperature_range>
+  <temperature_tolerance>1000.0</temperature_tolerance>
+</settings>

--- a/test/tests/neutronics/photon/tests
+++ b/test/tests/neutronics/photon/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [photon_heating]
+    type = RunException
+    input = openmc.i
+    expect_err = "Tracklength estimators are currently incompatible with photon transport and heating scores!"
+    requirement = "The system shall error if using incompatible tally estimator with a photon transport heating score."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
+[]


### PR DESCRIPTION
Thanks Shikhar for noting this incompatibility! Photon heating scores cannot be used with tracklength estimators due to some approximations made for thick-target bremmstrahlung.