### PR TITLE
Fix the generation of the cell to element map

### DIFF
--- a/include/base/OpenMCCellAverageProblem.h
+++ b/include/base/OpenMCCellAverageProblem.h
@@ -865,9 +865,6 @@ protected:
   /// A vector of external (output-based) auxvariable ids added by the [Tallies] block.
   std::vector<std::vector<std::vector<unsigned int>>> _tally_ext_var_ids;
 
-  /// Whether the problem contains a cell tally or not.
-  bool _contains_cell_tally = false;
-
   /// Blocks in MOOSE mesh that provide density feedback
   std::vector<SubdomainID> _density_blocks;
 

--- a/include/tallies/CellTally.h
+++ b/include/tallies/CellTally.h
@@ -52,6 +52,12 @@ public:
                             unsigned int global_score,
                             const std::string & output_type) override;
 
+  /**
+   * A function to get the blocks associated with this CellTally.
+   * @return a set of blocks associated with this tally.
+   */
+  const std::unordered_set<SubdomainID> & getBlocks() const { return _tally_blocks; }
+
 protected:
   /**
    * Loop over all the OpenMC cells and determine if a cell maps to more than one subdomain

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1667,7 +1667,8 @@ OpenMCCellAverageProblem::mapElemsToCells()
     {
       auto cell_tally = dynamic_cast<const CellTally *>(tally.get());
       if (cell_tally)
-        elem_mapped_to_cell_tally |= cell_tally->getBlocks().find(id) != cell_tally->getBlocks().end();
+        elem_mapped_to_cell_tally |=
+            cell_tally->getBlocks().find(id) != cell_tally->getBlocks().end();
     }
 
     bool requires_mapping = phase != coupling::none || elem_mapped_to_cell_tally;

--- a/test/tests/neutronics/tally_system/cell_with_unmapped.i
+++ b/test/tests/neutronics/tally_system/cell_with_unmapped.i
@@ -10,17 +10,6 @@
                  0 0 4
                  0 0 8'
   []
-  # Add another pebble which doesn't exist in the OpenMC model, so it will be unmapped.
-  [solid_2]
-    type = CombinerGenerator
-    inputs = sphere
-    positions = '0 0 12'
-  []
-  [solid_2_ids]
-    type = SubdomainIDGenerator
-    input = solid_2
-    subdomain_id = '300'
-  []
   [solid_ids]
     type = SubdomainIDGenerator
     input = solid
@@ -37,7 +26,7 @@
   []
   [combine]
     type = CombinerGenerator
-    inputs = 'solid_ids solid_2_ids fluid_ids'
+    inputs = 'solid_ids fluid_ids'
   []
 []
 
@@ -46,17 +35,19 @@
   verbose = true
   power = 1e4
   temperature_blocks = '100'
-  density_blocks = '200'
   cell_level = 0
   initial_properties = xml
 
   source_rate_normalization = 'kappa_fission'
 
+  # We are intentionally excluding some blocks, so we need to disable global normalization.
+  normalize_by_global_tally = false
+
   [Tallies]
     [Cell_1]
       type = CellTally
       score = kappa_fission
-      blocks = '100 200'
+      blocks = '100'
     []
   []
 []
@@ -77,9 +68,9 @@
     point = '0 0 8'
     variable = cell_id
   []
-  [Pebble_4_ID]
+  [Light_ID]
     type = PointValue
-    point = '0 0 12'
+    point = '0 0 10'
     variable = cell_id
   []
 

--- a/test/tests/neutronics/tally_system/cell_with_unmapped.i
+++ b/test/tests/neutronics/tally_system/cell_with_unmapped.i
@@ -1,0 +1,109 @@
+[Mesh]
+  [sphere]
+    type = FileMeshGenerator
+    file = ../meshes/sphere.e
+  []
+  [solid]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 0
+                 0 0 4
+                 0 0 8'
+  []
+  # Add another pebble which doesn't exist in the OpenMC model, so it will be unmapped.
+  [solid_2]
+    type = CombinerGenerator
+    inputs = sphere
+    positions = '0 0 12'
+  []
+  [solid_2_ids]
+    type = SubdomainIDGenerator
+    input = solid_2
+    subdomain_id = '300'
+  []
+  [solid_ids]
+    type = SubdomainIDGenerator
+    input = solid
+    subdomain_id = '100'
+  []
+  [fluid]
+    type = FileMeshGenerator
+    file = ../heat_source/stoplight.exo
+  []
+  [fluid_ids]
+    type = SubdomainIDGenerator
+    input = fluid
+    subdomain_id = '200'
+  []
+  [combine]
+    type = CombinerGenerator
+    inputs = 'solid_ids solid_2_ids fluid_ids'
+  []
+[]
+
+[Problem]
+  type = OpenMCCellAverageProblem
+  verbose = true
+  power = 1e4
+  temperature_blocks = '100'
+  density_blocks = '200'
+  cell_level = 0
+  initial_properties = xml
+
+  source_rate_normalization = 'kappa_fission'
+
+  [Tallies]
+    [Cell_1]
+      type = CellTally
+      score = kappa_fission
+      blocks = '100 200'
+    []
+  []
+[]
+
+[Postprocessors]
+  [Pebble_1_ID]
+    type = PointValue
+    point = '0 0 0'
+    variable = cell_id
+  []
+  [Pebble_2_ID]
+    type = PointValue
+    point = '0 0 4'
+    variable = cell_id
+  []
+  [Pebble_3_ID]
+    type = PointValue
+    point = '0 0 8'
+    variable = cell_id
+  []
+  [Pebble_4_ID]
+    type = PointValue
+    point = '0 0 12'
+    variable = cell_id
+  []
+
+  [Pebble_1_Heat]
+    type = PointValue
+    point = '0 0 0'
+    variable = kappa_fission
+  []
+  [Pebble_2_Heat]
+    type = PointValue
+    point = '0 0 4'
+    variable = kappa_fission
+  []
+  [Pebble_3_Heat]
+    type = PointValue
+    point = '0 0 8'
+    variable = kappa_fission
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/test/tests/neutronics/tally_system/gold/cell_with_unmapped_out.csv
+++ b/test/tests/neutronics/tally_system/gold/cell_with_unmapped_out.csv
@@ -1,3 +1,3 @@
-time,Pebble_1_Heat,Pebble_1_ID,Pebble_2_Heat,Pebble_2_ID,Pebble_3_Heat,Pebble_3_ID,Pebble_4_ID
+time,Light_ID,Pebble_1_Heat,Pebble_1_ID,Pebble_2_Heat,Pebble_2_ID,Pebble_3_Heat,Pebble_3_ID
 0,0,0,0,0,0,0,0
-1,91.245617807911,1,235.4335644497,2,398.08854558273,3,-1
+1,-1,95.222489857226,1,245.69476037805,2,415.43893728498,3

--- a/test/tests/neutronics/tally_system/gold/cell_with_unmapped_out.csv
+++ b/test/tests/neutronics/tally_system/gold/cell_with_unmapped_out.csv
@@ -1,0 +1,3 @@
+time,Pebble_1_Heat,Pebble_1_ID,Pebble_2_Heat,Pebble_2_ID,Pebble_3_Heat,Pebble_3_ID,Pebble_4_ID
+0,0,0,0,0,0,0,0
+1,91.245617807911,1,235.4335644497,2,398.08854558273,3,-1

--- a/test/tests/neutronics/tally_system/tests
+++ b/test/tests/neutronics/tally_system/tests
@@ -1,4 +1,12 @@
 [Tests]
+  [cell_tally_unmapped]
+    type = CSVDiff
+    input = cell_with_unmapped.i
+    csvdiff = cell_with_unmapped_out.csv
+    requirement = "The system shall correctly label elements in blocks which don't contain temperature feedback, density feedback, "
+                  "or a cell tally as unmapped."
+    required_objects = 'OpenMCCellAverageProblem'
+  []
   [multi_global_estimator]
     type = CSVDiff
     input = multi_estimator.i


### PR DESCRIPTION
This PR fixes an improper generation of the cell to element map for the case where a subset of elements in the MOOSE mesh do not map to any cells in the OpenMC geometry, but a `CellTally` and temperature/density feedback is requested by the user. This PR also adds a new test to cover this case.

@aprilnovak 