### PR TITLE
add list of sideset IDs to assembly flow mesher

### DIFF
--- a/doc/content/tutorials/assembly.md
+++ b/doc/content/tutorials/assembly.md
@@ -26,8 +26,8 @@ python mesh.py -g
 
 The mesh will be generated with the following sideset IDs:
 
- - 1 - fuel pins
- - 2 - inlet
- - 3 - outlet
- - 4 - hex can wall
+ - 1: fuel pins
+ - 2: inlet
+ - 3: outlet
+ - 4: hex can wall
 

--- a/doc/content/tutorials/assembly.md
+++ b/doc/content/tutorials/assembly.md
@@ -23,3 +23,11 @@ To create the mesh:
 cd utils/meshes/assembly/mesh.py
 python mesh.py -g
 ```
+
+The mesh will be generated with the following sideset IDs:
+
+ - 1 - fuel pins
+ - 2 - inlet
+ - 3 - outlet
+ - 4 - hex can wall
+


### PR DESCRIPTION
This adds a bulleted list of the sideset IDs for the assembly flow mesher documentation. 