### PR TITLE
Hints for fast parallel builds

### DIFF
--- a/scripts/download-openmc-cross-sections.sh
+++ b/scripts/download-openmc-cross-sections.sh
@@ -27,7 +27,7 @@ set +ex
 
 if [[ -z "${OPENMC_CROSS_SECTIONS}" ]]; then
   echo ""
-  echo "You must now set:"
+  echo -e "\e[31mYou must now set:\e[0m"
   echo ""
   echo "export OPENMC_CROSS_SECTIONS=${XS_DIR}/cross_sections.xml"
   echo ""

--- a/scripts/get-dependencies.sh
+++ b/scripts/get-dependencies.sh
@@ -14,8 +14,7 @@ set +ex
 
 if [[ -z "${OPENMC_CROSS_SECTIONS}" ]]; then
   echo ""
-  echo "If you are using OpenMC, remember that you need to set OPENMC_CROSS_SECTIONS to point to a cross_sections.xml file!"
-  echo "To get the ENDF/b-7.1 dataset, please run:"
+  echo -e "\e[31mIf you are using OpenMC, remember that you need to set OPENMC_CROSS_SECTIONS to point to a cross_sections.xml file! To get the ENDF/b-7.1 dataset, please run:\e[0m"
   echo ""
   echo "$SCRIPT_DIR/scripts/download-openmc-cross-sections.sh"
   echo ""
@@ -23,9 +22,16 @@ fi
 
 if [[ -z "${NEKRS_HOME}" ]]; then
   echo ""
-  echo "If you are using NekRS, remember that you need to set NEKRS_HOME to point to your NekRS install!"
-  echo "If you are using the NekRS submodule, please set:"
+  echo -e "\e[31mIf you are using NekRS, remember that you need to set NEKRS_HOME to point to your NekRS install! If you are using the NekRS submodule, please set:\e[0m"
   echo ""
   echo "export NEKRS_HOME=$SCRIPT_DIR/install"
+  echo ""
+fi
+
+if [[ -z "${LIBMESH_JOBS}" ]]; then
+  echo ""
+  echo -e "\e[32mIf you are compiling Cardinal without conda, you can build libMesh in parallel with 8 cores (just an example) by setting:\e[0m"
+  echo ""
+  echo "export LIBMESH_JOBS=8"
   echo ""
 fi

--- a/scripts/get-dependencies.sh
+++ b/scripts/get-dependencies.sh
@@ -30,7 +30,7 @@ fi
 
 if [[ -z "${LIBMESH_JOBS}" ]]; then
   echo ""
-  echo -e "\e[32mIf you are compiling Cardinal without conda, you can build libMesh in parallel with 8 cores (just an example) by setting:\e[0m"
+  echo -e "\e[32mTo save time and build in parallel, you can build libMesh in parallel with 8 cores (just an example) by setting:\e[0m"
   echo ""
   echo "export LIBMESH_JOBS=8"
   echo ""


### PR DESCRIPTION
Many people miss these instructions on the compilation to build in parallel. We can print it out when they fetch the dependencies to help them not miss them.