### PR TITLE
move all mesh parameters into mesh_settings

### DIFF
--- a/utils/meshes/assembly/convert.i
+++ b/utils/meshes/assembly/convert.i
@@ -19,7 +19,7 @@
     polygon_size = ${fparse flat_to_flat / sqrt(3.0)}
     corner_radius = ${duct_corner_radius_of_curvature}
     polygon_layers = ${fparse e_per_bl + e_per_assembly_background}
-    polygon_layer_smoothing = ${cs}
+    polygon_layer_smoothing = ${corner_smoothing}
     polygon_boundary = '4'
     rotation_angle = 30.0
   []

--- a/utils/meshes/assembly/mesh.py
+++ b/utils/meshes/assembly/mesh.py
@@ -19,11 +19,6 @@ import csv
 # flow area are evaluated accounting for the wire, even though the
 # wire is not explicitly meshed.
 
-# Smoothing factors to apply to the corner movement; must match the length
-# of the e_per_bl + e_per_assembly_background (if specified). You may
-# need to adjust this parameter if the default doesn't work nicely.
-corner_smoothing = [1.0, 1.0, 1.0, 0.75, 0.25, 0.25]
-
 ####################################################################
 
 ap = ArgumentParser()
@@ -52,15 +47,7 @@ e_per_assembly_background = ms.e_per_assembly_background
 growth_factor = ms.growth_factor
 nl = ms.nl
 bl_height = ms.bl_height
-
-# If not specified by user, set a reasonable default
-if (len(corner_smoothing) == 0):
-  for i in range(e_per_bl + e_per_assembly_background):
-    corner_smoothing.append(1.0)
-
-cs = ""
-for i in range(len(corner_smoothing)):
-  cs += " " + str(corner_smoothing[i])
+corner_smoothing = ms.corner_smoothing
 
 # dummy block IDs just for mesh creation purposes
 fluid_id = 5
@@ -270,7 +257,7 @@ with open('mesh_info.i', 'w') as f:
   f.write("fluid_elems=" + fluid_elems + "'\n")
   f.write("pattern=" + str(pattern) + "\n")
   f.write("pin_centers=" + str(pin_centers) + "\n")
-  f.write("cs='" + cs + "'\n")
+  f.write("corner_smoothing='" + corner_smoothing + "'\n")
 
 if (args.generate):
   home = os.getenv('HOME')

--- a/utils/meshes/assembly/mesh_settings.py
+++ b/utils/meshes/assembly/mesh_settings.py
@@ -14,3 +14,8 @@ e_per_assembly_background = 3 # number of background elements in assembly
 growth_factor = 1.8           # boundary layer growth factor
 nl = 1                        # number of axial layers
 bl_height = 0.00006           # height of first boundary layer
+
+# Smoothing factors to apply to the corner movement; must match the length
+# of the e_per_bl + e_per_assembly_background. You may
+# need to adjust this parameter if the default doesn't work nicely.
+corner_smoothing = '1.0 1.0 1.0 0.75 0.25 0.25'

--- a/utils/meshes/interassembly/convert.i
+++ b/utils/meshes/interassembly/convert.i
@@ -15,7 +15,7 @@
     curve_corners = true
     polygon_sides = 6
     polygon_size = ${fparse outer_flat_to_flat / sqrt(3.0)}
-    polygon_layer_smoothing = ${cs}
+    polygon_layer_smoothing = ${corner_smoothing}
     polygon_layers = ${e_per_bl}
     polygon_origins = ${polygon_origins}
     polygon_boundary = '3'

--- a/utils/meshes/interassembly/mesh.py
+++ b/utils/meshes/interassembly/mesh.py
@@ -18,10 +18,6 @@ from argparse import ArgumentParser
 # defined in the mesh_settings.py file. You should not need to
 # edit anything in this script except optionally:
 
-# Smoothing factors to apply to the corner movement; must match the length
-# of the e_per_bl (if specified)
-corner_smoothing = []
-
 ####################################################################
 
 ap = ArgumentParser()
@@ -48,11 +44,7 @@ e_per_bl = ms.e_per_bl
 e_per_peripheral = ms.e_per_peripheral
 growth_factor = ms.growth_factor
 bl_height = ms.bl_height
-
-# If not specified by user, set a do-nothing default
-if (len(corner_smoothing) == 0):
-  for i in range(e_per_bl):
-    corner_smoothing.append(1.0)
+corner_smoothing = ms.corner_smoothing
 
 # dummy block IDs just for mesh creation purposes
 gap_id = 5
@@ -142,10 +134,6 @@ def lattice_centers(nrings, pitch):
     lattices += str(rotated_x) + " " + str(rotated_y) + " 0.0;"
 
   return lattices[:-1] + "'"
-
-cs = ""
-for i in range(len(corner_smoothing)):
-  cs += " " + str(corner_smoothing[i])
 
 # Get the 'pattern' needed for the core by assuming a simple hex grid of bundles
 n_rings = rings(n_bundles)
@@ -238,7 +226,7 @@ with open('mesh_info.i', 'w') as f:
   f.write("duct_ids=" + str(duct_ids) + "'\n")
   f.write("pattern=" + str(pattern) + "\n")
   f.write("polygon_origins=" + str(bundle_origins) + "\n")
-  f.write("cs='" + cs + "'\n")
+  f.write("corner_smoothing='" + corner_smoothing + "'\n")
 
 if (args.generate):
   home = os.getenv('HOME')

--- a/utils/meshes/interassembly/mesh_settings.py
+++ b/utils/meshes/interassembly/mesh_settings.py
@@ -12,3 +12,7 @@ e_per_bl = 1                 # number of elements in each boundary layer
 e_per_peripheral = 1         # number of elements to put in the peripheral region
 growth_factor = 1.7          # growth factor for the boundary layers
 bl_height = 0.0001           # height of the first boundary layer
+
+# Smoothing factors to apply to the corner movement; must match the length
+# of the e_per_bl/
+corner_smoothing = '1'

--- a/utils/meshes/interassembly_w_structures/convert.i
+++ b/utils/meshes/interassembly_w_structures/convert.i
@@ -16,7 +16,7 @@
     polygon_sides = 6
     polygon_size = ${fparse outer_flat_to_flat / sqrt(3.0)}
     polygon_layers = ${e_per_bl}
-    polygon_layer_smoothing = ${cs}
+    polygon_layer_smoothing = ${corner_smoothing}
     polygon_origins = ${polygon_origins}
     polygon_boundary = '${duct_outer}'
     corner_radius = ${fparse corner_radius}

--- a/utils/meshes/interassembly_w_structures/mesh.py
+++ b/utils/meshes/interassembly_w_structures/mesh.py
@@ -27,10 +27,6 @@ from argparse import ArgumentParser
 # defined in the mesh_settings.py file. You should not need to
 # edit anything in this script except for:
 
-# Smoothing factors to apply to the corner movement; must match the length
-# of the e_per_bl (if specified)
-corner_smoothing = []
-
 ################################################################################
 
 ap = ArgumentParser()
@@ -71,6 +67,7 @@ e_per_gap_bl = ms.e_per_gap_bl
 bl_height = ms.bl_height
 bl_pad_height = ms.bl_pad_height
 growth_factor = ms.growth_factor
+corner_smoothing = ms.corner_smoothing
 
 num_layers_per_dz = ms.num_layers_per_dz
 
@@ -183,10 +180,6 @@ def lattice_centers(nrings, pitch):
     lattices += str(rotated_x) + " " + str(rotated_y) + " 0.0;"
 
   return lattices[:-1] + "'"
-
-cs = ""
-for i in range(len(corner_smoothing)):
-  cs += " " + str(corner_smoothing[i])
 
 # Get the 'pattern' needed for the core by assuming a simple hex grid of bundles
 n_rings = rings(n_bundles)
@@ -397,7 +390,7 @@ with open('mesh_info.i', 'w') as f:
   f.write("s_swaps='" + s_swaps + "'\n")
   f.write("s_swaps_extra='" + s_swaps_extra + "'\n")
   f.write("polygon_origins=" + str(bundle_origins) + "\n")
-  f.write("cs='" + cs + "'\n")
+  f.write("corner_smoothing='" + corner_smoothing + "'\n")
 
 if (args.generate):
   home = os.getenv('HOME')

--- a/utils/meshes/interassembly_w_structures/mesh_settings.py
+++ b/utils/meshes/interassembly_w_structures/mesh_settings.py
@@ -28,3 +28,8 @@ bl_pad_height = 0.0001        # height of first boundary layer on bottom/top fac
 growth_factor = 1.8           # boundary layer growth factor
 
 num_layers_per_dz = 1.0       # layers per axial pitch
+
+# Smoothing factors to apply to the corner movement; must match the length
+# of the e_per_bl.
+corner_smoothing = '1'
+


### PR DESCRIPTION
For the meshing scripts, for some reason we had one user-defined setting (`corner_smoothing`) which was not defined in the `mesh_settings.py`. This moves everything into this file for consistency.