### PR TITLE
Only set `OPENMC_CROSS_SECTIONS` if it is unset in apptainer

### DIFF
--- a/apptainer/app_environment
+++ b/apptainer/app_environment
@@ -1,2 +1,4 @@
 export NEKRS_HOME=/opt/cardinal/contrib
-export OPENMC_CROSS_SECTIONS=/opt/cardinal/share/cardinal/endfb-vii.1-hdf5/cross_sections.xml
+if [ -z "$OPENMC_CROSS_SECTIONS" ]; then
+  export OPENMC_CROSS_SECTIONS=/opt/cardinal/share/cardinal/endfb-vii.1-hdf5/cross_sections.xml
+fi


### PR DESCRIPTION
This allows users to override `OPENMC_CROSS_SECTIONS` when running in a container.