### PR TITLE
Turn off search conflicts

### DIFF
--- a/test/tests/cht/pebble/nek_master.i
+++ b/test/tests/cht/pebble/nek_master.i
@@ -67,12 +67,14 @@
     source_variable = temp
     from_multi_app = nek
     variable = nek_temp
+    search_value_conflicts = false
   []
   [avg_flux]
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = avg_flux
     to_multi_app = nek
     variable = avg_flux
+    search_value_conflicts = false
   []
   [flux_integral_to_nek]
     type = MultiAppPostprocessorTransfer

--- a/test/tests/cht/pebble/shift/nek_master.i
+++ b/test/tests/cht/pebble/shift/nek_master.i
@@ -67,12 +67,14 @@
     source_variable = temp
     from_multi_app = nek
     variable = nek_temp
+    search_value_conflicts = false
   []
   [avg_flux]
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = avg_flux
     to_multi_app = nek
     variable = avg_flux
+    search_value_conflicts = false
   []
   [flux_integral_to_nek]
     type = MultiAppPostprocessorTransfer

--- a/test/tests/cht/pincell_p_v/nek_master.i
+++ b/test/tests/cht/pincell_p_v/nek_master.i
@@ -78,6 +78,7 @@
     source_variable = temp
     from_multi_app = nek
     variable = nek_temp
+    search_value_conflicts = false
   []
   [flux]
     type = MultiAppGeneralFieldNearestLocationTransfer
@@ -86,6 +87,7 @@
     variable = avg_flux
     from_boundaries = '1'
     to_boundaries = '1'
+    search_value_conflicts = false
   []
   [flux_integral]
     type = MultiAppPostprocessorTransfer

--- a/test/tests/cht/sfr_pincell/nek_main_vpp.i
+++ b/test/tests/cht/sfr_pincell/nek_main_vpp.i
@@ -73,6 +73,7 @@
     source_variable = temp
     from_multi_app = nek
     variable = nek_temp
+    search_value_conflicts = false
   []
   [flux]
     type = MultiAppGeneralFieldNearestLocationTransfer
@@ -80,6 +81,7 @@
     to_multi_app = nek
     variable = avg_flux
     from_boundaries = '1'
+    search_value_conflicts = false
   []
   [flux_integral]
     type = MultiAppReporterTransfer

--- a/test/tests/cht/sfr_pincell/nek_master.i
+++ b/test/tests/cht/sfr_pincell/nek_master.i
@@ -78,6 +78,7 @@
     source_variable = temp
     from_multi_app = nek
     variable = nek_temp
+    search_value_conflicts = false
   []
   [flux]
     type = MultiAppGeneralFieldNearestLocationTransfer
@@ -85,6 +86,7 @@
     to_multi_app = nek
     variable = avg_flux
     from_boundaries = '1'
+    search_value_conflicts = false
   []
   [flux_integral]
     type = MultiAppPostprocessorTransfer

--- a/test/tests/conduction/identical_interface/cube/nek_master.i
+++ b/test/tests/conduction/identical_interface/cube/nek_master.i
@@ -72,6 +72,7 @@
     source_variable = temp
     from_multi_app = nek
     variable = nek_temp
+    search_value_conflicts = false
   []
   [flux]
     type = MultiAppGeneralFieldNearestLocationTransfer
@@ -79,6 +80,7 @@
     to_multi_app = nek
     variable = avg_flux
     source_boundary = 'right'
+    search_value_conflicts = false
   []
   [flux_integral]
     type = MultiAppPostprocessorTransfer

--- a/test/tests/conduction/identical_interface/pyramid/nek_master.i
+++ b/test/tests/conduction/identical_interface/pyramid/nek_master.i
@@ -70,6 +70,7 @@ coupling_boundaries = '2'
     source_variable = temp
     from_multi_app = nek
     variable = nek_temp
+    search_value_conflicts = false
   []
   [flux]
     type = MultiAppGeneralFieldNearestLocationTransfer
@@ -77,6 +78,7 @@ coupling_boundaries = '2'
     to_multi_app = nek
     variable = avg_flux
     source_boundary = ${coupling_boundaries}
+    search_value_conflicts = false
   []
   [flux_integral]
     type = MultiAppPostprocessorTransfer

--- a/test/tests/conduction/nonidentical_volume/nondimensional/nek_master.i
+++ b/test/tests/conduction/nonidentical_volume/nondimensional/nek_master.i
@@ -110,12 +110,14 @@ o=0.15
     source_variable = temp
     from_multi_app = nek
     variable = nek_temp
+    search_value_conflicts = false
   []
   [source]
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = source
     to_multi_app = nek
     variable = heat_source
+    search_value_conflicts = false
   []
   [source_integral]
     type = MultiAppPostprocessorTransfer

--- a/test/tests/conduction/zero_flux/main_disjoint.i
+++ b/test/tests/conduction/zero_flux/main_disjoint.i
@@ -45,6 +45,7 @@
     source_variable = flux
     to_multi_app = nek
     variable = avg_flux
+    search_value_conflicts = false
   []
   [flux_integral]
     type = MultiAppReporterTransfer

--- a/test/tests/conduction/zero_flux/main_shared.i
+++ b/test/tests/conduction/zero_flux/main_shared.i
@@ -45,6 +45,7 @@
     source_variable = flux
     to_multi_app = nek
     variable = avg_flux
+    search_value_conflicts = false
   []
   [flux_integral]
     type = MultiAppReporterTransfer

--- a/test/tests/conduction/zero_flux/main_zero.i
+++ b/test/tests/conduction/zero_flux/main_zero.i
@@ -45,6 +45,7 @@
     source_variable = flux
     to_multi_app = nek
     variable = avg_flux
+    search_value_conflicts = false
   []
   [flux_integral]
     type = MultiAppReporterTransfer

--- a/test/tests/deformation/simple-cube/box-test.i
+++ b/test/tests/deformation/simple-cube/box-test.i
@@ -159,12 +159,14 @@
      source_variable = temp_ansol
      to_multi_app = nek
      variable = temp_ansol
+    search_value_conflicts = false
    []
    [source_to_nek]
      type = MultiAppGeneralFieldNearestLocationTransfer
      source_variable = source_auxvar
      to_multi_app = nek
      variable = heat_source
+    search_value_conflicts = false
    []
    [source_integral_to_nek]
      type = MultiAppPostprocessorTransfer
@@ -177,18 +179,21 @@
      source_variable = disp_x_o
      to_multi_app = nek
      variable = disp_x
+    search_value_conflicts = false
    []
    [disp_y_to_nek]
      type = MultiAppGeneralFieldNearestLocationTransfer
      source_variable = disp_y_o
      to_multi_app = nek
      variable = disp_y
+    search_value_conflicts = false
    []
    [disp_z_to_nek]
      type = MultiAppGeneralFieldNearestLocationTransfer
      source_variable = disp_z_o
      to_multi_app = nek
      variable = disp_z
+    search_value_conflicts = false
    []
    [synchronize]
     type = MultiAppPostprocessorTransfer

--- a/test/tests/deformation/vol-areas/box-test.i
+++ b/test/tests/deformation/vol-areas/box-test.i
@@ -165,6 +165,7 @@
      source_variable = source_auxvar
      to_multi_app = nek
      variable = heat_source
+    search_value_conflicts = false
    []
    [source_integral_to_nek]
      type = MultiAppPostprocessorTransfer
@@ -177,18 +178,21 @@
      source_variable = disp_x_o
      to_multi_app = nek
      variable = disp_x
+    search_value_conflicts = false
    []
    [disp_y_to_nek]
      type = MultiAppGeneralFieldNearestLocationTransfer
      source_variable = disp_y_o
      to_multi_app = nek
      variable = disp_y
+    search_value_conflicts = false
    []
    [disp_z_to_nek]
      type = MultiAppGeneralFieldNearestLocationTransfer
      source_variable = disp_z_o
      to_multi_app = nek
      variable = disp_z
+    search_value_conflicts = false
    []
 []
 

--- a/test/tests/multiple_nek_apps/two_channels/moose.i
+++ b/test/tests/multiple_nek_apps/two_channels/moose.i
@@ -108,6 +108,7 @@ c = 450
     from_multi_app = sub
     variable = sub_temp
     target_boundary = 'left_pin right_pin'
+    search_value_conflicts = false
   []
   [flux]
     type = MultiAppGeneralFieldNearestLocationTransfer
@@ -117,6 +118,7 @@ c = 450
     from_postprocessors_to_be_preserved = 'flux_pin_left flux_pin_right'
     to_postprocessors_to_be_preserved = flux_integral
     target_boundary = 'surface'
+    search_value_conflicts = false
   []
 []
 

--- a/test/tests/multiple_nek_apps/two_channels/moose_combined.i
+++ b/test/tests/multiple_nek_apps/two_channels/moose_combined.i
@@ -99,6 +99,7 @@ c = 450
     from_multi_app = sub
     variable = sub_temp
     target_boundary = 'left_pin right_pin'
+    search_value_conflicts = false
   []
   [flux]
     type = MultiAppGeneralFieldNearestLocationTransfer
@@ -108,6 +109,7 @@ c = 450
     from_postprocessors_to_be_preserved = flux_integral
     to_postprocessors_to_be_preserved = flux_integral
     target_boundary = 'surface'
+    search_value_conflicts = false
   []
 []
 

--- a/test/tests/nek_errors/invalid_transfer_pp/nek_master.i
+++ b/test/tests/nek_errors/invalid_transfer_pp/nek_master.i
@@ -72,6 +72,7 @@
     source_variable = temp
     from_multi_app = nek
     variable = nek_temp
+    search_value_conflicts = false
   []
   [flux]
     type = MultiAppGeneralFieldNearestLocationTransfer
@@ -79,6 +80,7 @@
     to_multi_app = nek
     variable = avg_flux
     from_boundaries = 'right'
+    search_value_conflicts = false
   []
   [flux_integral]
     type = MultiAppPostprocessorTransfer

--- a/test/tests/neutronics/feedback/different_units/openmc_master.i
+++ b/test/tests/neutronics/feedback/different_units/openmc_master.i
@@ -100,12 +100,14 @@
     to_multi_app = openmc
     variable = temp
     source_variable = temp
+    search_value_conflicts = false
   []
   [density_to_openmc]
     type = MultiAppGeneralFieldNearestLocationTransfer
     to_multi_app = openmc
     variable = density
     source_variable = density
+    search_value_conflicts = false
   []
 []
 

--- a/test/tests/neutronics/feedback/different_units/openmc_master_cm.i
+++ b/test/tests/neutronics/feedback/different_units/openmc_master_cm.i
@@ -95,12 +95,14 @@
     to_multi_app = openmc
     variable = temp
     source_variable = temp
+    search_value_conflicts = false
   []
   [density_to_openmc]
     type = MultiAppGeneralFieldNearestLocationTransfer
     to_multi_app = openmc
     variable = density
     source_variable = density
+    search_value_conflicts = false
   []
 []
 

--- a/test/tests/neutronics/solid/openmc_master_zero.i
+++ b/test/tests/neutronics/solid/openmc_master_zero.i
@@ -145,5 +145,6 @@ b=${fparse 300-500/(zmax-zmin)*zmin}
     to_multi_app = openmc
     source_variable = temp
     variable = temp
+    search_value_conflicts = false
   []
 []

--- a/test/tests/userobjects/hexagonal_gap_layered/nek.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/nek.i
@@ -91,6 +91,7 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
     to_multi_app = subchannel
     variable = temp
     source_variable = temp
+    search_value_conflicts = false
   []
 []
 

--- a/test/tests/userobjects/hexagonal_gap_layered/nek_axial.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/nek_axial.i
@@ -91,6 +91,7 @@ gap_thickness = ${fparse 0.1 * 7.646e-3}
     to_multi_app = subchannel
     variable = P
     source_variable = P
+    search_value_conflicts = false
   []
 []
 

--- a/test/tests/userobjects/hexagonal_gap_layered/normals/nek.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/normals/nek.i
@@ -93,18 +93,21 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
     to_multi_app = subchannel
     source_variable = uo_x
     variable = uo_x
+    search_value_conflicts = false
   []
   [uoy_to_sub]
     type = MultiAppGeneralFieldNearestLocationTransfer
     to_multi_app = subchannel
     source_variable = uo_y
     variable = uo_y
+    search_value_conflicts = false
   []
   [uoz_to_sub]
     type = MultiAppGeneralFieldNearestLocationTransfer
     to_multi_app = subchannel
     source_variable = uo_z
     variable = uo_z
+    search_value_conflicts = false
   []
 []
 

--- a/test/tests/userobjects/hexagonal_gap_layered/normals/nek_axial.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/normals/nek_axial.i
@@ -87,18 +87,21 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
     to_multi_app = subchannel
     source_variable = uo_x
     variable = uo_x
+    search_value_conflicts = false
   []
   [uoy_to_sub]
     type = MultiAppGeneralFieldNearestLocationTransfer
     to_multi_app = subchannel
     source_variable = uo_y
     variable = uo_y
+    search_value_conflicts = false
   []
   [uoz_to_sub]
     type = MultiAppGeneralFieldNearestLocationTransfer
     to_multi_app = subchannel
     source_variable = uo_z
     variable = uo_z
+    search_value_conflicts = false
   []
 []
 

--- a/test/tests/userobjects/hexagonal_gap_layered/user_component.i
+++ b/test/tests/userobjects/hexagonal_gap_layered/user_component.i
@@ -104,24 +104,28 @@ gap_thickness = ${fparse 0.05 * 7.646e-3}
     to_multi_app = subchannel
     source_variable = uo_x
     variable = uo_x
+    search_value_conflicts = false
   []
   [uoy_to_sub]
     type = MultiAppGeneralFieldNearestLocationTransfer
     to_multi_app = subchannel
     source_variable = uo_y
     variable = uo_y
+    search_value_conflicts = false
   []
   [uoz_to_sub]
     type = MultiAppGeneralFieldNearestLocationTransfer
     to_multi_app = subchannel
     source_variable = uo_z
     variable = uo_z
+    search_value_conflicts = false
   []
   [actual_velocity_component]
     type = MultiAppGeneralFieldNearestLocationTransfer
     to_multi_app = subchannel
     source_variable = velocity_component
     variable = velocity_component
+    search_value_conflicts = false
   []
 []
 

--- a/test/tests/userobjects/moab_skinner/expanding-cube/constant_expansion_coeff.i
+++ b/test/tests/userobjects/moab_skinner/expanding-cube/constant_expansion_coeff.i
@@ -120,12 +120,14 @@
     source_variable = disp_y
     variable = disp_y
     to_multi_app = sub
+    search_value_conflicts = false
   []
   [dispz]
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = disp_z
     variable = disp_z
     to_multi_app = sub
+    search_value_conflicts = false
   []
 []
 

--- a/test/tests/userobjects/subchannel_layered/user_component.i
+++ b/test/tests/userobjects/subchannel_layered/user_component.i
@@ -100,24 +100,28 @@
     source_variable = uo_x
     to_multi_app = subchannel
     variable = uo_x
+    search_value_conflicts = false
   []
   [uoy_to_sub]
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = uo_y
     to_multi_app = subchannel
     variable = uo_y
+    search_value_conflicts = false
   []
   [uoz_to_sub]
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = uo_z
     to_multi_app = subchannel
     variable = uo_z
+    search_value_conflicts = false
   []
   [analytic_to_sub]
     type = MultiAppGeneralFieldNearestLocationTransfer
     source_variable = velocity_component
     to_multi_app = subchannel
     variable = velocity_component
+    search_value_conflicts = false
   []
 []
 


### PR DESCRIPTION
MOOSE added error checking which severely slows down the nearest node transfer. Disable this error checking in our test suite, since we don't need it to match the test results.