### PR TITLE
Allow to skip a statepoint

### DIFF
--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -422,6 +422,9 @@ protected:
    */
   const Real & _scaling;
 
+  /// Whether to skip writing statepoints from OpenMC
+  const bool & _skip_statepoint;
+
   /**
    * Fixed point iteration index used in relaxation; because we sometimes run OpenMC
    * in a pseudo-transient coupling with NekRS, we simply increment this by 1 each

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -909,11 +909,12 @@ OpenMCCellAverageProblem::getTallyTriggerParameters(const InputParameters & para
   {
     checkRequiredParam(parameters, "k_trigger_threshold", "using a k trigger");
     openmc::settings::keff_trigger.threshold = getParam<Real>("k_trigger_threshold");
+    has_tally_trigger = true;
   }
   else
     checkUnusedParam(parameters, "k_trigger_threshold", "not using a k trigger");
 
-  if (_k_trigger != trigger::none || has_tally_trigger) // at least one trigger
+  if (has_tally_trigger) // at least one trigger
   {
     openmc::settings::trigger_on = true;
     checkRequiredParam(parameters, "max_batches", "using triggers");
@@ -2424,11 +2425,11 @@ OpenMCCellAverageProblem::resetTallies()
 void
 OpenMCCellAverageProblem::initializeTallies()
 {
-  if (_tally_type == tally::none)
-    return;
-
   // add trigger information for k, if present
   openmc::settings::keff_trigger.metric = triggerMetric(_k_trigger);
+
+  if (_tally_type == tally::none)
+    return;
 
   // create the global tally for normalization; we make sure to use the
   // same estimator as the local tally
@@ -2533,9 +2534,9 @@ OpenMCCellAverageProblem::latticeOuterError(const Point & c, int level) const
   std::stringstream msg;
   msg << "The point " << c << " mapped to cell " << cell->id_
       << " in the OpenMC model is inside a universe "
-         "used as the 'outer' universe of a lattice.\n"
+         "used as the 'outer' universe of a lattice. "
          "All cells used for mapping in lattices must be explicitly set "
-         "on the 'universes' attribute of lattice objects.\n"
+         "on the 'universes' attribute of lattice objects. "
       << "If you want to obtain feedback or cell tallies here, you "
          "will need to widen your lattice to have universes covering all of the space you "
          "want feedback or cell tallies.\n\nFor more information, see: "

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -917,6 +917,9 @@ OpenMCCellAverageProblem::getTallyTriggerParameters(const InputParameters & para
     openmc::settings::trigger_on = true;
     checkRequiredParam(parameters, "max_batches", "using triggers");
 
+    if (_skip_statepoint)
+      checkUnusedParam(parameters, "skip_statepoint", "using a trigger");
+
     int err = openmc_set_n_batches(getParam<unsigned int>("max_batches"),
                                    true /* set the max batches */,
                                    true /* add the last batch for statepoint writing */);
@@ -928,6 +931,8 @@ OpenMCCellAverageProblem::getTallyTriggerParameters(const InputParameters & para
   {
     checkUnusedParam(parameters, "max_batches", "not using triggers");
     checkUnusedParam(parameters, "batch_interval", "not using triggers");
+
+    if (_skip_statepoint)                                                                      openmc::settings::statepoint_batch.clear();
   }
 }
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -548,6 +548,7 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     }
     case tally::cell:
     {
+      checkRequiredParam(params, "tally_blocks", "using cell tallies");
       checkUnusedParam(params, {"mesh_template", "mesh_translations", "mesh_translations_file"},
                                "using cell tallies");
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -932,7 +932,8 @@ OpenMCCellAverageProblem::getTallyTriggerParameters(const InputParameters & para
     checkUnusedParam(parameters, "max_batches", "not using triggers");
     checkUnusedParam(parameters, "batch_interval", "not using triggers");
 
-    if (_skip_statepoint)                                                                      openmc::settings::statepoint_batch.clear();
+    if (_skip_statepoint)
+      openmc::settings::statepoint_batch.clear();
   }
 }
 

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -65,7 +65,11 @@ OpenMCProblemBase::validParams()
                         false,
                         "Whether to take the initial fission source "
                         "for interation n to be the converged source bank from iteration n-1");
-  params.addParam<bool>("skip_statepoint", false, "Whether to skip writing any statepoint files from OpenMC; this is a performance optimization for scenarios where you may not want the statepoint files anyways");
+  params.addParam<bool>(
+      "skip_statepoint",
+      false,
+      "Whether to skip writing any statepoint files from OpenMC; this is a performance "
+      "optimization for scenarios where you may not want the statepoint files anyways");
   return params;
 }
 

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -603,10 +603,14 @@ OpenMCProblemBase::tallyEstimator(tally::TallyEstimatorEnum estimator) const
 openmc::TriggerMetric
 OpenMCProblemBase::triggerMetric(std::string trigger) const
 {
-  if (trigger == "none")
-    return openmc::TriggerMetric::not_active;
+  if (trigger == "variance")
+    return openmc::TriggerMetric::variance;
+  else if (trigger == "std_dev")
+    return openmc::TriggerMetric::standard_deviation;
   else if (trigger == "rel_err")
     return openmc::TriggerMetric::relative_error;
+  else if (trigger == "none")
+    return openmc::TriggerMetric::not_active;
   else
     mooseError("Unhandled TallyTriggerTypeEnum: ", trigger);
 }

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -65,6 +65,7 @@ OpenMCProblemBase::validParams()
                         false,
                         "Whether to take the initial fission source "
                         "for interation n to be the converged source bank from iteration n-1");
+  params.addParam<bool>("skip_statepoint", false, "Whether to skip writing any statepoint files from OpenMC; this is a performance optimization for scenarios where you may not want the statepoint files anyways");
   return params;
 }
 
@@ -76,6 +77,7 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
     _reuse_source(getParam<bool>("reuse_source")),
     _specified_scaling(params.isParamSetByUser("scaling")),
     _scaling(getParam<Real>("scaling")),
+    _skip_statepoint(getParam<bool>("skip_statepoint")),
     _fixed_point_iteration(-1),
     _total_n_particles(0)
 {

--- a/test/tests/neutronics/dagmc/density_skin/disjoint_bins.i
+++ b/test/tests/neutronics/dagmc/density_skin/disjoint_bins.i
@@ -38,6 +38,7 @@ dT = 50.0
   type = OpenMCCellAverageProblem
   verbose = true
   tally_type = cell
+  tally_blocks = '1 2'
 
   temperature_blocks = '1 2'
   density_blocks = '1 2'

--- a/test/tests/neutronics/feedback/temperature/one_one/openmc.i
+++ b/test/tests/neutronics/feedback/temperature/one_one/openmc.i
@@ -23,10 +23,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   verbose = true
-  power = 100.0
-
-  tally_type = cell
-
+  tally_type = none
   temperature_blocks = '0'
   cell_level = 0
 []

--- a/test/tests/neutronics/feedback/temperature/one_two/openmc.i
+++ b/test/tests/neutronics/feedback/temperature/one_two/openmc.i
@@ -44,10 +44,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   verbose = true
-  power = 100.0
-
-  tally_type = cell
-
+  tally_type = none
   temperature_blocks = '0'
   cell_level = 0
 []

--- a/test/tests/neutronics/feedback/temperature/two_one/openmc.i
+++ b/test/tests/neutronics/feedback/temperature/two_one/openmc.i
@@ -54,7 +54,7 @@
   verbose = true
   power = 100.0
 
-  tally_type = cell
+  tally_type = none
 
   temperature_blocks = '0 3'
   cell_level = 0

--- a/test/tests/neutronics/feedback/temperature/two_one/openmc_default.i
+++ b/test/tests/neutronics/feedback/temperature/two_one/openmc_default.i
@@ -52,12 +52,8 @@
 [Problem]
   type = OpenMCCellAverageProblem
   verbose = true
-  power = 100.0
-
-  tally_type = cell
-
+  tally_type = none
   cell_level = 0
-
   temperature_blocks = '3 0'
 []
 

--- a/test/tests/neutronics/feedback/temperature/two_one/openmc_multi_temp.i
+++ b/test/tests/neutronics/feedback/temperature/two_one/openmc_multi_temp.i
@@ -57,12 +57,8 @@
 [Problem]
   type = OpenMCCellAverageProblem
   verbose = true
-  power = 100.0
-
-  tally_type = cell
-
+  tally_type = none
   cell_level = 0
-
   temperature_variables = 'temp_left; temp_right'
   temperature_blocks = '3; 0'
 []

--- a/test/tests/neutronics/heat_source/default_tally_blocks.i
+++ b/test/tests/neutronics/heat_source/default_tally_blocks.i
@@ -39,6 +39,7 @@
   cell_level = 0
   tally_type = cell
   tally_name = heat_source
+  tally_blocks = '100 200'
 
   initial_properties = xml
 []

--- a/test/tests/neutronics/openmc_xml/skip_statepoint.i
+++ b/test/tests/neutronics/openmc_xml/skip_statepoint.i
@@ -1,0 +1,24 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../meshes/sphere.e
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  power = 100.0
+  cell_level = 0
+  tally_type = cell
+  normalize_by_global_tally = false
+  initial_properties = xml
+
+  inactive_batches = 3
+  batches = 8
+  skip_statepoint = true
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]

--- a/test/tests/neutronics/openmc_xml/skip_statepoint.i
+++ b/test/tests/neutronics/openmc_xml/skip_statepoint.i
@@ -8,10 +8,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   power = 100.0
-  cell_level = 0
-  tally_type = cell
-  normalize_by_global_tally = false
-  initial_properties = xml
+  tally_type = none
 
   inactive_batches = 3
   batches = 8

--- a/test/tests/neutronics/openmc_xml/tests
+++ b/test/tests/neutronics/openmc_xml/tests
@@ -41,4 +41,11 @@
                   "(with 60 batches) to ensure correctness."
     required_objects = 'OpenMCCellAverageProblem'
   []
+  [skip_statepoint]
+    type = CheckFiles
+    input = skip_statepoint.i
+    check_not_exists = 'statepoint.8.h5'
+    requirement = 'The system shall allow skipping of statepoint output files'
+    required_objects = 'OpenMCCellAverageProblem'
+  []
 []

--- a/test/tests/neutronics/solid/openmc_missing_pebble.i
+++ b/test/tests/neutronics/solid/openmc_missing_pebble.i
@@ -20,7 +20,8 @@
 [Problem]
   type = OpenMCCellAverageProblem
   power = 10.0
-  tally_type = 'cell'
+  tally_type = cell
+  tally_blocks = '1'
   cell_level = 0
   temperature_blocks = '1'
 []

--- a/test/tests/neutronics/solid/openmc_zero.i
+++ b/test/tests/neutronics/solid/openmc_zero.i
@@ -23,6 +23,7 @@
   type = OpenMCCellAverageProblem
   power = 0.0
   tally_type = cell
+  tally_blocks = '1'
   tally_name = heat_source
   cell_level = 0
   temperature_blocks = '1'

--- a/test/tests/neutronics/triggers/k_std_dev.i
+++ b/test/tests/neutronics/triggers/k_std_dev.i
@@ -19,12 +19,7 @@
 
 [Problem]
   type = OpenMCCellAverageProblem
-  power = 100.0
-  temperature_blocks = '100'
-  cell_level = 0
-  tally_type = cell
-  normalize_by_global_tally = false
-  initial_properties = xml
+  tally_type = none
 
   k_trigger = std_dev
   k_trigger_threshold = 1.2e-2

--- a/test/tests/neutronics/triggers/mesh_tally_rel_err.i
+++ b/test/tests/neutronics/triggers/mesh_tally_rel_err.i
@@ -23,15 +23,12 @@
   type = OpenMCCellAverageProblem
   verbose = true
   power = 100.0
-  temperature_blocks = '100'
-  cell_level = 0
   tally_type = mesh
   mesh_template = '../meshes/sphere.e'
   mesh_translations = '0 0 0
                        0 0 4
                        0 0 8'
   normalize_by_global_tally = false
-  initial_properties = xml
 
   tally_trigger = rel_err
   tally_trigger_threshold = 5e-1

--- a/test/tests/neutronics/triggers/multi_rel_err.i
+++ b/test/tests/neutronics/triggers/multi_rel_err.i
@@ -21,11 +21,10 @@
   type = OpenMCCellAverageProblem
   power = 100.0
   batches = 20
-  temperature_blocks = '100'
   cell_level = 0
   tally_type = cell
+  tally_blocks = '100'
   normalize_by_global_tally = false
-  initial_properties = xml
 
   tally_score = 'damage_energy kappa_fission'
 

--- a/test/tests/neutronics/triggers/tally_rel_err.i
+++ b/test/tests/neutronics/triggers/tally_rel_err.i
@@ -20,11 +20,10 @@
 [Problem]
   type = OpenMCCellAverageProblem
   power = 100.0
-  temperature_blocks = '100'
   cell_level = 0
   tally_type = cell
+  tally_blocks = '100'
   normalize_by_global_tally = false
-  initial_properties = xml
 
   tally_trigger = rel_err
   tally_trigger_threshold = 2e-2

--- a/test/tests/openmc_errors/cell_instances/lattice_outer/temp.i
+++ b/test/tests/openmc_errors/cell_instances/lattice_outer/temp.i
@@ -23,7 +23,7 @@
 [Problem]
   type = OpenMCCellAverageProblem
   power = 1.0
-  tally_type = cell
+  tally_type = none
   temperature_blocks = 0
   cell_level = 1
 []

--- a/test/tests/openmc_errors/input_params/levels.i
+++ b/test/tests/openmc_errors/input_params/levels.i
@@ -1,0 +1,18 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../../neutronics/meshes/sphere.e
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  temperature_blocks = '1'
+  cell_level = 0
+  lowest_cell_level = 0
+  tally_type = none
+[]
+
+[Executioner]
+  type = Transient
+[]

--- a/test/tests/openmc_errors/input_params/tests
+++ b/test/tests/openmc_errors/input_params/tests
@@ -29,4 +29,11 @@
     requirement = "The system shall error if using a skinner without a DagMC geometry"
     required_objects = 'MoabSkinner'
   []
+  [duplicate_levels]
+    type = RunException
+    input = levels.i
+    expect_err = "Either 'cell_level' or 'lowest_cell_level' must be specified. You have given either both or none."
+    requirement = "The system shall error if both or none of the cell level options have been prescribed."
+    required_objects = 'MoabSkinner'
+  []
 []

--- a/test/tests/symmetry/reflection.i
+++ b/test/tests/symmetry/reflection.i
@@ -47,13 +47,7 @@
 
 [Problem]
   type = OpenMCCellAverageProblem
-  power = 100.0
-  temperature_blocks = '100'
-  cell_level = 0
-  tally_type = cell
-  normalize_by_global_tally = false
-  initial_properties = xml
-
+  tally_type = none
   symmetry_mapper = sym
 []
 
@@ -71,7 +65,4 @@
 
 [Outputs]
   exodus = true
-
-  # we are only interested in the point transformation aspects here
-  hide = 'kappa_fission temp cell_id cell_instance'
 []

--- a/test/tests/symmetry/rotation.i
+++ b/test/tests/symmetry/rotation.i
@@ -48,13 +48,7 @@
 
 [Problem]
   type = OpenMCCellAverageProblem
-  power = 100.0
-  temperature_blocks = '100'
-  cell_level = 0
-  tally_type = cell
-  normalize_by_global_tally = false
-  initial_properties = xml
-
+  tally_type = none
   symmetry_mapper = sym
 []
 
@@ -74,7 +68,4 @@
 
 [Outputs]
   exodus = true
-
-  # we are only interested in the point transformation aspects here
-  hide = 'kappa_fission temp cell_id cell_instance'
 []


### PR DESCRIPTION
For some reason, the statepoint writing on Summit is really slow to the point where it's precluding my simulations. This adds an option to skip statepoint writing.