### PR TITLE
Allow CSG in DAGMC

### DIFF
--- a/test/tests/neutronics/dagmc/incompatible_geom/has_csg/tests
+++ b/test/tests/neutronics/dagmc/incompatible_geom/has_csg/tests
@@ -2,9 +2,9 @@
   [includes_csg]
     type = RunException
     input = openmc.i
-    expect_err = "The 'skinner' can only be used with OpenMC geometries that are entirely DAGMC based.\n"
-                 "Your model contains a combination of both CSG and DAG cells."
-    requirement = "The system shall error if attempting to skin an OpenMC geometry that is a combination "
+    cli_args = '--error'
+    expect_err = "Your model contains a combination of CSG and DAG cells."
+    requirement = "The system shall warn if attempting to skin an OpenMC geometry that is a combination "
                   "of DAG and CSG cells."
     required_objects = 'MoabSkinner'
   []

--- a/test/tests/neutronics/dagmc/incompatible_geom/multiple_dagmc/geometry.xml
+++ b/test/tests/neutronics/dagmc/incompatible_geom/multiple_dagmc/geometry.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<geometry>
+  <cell fill="1" id="1" region="-1" universe="3"/>
+  <cell fill="2" id="2" region="-2" universe="3"/>
+  <dagmc_universe auto_geom_ids="true" filename="../../mesh_tallies/slab.h5m" id="1"/>
+  <dagmc_universe auto_geom_ids="true" filename="../../../../../../tutorials/dagmc/dagmc.h5m" id="2"/>
+  <surface boundary="vacuum" coeffs="0.0 0.0 0.0 10.0" id="1" type="sphere"/>
+  <surface boundary="vacuum" coeffs="100 100 100 10.0" id="2" type="sphere"/>
+</geometry>

--- a/test/tests/neutronics/dagmc/incompatible_geom/multiple_dagmc/make_openmc_model.py
+++ b/test/tests/neutronics/dagmc/incompatible_geom/multiple_dagmc/make_openmc_model.py
@@ -1,0 +1,56 @@
+#********************************************************************/
+#*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+#*                             Cardinal                             */
+#*                                                                  */
+#*                  (c) 2021 UChicago Argonne, LLC                  */
+#*                        ALL RIGHTS RESERVED                       */
+#*                                                                  */
+#*                 Prepared by UChicago Argonne, LLC                */
+#*               Under Contract No. DE-AC02-06CH11357               */
+#*                With the U. S. Department of Energy               */
+#*                                                                  */
+#*             Prepared by Battelle Energy Alliance, LLC            */
+#*               Under Contract No. DE-AC07-05ID14517               */
+#*                With the U. S. Department of Energy               */
+#*                                                                  */
+#*                 See LICENSE for full restrictions                */
+#********************************************************************/
+
+import openmc
+
+# materials in slab.h5m
+a = openmc.Material()
+a.set_density('g/cc', 11.0)
+a.add_nuclide('U235', 1.0)
+
+b = openmc.Material()
+b.set_density('g/cc', 11.0)
+b.add_nuclide('U235', 0.5)
+b.add_nuclide('U238', 0.5)
+
+# materials in dagmc.h5m
+u235 = openmc.Material(name="fuel")
+u235.add_nuclide('U235', 1.0, 'ao')
+u235.set_density('g/cc', 11)
+u235.id = 40
+
+water = openmc.Material(name="water")
+water.add_nuclide('H1', 2.0, 'ao')
+water.add_nuclide('O16', 1.0, 'ao')
+water.set_density('g/cc', 1.0)
+water.add_s_alpha_beta('c_H_in_H2O')
+water.id = 41
+
+mats = openmc.Materials([a, b, u235, water])
+mats.export_to_xml()
+
+univ1 = openmc.DAGMCUniverse(filename="../../mesh_tallies/slab.h5m", auto_geom_ids=True)
+univ2 = openmc.DAGMCUniverse(filename="../../../../../../tutorials/dagmc/dagmc.h5m", auto_geom_ids=True)
+
+sphere1 = openmc.Sphere(r=10.0, boundary_type='vacuum')
+csg1 = openmc.Cell(region=-sphere1, fill=univ1)
+sphere2 = openmc.Sphere(x0=100, y0=100, z0=100, r=10.0, boundary_type='vacuum')
+csg2 = openmc.Cell(region=-sphere2, fill=univ2)
+
+geometry = openmc.Geometry([csg1, csg2])
+geometry.export_to_xml()

--- a/test/tests/neutronics/dagmc/incompatible_geom/multiple_dagmc/materials.xml
+++ b/test/tests/neutronics/dagmc/incompatible_geom/multiple_dagmc/materials.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material depletable="true" id="1">
+    <density units="g/cc" value="11.0"/>
+    <nuclide ao="1.0" name="U235"/>
+  </material>
+  <material depletable="true" id="2">
+    <density units="g/cc" value="11.0"/>
+    <nuclide ao="0.5" name="U235"/>
+    <nuclide ao="0.5" name="U238"/>
+  </material>
+  <material depletable="true" id="40" name="fuel">
+    <density units="g/cc" value="11"/>
+    <nuclide ao="1.0" name="U235"/>
+  </material>
+  <material id="41" name="water">
+    <density units="g/cc" value="1.0"/>
+    <nuclide ao="2.0" name="H1"/>
+    <nuclide ao="1.0" name="O16"/>
+    <sab name="c_H_in_H2O"/>
+  </material>
+</materials>

--- a/test/tests/neutronics/dagmc/incompatible_geom/multiple_dagmc/openmc.i
+++ b/test/tests/neutronics/dagmc/incompatible_geom/multiple_dagmc/openmc.i
@@ -1,0 +1,29 @@
+[Mesh]
+  [m]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 5
+    ny = 5
+    nz = 5
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  tally_type = none
+  skinner = moab
+[]
+
+[UserObjects]
+  [moab]
+    type = MoabSkinner
+    temperature = temp
+    n_temperature_bins = 2
+    temperature_min = 0.0
+    temperature_max = 1000.0
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/neutronics/dagmc/incompatible_geom/multiple_dagmc/settings.xml
+++ b/test/tests/neutronics/dagmc/incompatible_geom/multiple_dagmc/settings.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<settings>
+  <run_mode>eigenvalue</run_mode>
+  <particles>1000</particles>
+  <batches>100</batches>
+  <inactive>50</inactive>
+  <source strength="1.0">
+    <space type="box">
+      <parameters>-12.5 -12.5 -12.5 87.5 37.5 12.5</parameters>
+    </space>
+  </source>
+  <temperature_default>500.0</temperature_default>
+  <temperature_method>interpolation</temperature_method>
+  <temperature_range>294.0 3000.0</temperature_range>
+  <temperature_tolerance>1000.0</temperature_tolerance>
+</settings>

--- a/test/tests/neutronics/dagmc/incompatible_geom/multiple_dagmc/tests
+++ b/test/tests/neutronics/dagmc/incompatible_geom/multiple_dagmc/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [includes_csg]
+    type = RunException
+    input = openmc.i
+    expect_err = "The 'skinner' is currently limited to models with a single DAGMC universe! Your model has 2 universes."
+    requirement = "The system shall error if attempting to skin an OpenMC model with more than one DAGMC universe"
+    required_objects = 'MoabSkinner'
+  []
+[]


### PR DESCRIPTION
This allows CSG cells to be defined in a DAGMC model used for skinning, but it ignores them for skinning (so they will disappear from the model after the first skin operation). This is an attempt to workaround https://github.com/openmc-dev/openmc/issues/2402 to allow us to pre-load the necessary MGXS temperatures into a skinned DAGMC model.