### PR TITLE
Install xs into the container

### DIFF
--- a/apptainer/app_environment
+++ b/apptainer/app_environment
@@ -1,1 +1,2 @@
 export NEKRS_HOME=/opt/cardinal/contrib
+export OPENMC_CROSS_SECTIONS=/opt/cardinal/share/cardinal/endfb-vii.1-hdf5/cross_sections.xml

--- a/apptainer/app_post_post_install
+++ b/apptainer/app_post_post_install
@@ -1,3 +1,7 @@
-# Copy script for getting cross sections for the test section
-cp ${APPLICATION_DIR}/scripts/download-openmc-cross-sections.sh ${MOOSE_PREFIX}/share/${BINARY_NAME}
-chmod +x ${MOOSE_PREFIX}/share/${BINARY_NAME}/download-openmc-cross-sections.sh
+# Download cross sections
+umask 022
+FROM_XS_SCRIPT=${APPLICATION_DIR}/scripts/download-openmc-cross-sections.sh
+XS_SCRIPT=${MOOSE_PREFIX}/share/${BINARY_NAME}/download-openmc-cross-sections.sh
+cp ${FROM_XS_SCRIPT} ${XS_SCRIPT}
+chmod +x ${XS_SCRIPT}
+${XS_SCRIPT} ${MOOSE_PREFIX}/share/cardinal

--- a/apptainer/app_test_begin
+++ b/apptainer/app_test_begin
@@ -1,3 +1,0 @@
-# Get cross sections
-/opt/${BINARY_NAME}/share/${BINARY_NAME}/download-openmc-cross-sections.sh ${TEMP_LOC}
-export OPENMC_CROSS_SECTIONS=${TEMP_LOC}/endfb-vii.1-hdf5/cross_sections.xml


### PR DESCRIPTION
Installs the current cross sections into the cardinal container. Needed so that trainees don't need to when using a docker or apptainer container.