### PR TITLE
Remove threaded user object inheritance

### DIFF
--- a/include/userobjects/NekUserObject.h
+++ b/include/userobjects/NekUserObject.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "ThreadedGeneralUserObject.h"
+#include "GeneralUserObject.h"
 #include "NekRSProblemBase.h"
 #include "CardinalEnums.h"
 #include "GeometryUtils.h"
@@ -27,7 +27,7 @@
  * Base class for providing common information to userobjects
  * operating directly on the NekRS solution and mesh.
  */
-class NekUserObject : public ThreadedGeneralUserObject
+class NekUserObject : public GeneralUserObject
 {
 public:
   static InputParameters validParams();

--- a/include/userobjects/SpatialBinUserObject.h
+++ b/include/userobjects/SpatialBinUserObject.h
@@ -18,12 +18,12 @@
 
 #pragma once
 
-#include "ThreadedGeneralUserObject.h"
+#include "GeneralUserObject.h"
 
 /**
  * Class that provides a bin index given a spatial coordinate
  */
-class SpatialBinUserObject : public ThreadedGeneralUserObject
+class SpatialBinUserObject : public GeneralUserObject
 {
 public:
   static InputParameters validParams();

--- a/src/userobjects/NekUserObject.C
+++ b/src/userobjects/NekUserObject.C
@@ -34,8 +34,7 @@ NekUserObject::validParams()
 }
 
 NekUserObject::NekUserObject(const InputParameters & parameters)
-  : ThreadedGeneralUserObject(parameters),
-    _interval(getParam<unsigned int>("interval"))
+  : GeneralUserObject(parameters), _interval(getParam<unsigned int>("interval"))
 {
   _nek_problem = dynamic_cast<const NekRSProblemBase *>(&_fe_problem);
   if (!_nek_problem)

--- a/src/userobjects/SpatialBinUserObject.C
+++ b/src/userobjects/SpatialBinUserObject.C
@@ -27,7 +27,7 @@ SpatialBinUserObject::validParams()
 }
 
 SpatialBinUserObject::SpatialBinUserObject(const InputParameters & parameters)
-  : ThreadedGeneralUserObject(parameters)
+  : GeneralUserObject(parameters)
 {
 }
 


### PR DESCRIPTION
Some of our user objects arbitrarily inherited from `ThreadedGeneralUserObject`, which requires overriding functions to join data across threads. We don't actually need to use this base class, and can instead inherit from `GeneralUserObject`, which would allow the NekRS user objects to be run with threading. 

@pshriwise noticed this when running a Nek case with threads -- previously, all our cases used pure MPI because that's what Nek uses, so we had not run into this before.