### PR TITLE
Fix the debug output we dump in the console for tallies.

### DIFF
--- a/include/tallies/TallyBase.h
+++ b/include/tallies/TallyBase.h
@@ -170,6 +170,12 @@ public:
    */
   bool renamesTallyVars() const { return _renames_tally_vars; }
 
+  /**
+   * Get the total number of external filter bins applied to this tally.
+   * @return the total number of external filter bins.
+   */
+  unsigned int numExtFilterBins() const { return _num_ext_filter_bins; }
+
 protected:
   /**
    * A function which stores the results of this tally into the created

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -1026,17 +1026,18 @@ OpenMCCellAverageProblem::printAuxVariableIO()
     {
       const auto & scores = _local_tallies[i]->getScores();
       const auto & names = _local_tallies[i]->getAuxVarNames();
+      const auto bins = _local_tallies[i]->numExtFilterBins();
       for (unsigned int j = 0; j < scores.size(); ++j)
       {
         if (names.size() == 0)
           continue;
 
-        for (unsigned int k = 0; k < names.size(); ++k)
+        for (unsigned int k = bins * j; k < (j + 1) * bins; ++k)
         {
-          if (j == 0 && k == 0)
-            tallies.addRow(_local_tallies[i]->name(), scores[j], names[k]);
-          else
-            tallies.addRow("", "", names[k]);
+          const auto l = j == 0 && k == bins * j ? _local_tallies[i]->name() : "";
+          const auto c = k == bins * j ? scores[j] : "";
+          const auto r = names[k];
+          tallies.addRow(l, c, r);
         }
       }
     }


### PR DESCRIPTION
The addition of the filter system broke the tally debug output we dump to the console (example below after the filter system was merged):
```
--------------------------------------------------------
| Tally Name |  Tally Score  |     AuxVariable(s)      |
--------------------------------------------------------
| Heating    | kappa-fission | kappa_fission_g1_theta1 |
|            |               | kappa_fission_g1_theta2 |
|            |               | kappa_fission_g2_theta1 |
|            |               | kappa_fission_g2_theta2 |
|            |               | fission_g1_theta1       |
|            |               | fission_g1_theta2       |
|            |               | fission_g2_theta1       |
|            |               | fission_g2_theta2       |
|            |               | kappa_fission_g1_theta1 |
|            |               | kappa_fission_g1_theta2 |
|            |               | kappa_fission_g2_theta1 |
|            |               | kappa_fission_g2_theta2 |
|            |               | fission_g1_theta1       |
|            |               | fission_g1_theta2       |
|            |               | fission_g2_theta1       |
|            |               | fission_g2_theta2       |
| Flux       | flux          | flux_g1_theta1          |
|            |               | flux_g1_theta2          |
|            |               | flux_g2_theta1          |
|            |               | flux_g2_theta2          |
--------------------------------------------------------
``` 

This PR fixes that debug output to account for filter bins:
```
--------------------------------------------------------
| Tally Name |  Tally Score  |     AuxVariable(s)      |
--------------------------------------------------------
| Heating    | kappa-fission | kappa_fission_g1_theta1 |
|            |               | kappa_fission_g1_theta2 |
|            |               | kappa_fission_g2_theta1 |
|            |               | kappa_fission_g2_theta2 |
|            | fission       | fission_g1_theta1       |
|            |               | fission_g1_theta2       |
|            |               | fission_g2_theta1       |
|            |               | fission_g2_theta2       |
| Flux       | flux          | flux_g1_theta1          |
|            |               | flux_g1_theta2          |
|            |               | flux_g2_theta1          |
|            |               | flux_g2_theta2          |
--------------------------------------------------------
```