### PR TITLE
Swap mooseErrors to paramErrors

### DIFF
--- a/src/auxkernels/CellVolumeAux.C
+++ b/src/auxkernels/CellVolumeAux.C
@@ -49,8 +49,9 @@ Real
 CellVolumeAux::computeValue()
 {
   if (_volume_type == "actual" && !_openmc_problem->volumeCalculation())
-    paramError("volume_type", "To display the actual OpenMC cell volumes, the [Problem] block needs to set the\n"
-      "'volume_calculation' parameter.");
+    paramError("volume_type",
+               "To display the actual OpenMC cell volumes, the [Problem] block needs to set the\n"
+               "'volume_calculation' parameter.");
 
   // if the element doesn't map to an OpenMC cell, return a volume of -1; this is required
   // because otherwise OpenMC would throw an error for an invalid instance, index pair passed to the

--- a/src/auxkernels/CellVolumeAux.C
+++ b/src/auxkernels/CellVolumeAux.C
@@ -49,7 +49,7 @@ Real
 CellVolumeAux::computeValue()
 {
   if (_volume_type == "actual" && !_openmc_problem->volumeCalculation())
-    mooseError("To display the actual OpenMC cell volumes, the [Problem] block needs to set the\n"
+    paramError("volume_type", "To display the actual OpenMC cell volumes, the [Problem] block needs to set the\n"
       "'volume_calculation' parameter.");
 
   // if the element doesn't map to an OpenMC cell, return a volume of -1; this is required

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -255,7 +255,8 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
   // the same number of bins or to exactly the same regions of space, so we must
   // disable relaxation.
   if (_need_to_reinit_coupling && _relaxation != relaxation::none)
-    paramError("relaxation",
+    paramError(
+        "relaxation",
         "When adaptivity is requested or a displaced problem is used, the mapping from the "
         "OpenMC model to the [Mesh] may vary in time. This means that we have no guarantee that "
         "the "
@@ -267,7 +268,8 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     checkUnusedParam(params, "normalize_by_global_tally", "running OpenMC in fixed source mode");
 
   if (_run_mode != openmc::RunMode::EIGENVALUE && _k_trigger != trigger::none)
-    paramError("k_trigger", "Cannot specify a 'k_trigger' for OpenMC runs that are not eigenvalue mode!");
+    paramError("k_trigger",
+               "Cannot specify a 'k_trigger' for OpenMC runs that are not eigenvalue mode!");
 
   if (_assume_separate_tallies && _needs_global_tally)
     paramError("assume_separate_tallies",
@@ -390,7 +392,8 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
 
   for (const auto & i : _identical_cell_fill_blocks)
     if (std::find(_density_blocks.begin(), _density_blocks.end(), i) != _density_blocks.end())
-      paramError("identical_cell_fills",
+      paramError(
+          "identical_cell_fills",
           "Entries in 'identical_cell_fills' cannot be contained in 'density_blocks'; the\n"
           "identical fill universe optimization is not yet implemented for density feedback.");
 
@@ -513,7 +516,8 @@ OpenMCCellAverageProblem::initialSetup()
     _symmetry = dynamic_cast<SymmetryPointGenerator *>(base);
 
     if (!_symmetry)
-      paramError("symmetry_mapper", "The 'symmetry_mapper' user object has to be of type SymmetryPointGenerator!");
+      paramError("symmetry_mapper",
+                 "The 'symmetry_mapper' user object has to be of type SymmetryPointGenerator!");
   }
 
   // Get triggers.
@@ -528,11 +532,13 @@ OpenMCCellAverageProblem::initialSetup()
     std::set<SubdomainID> d(_density_blocks.begin(), _density_blocks.end());
 
     if (t != _mesh.meshSubdomains())
-      paramError("temperature_blocks", "The 'skinner' requires temperature feedback to be applied over the entire mesh. "
+      paramError("temperature_blocks",
+                 "The 'skinner' requires temperature feedback to be applied over the entire mesh. "
                  "Please update `temperature_blocks` to include all blocks.");
 
     if (d != _mesh.meshSubdomains() && _specified_density_feedback)
-      paramError("density_blocks", "The 'skinner' requires density feedback to be applied over the entire mesh. "
+      paramError("density_blocks",
+                 "The 'skinner' requires density feedback to be applied over the entire mesh. "
                  "Please update `density_blocks` to include all blocks.");
 
     if (t != d && _specified_density_feedback)

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -255,7 +255,7 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
   // the same number of bins or to exactly the same regions of space, so we must
   // disable relaxation.
   if (_need_to_reinit_coupling && _relaxation != relaxation::none)
-    mooseError(
+    paramError("relaxation",
         "When adaptivity is requested or a displaced problem is used, the mapping from the "
         "OpenMC model to the [Mesh] may vary in time. This means that we have no guarantee that "
         "the "
@@ -267,7 +267,7 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     checkUnusedParam(params, "normalize_by_global_tally", "running OpenMC in fixed source mode");
 
   if (_run_mode != openmc::RunMode::EIGENVALUE && _k_trigger != trigger::none)
-    mooseError("Cannot specify a 'k_trigger' for OpenMC runs that are not eigenvalue mode!");
+    paramError("k_trigger", "Cannot specify a 'k_trigger' for OpenMC runs that are not eigenvalue mode!");
 
   if (_assume_separate_tallies && _needs_global_tally)
     paramError("assume_separate_tallies",
@@ -390,7 +390,7 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
 
   for (const auto & i : _identical_cell_fill_blocks)
     if (std::find(_density_blocks.begin(), _density_blocks.end(), i) != _density_blocks.end())
-      mooseError(
+      paramError("identical_cell_fills",
           "Entries in 'identical_cell_fills' cannot be contained in 'density_blocks'; the\n"
           "identical fill universe optimization is not yet implemented for density feedback.");
 
@@ -513,7 +513,7 @@ OpenMCCellAverageProblem::initialSetup()
     _symmetry = dynamic_cast<SymmetryPointGenerator *>(base);
 
     if (!_symmetry)
-      mooseError("The 'symmetry_mapper' user object has to be of type SymmetryPointGenerator!");
+      paramError("symmetry_mapper", "The 'symmetry_mapper' user object has to be of type SymmetryPointGenerator!");
   }
 
   // Get triggers.
@@ -528,11 +528,11 @@ OpenMCCellAverageProblem::initialSetup()
     std::set<SubdomainID> d(_density_blocks.begin(), _density_blocks.end());
 
     if (t != _mesh.meshSubdomains())
-      mooseError("The 'skinner' requires temperature feedback to be applied over the entire mesh. "
+      paramError("temperature_blocks", "The 'skinner' requires temperature feedback to be applied over the entire mesh. "
                  "Please update `temperature_blocks` to include all blocks.");
 
     if (d != _mesh.meshSubdomains() && _specified_density_feedback)
-      mooseError("The 'skinner' requires density feedback to be applied over the entire mesh. "
+      paramError("density_blocks", "The 'skinner' requires density feedback to be applied over the entire mesh. "
                  "Please update `density_blocks` to include all blocks.");
 
     if (t != d && _specified_density_feedback)

--- a/src/filters/FromXMLFilter.C
+++ b/src/filters/FromXMLFilter.C
@@ -51,9 +51,10 @@ FromXMLFilter::FromXMLFilter(const InputParameters & parameters)
 {
   // Check to make sure the filter exists.
   if (openmc::model::filter_map.count(_filter_id) == 0)
-    paramError("filter_id", "A filter with the id " + Moose::stringify(_filter_id) +
-               " does not exist in the OpenMC model! Please make sure the filter has been "
-               "added in the OpenMC model and you've supplied the correct filter id.");
+    paramError("filter_id",
+               "A filter with the id " + Moose::stringify(_filter_id) +
+                   " does not exist in the OpenMC model! Please make sure the filter has been "
+                   "added in the OpenMC model and you've supplied the correct filter id.");
 
   _filter_index = openmc::model::filter_map.at(_filter_id);
   _filter = openmc::model::tally_filters[_filter_index].get();
@@ -76,12 +77,13 @@ FromXMLFilter::FromXMLFilter(const InputParameters & parameters)
     case openmc::FilterType::UNIVERSE:
     case openmc::FilterType::ZERNIKE:
     case openmc::FilterType::ZERNIKE_RADIAL:
-      paramError("filter_id",
+      paramError(
+          "filter_id",
           "The filter with the id " + Moose::stringify(_filter_id) +
-          " is a spatial filter. "
-          "FromXMLFilter currently does not support the addition of spatial filters from the "
-          "OpenMC XML files because they would clash with the OpenMC -> MOOSE mapping "
-          "performed by Cardinal's tally objects.");
+              " is a spatial filter. "
+              "FromXMLFilter currently does not support the addition of spatial filters from the "
+              "OpenMC XML files because they would clash with the OpenMC -> MOOSE mapping "
+              "performed by Cardinal's tally objects.");
       break;
     default:
       break;
@@ -106,7 +108,8 @@ FromXMLFilter::FromXMLFilter(const InputParameters & parameters)
                  "may fail normalization as the sum over all tally bins may not be well posed "
                  "if any bins contain functional expansion coefficients.");
   else if (is_exp && !getParam<bool>("allow_expansion_filters"))
-    paramError("filter_id", "You have selected a functional expansion filter. Tallies which use this filter "
+    paramError("filter_id",
+               "You have selected a functional expansion filter. Tallies which use this filter "
                "may fail normalization as the sum over all tally bins may not be well posed "
                "if any bins contain functional expansion coefficients. If you still wish to "
                "use this filter, set 'allow_expansion_filters' to true.");

--- a/src/filters/FromXMLFilter.C
+++ b/src/filters/FromXMLFilter.C
@@ -51,7 +51,7 @@ FromXMLFilter::FromXMLFilter(const InputParameters & parameters)
 {
   // Check to make sure the filter exists.
   if (openmc::model::filter_map.count(_filter_id) == 0)
-    mooseError("A filter with the id " + Moose::stringify(_filter_id) +
+    paramError("filter_id", "A filter with the id " + Moose::stringify(_filter_id) +
                " does not exist in the OpenMC model! Please make sure the filter has been "
                "added in the OpenMC model and you've supplied the correct filter id.");
 
@@ -76,7 +76,7 @@ FromXMLFilter::FromXMLFilter(const InputParameters & parameters)
     case openmc::FilterType::UNIVERSE:
     case openmc::FilterType::ZERNIKE:
     case openmc::FilterType::ZERNIKE_RADIAL:
-      mooseError(
+      paramError("filter_id",
           "The filter with the id " + Moose::stringify(_filter_id) +
           " is a spatial filter. "
           "FromXMLFilter currently does not support the addition of spatial filters from the "
@@ -106,7 +106,7 @@ FromXMLFilter::FromXMLFilter(const InputParameters & parameters)
                  "may fail normalization as the sum over all tally bins may not be well posed "
                  "if any bins contain functional expansion coefficients.");
   else if (is_exp && !getParam<bool>("allow_expansion_filters"))
-    mooseError("You have selected a functional expansion filter. Tallies which use this filter "
+    paramError("filter_id", "You have selected a functional expansion filter. Tallies which use this filter "
                "may fail normalization as the sum over all tally bins may not be well posed "
                "if any bins contain functional expansion coefficients. If you still wish to "
                "use this filter, set 'allow_expansion_filters' to true.");

--- a/src/ics/BulkEnergyConservationIC.C
+++ b/src/ics/BulkEnergyConservationIC.C
@@ -57,7 +57,7 @@ BulkEnergyConservationIC::initialSetup()
 {
   const UserObject & pp = _fe_problem.getUserObject<UserObject>(_pp_name);
   if (!pp.getExecuteOnEnum().contains(EXEC_INITIAL))
-    mooseError("The 'execute_on' parameter for the '" + _pp_name +
+    paramError("execute_on", "The 'execute_on' parameter for the '" + _pp_name +
                "' postprocessor must include 'initial'!");
 }
 

--- a/src/ics/BulkEnergyConservationIC.C
+++ b/src/ics/BulkEnergyConservationIC.C
@@ -57,8 +57,9 @@ BulkEnergyConservationIC::initialSetup()
 {
   const UserObject & pp = _fe_problem.getUserObject<UserObject>(_pp_name);
   if (!pp.getExecuteOnEnum().contains(EXEC_INITIAL))
-    paramError("execute_on", "The 'execute_on' parameter for the '" + _pp_name +
-               "' postprocessor must include 'initial'!");
+    paramError("execute_on",
+               "The 'execute_on' parameter for the '" + _pp_name +
+                   "' postprocessor must include 'initial'!");
 }
 
 Real

--- a/src/tallies/CellTally.C
+++ b/src/tallies/CellTally.C
@@ -64,7 +64,8 @@ CellTally::CellTally(const InputParameters & parameters)
     const auto & subdomains = _mesh.meshSubdomains();
     for (std::size_t b = 0; b < block_names.size(); ++b)
       if (subdomains.find(block_ids[b]) == subdomains.end())
-        paramError("blocks", "Block '" + block_names[b] + "' specified in 'blocks' not found in mesh!");
+        paramError("blocks",
+                   "Block '" + block_names[b] + "' specified in 'blocks' not found in mesh!");
   }
   else
   {

--- a/src/tallies/CellTally.C
+++ b/src/tallies/CellTally.C
@@ -54,7 +54,7 @@ CellTally::CellTally(const InputParameters & parameters)
   {
     auto block_names = getParam<std::vector<SubdomainName>>("blocks");
     if (block_names.empty())
-      mooseError("Subdomain names must be provided if using 'blocks'!");
+      paramError("blocks", "Subdomain names must be provided if using 'blocks'!");
 
     auto block_ids = _mesh.getSubdomainIDs(block_names);
     std::copy(
@@ -64,7 +64,7 @@ CellTally::CellTally(const InputParameters & parameters)
     const auto & subdomains = _mesh.meshSubdomains();
     for (std::size_t b = 0; b < block_names.size(); ++b)
       if (subdomains.find(block_ids[b]) == subdomains.end())
-        mooseError("Block '" + block_names[b] + "' specified in 'blocks' not found in mesh!");
+        paramError("blocks", "Block '" + block_names[b] + "' specified in 'blocks' not found in mesh!");
   }
   else
   {

--- a/src/tallies/MeshTally.C
+++ b/src/tallies/MeshTally.C
@@ -58,7 +58,8 @@ MeshTally::MeshTally(const InputParameters & parameters)
   if (isParamValid("estimator"))
   {
     if (_estimator == openmc::TallyEstimator::TRACKLENGTH)
-      paramError("estimator", "Tracklength estimators are currently incompatible with mesh tallies!");
+      paramError("estimator",
+                 "Tracklength estimators are currently incompatible with mesh tallies!");
   }
   else
     _estimator = openmc::TallyEstimator::COLLISION;
@@ -71,10 +72,12 @@ MeshTally::MeshTally(const InputParameters & parameters)
   if (isParamValid("mesh_template"))
   {
     if (_is_adaptive)
-      paramError("mesh_template", "Adaptivity is not supported when loading a mesh from 'mesh_template'!");
+      paramError("mesh_template",
+                 "Adaptivity is not supported when loading a mesh from 'mesh_template'!");
 
     if (isParamValid("blocks"))
-      paramError("blocks", "Block restriction is currently not supported for mesh tallies which load a "
+      paramError("blocks",
+                 "Block restriction is currently not supported for mesh tallies which load a "
                  "mesh from a file!");
 
     _mesh_template_filename = &getParam<std::string>("mesh_template");
@@ -96,7 +99,8 @@ MeshTally::MeshTally(const InputParameters & parameters)
                  "for distributed meshes!");
 
     if (isParamValid("mesh_translation"))
-      paramError("mesh_translation", "The mesh filter cannot be translated if directly tallying on the mesh "
+      paramError("mesh_translation",
+                 "The mesh filter cannot be translated if directly tallying on the mesh "
                  "provided in the [Mesh] block!");
 
     // Fetch subdomain IDs for block restrictions.
@@ -114,7 +118,8 @@ MeshTally::MeshTally(const InputParameters & parameters)
       const auto & subdomains = _mesh.meshSubdomains();
       for (std::size_t b = 0; b < block_names.size(); ++b)
         if (subdomains.find(block_ids[b]) == subdomains.end())
-          paramError("blocks", "Block '" + block_names[b] + "' specified in 'blocks' not found in mesh!");
+          paramError("blocks",
+                     "Block '" + block_names[b] + "' specified in 'blocks' not found in mesh!");
     }
     else
     {
@@ -285,11 +290,12 @@ MeshTally::checkMeshTemplateAndTranslations() const
       }
 
       if (incorrect_scaling)
-        paramError("mesh_template", "The centroids of the 'mesh_template' differ from the "
+        paramError("mesh_template",
+                   "The centroids of the 'mesh_template' differ from the "
                    "centroids of the [Mesh] by a factor of " +
-                   Moose::stringify(centroid_mesh(0) / centroid_template(0)) +
-                   ".\nDid you forget that the 'mesh_template' must be in "
-                   "the same units as the [Mesh]?");
+                       Moose::stringify(centroid_mesh(0) / centroid_template(0)) +
+                       ".\nDid you forget that the 'mesh_template' must be in "
+                       "the same units as the [Mesh]?");
     }
 
     // check if centroids are the same
@@ -299,12 +305,14 @@ MeshTally::checkMeshTemplateAndTranslations() const
                             !MooseUtils::absoluteFuzzyEqual(centroid_mesh(j), centroid_template(j));
 
     if (different_centroids)
-      paramError("mesh_template",
-          "Centroid for element " + Moose::stringify(elem_id) + " in the [Mesh] (cm): " +
-          _openmc_problem.printPoint(centroid_mesh) + "\ndoes not match centroid for element " +
-          Moose::stringify(e) + " in the 'mesh_template' with instance " +
-          Moose::stringify(_instance) + " (cm): " + _openmc_problem.printPoint(centroid_template) +
-          "!\n\nThe copy transfer requires that the [Mesh] and 'mesh_template' be identical.");
+      paramError(
+          "mesh_template",
+          "Centroid for element " + Moose::stringify(elem_id) +
+              " in the [Mesh] (cm): " + _openmc_problem.printPoint(centroid_mesh) +
+              "\ndoes not match centroid for element " + Moose::stringify(e) +
+              " in the 'mesh_template' with instance " + Moose::stringify(_instance) +
+              " (cm): " + _openmc_problem.printPoint(centroid_template) +
+              "!\n\nThe copy transfer requires that the [Mesh] and 'mesh_template' be identical.");
   }
 }
 #endif

--- a/src/tallies/MeshTally.C
+++ b/src/tallies/MeshTally.C
@@ -58,7 +58,7 @@ MeshTally::MeshTally(const InputParameters & parameters)
   if (isParamValid("estimator"))
   {
     if (_estimator == openmc::TallyEstimator::TRACKLENGTH)
-      mooseError("Tracklength estimators are currently incompatible with mesh tallies!");
+      paramError("estimator", "Tracklength estimators are currently incompatible with mesh tallies!");
   }
   else
     _estimator = openmc::TallyEstimator::COLLISION;
@@ -71,10 +71,10 @@ MeshTally::MeshTally(const InputParameters & parameters)
   if (isParamValid("mesh_template"))
   {
     if (_is_adaptive)
-      mooseError("Adaptivity is only supported when tallying on the mesh in the [Mesh] block!");
+      paramError("mesh_template", "Adaptivity is not supported when loading a mesh from 'mesh_template'!");
 
     if (isParamValid("blocks"))
-      mooseError("Block restriction is currently not supported for mesh tallies which load a "
+      paramError("blocks", "Block restriction is currently not supported for mesh tallies which load a "
                  "mesh from a file!");
 
     _mesh_template_filename = &getParam<std::string>("mesh_template");
@@ -96,7 +96,7 @@ MeshTally::MeshTally(const InputParameters & parameters)
                  "for distributed meshes!");
 
     if (isParamValid("mesh_translation"))
-      mooseError("The mesh filter cannot be translated if directly tallying on the mesh "
+      paramError("mesh_translation", "The mesh filter cannot be translated if directly tallying on the mesh "
                  "provided in the [Mesh] block!");
 
     // Fetch subdomain IDs for block restrictions.
@@ -104,7 +104,7 @@ MeshTally::MeshTally(const InputParameters & parameters)
     {
       auto block_names = getParam<std::vector<SubdomainName>>("blocks");
       if (block_names.empty())
-        mooseError("Subdomain names must be provided if using 'blocks'!");
+        paramError("blocks", "Subdomain names must be provided if using 'blocks'!");
 
       auto block_ids = _mesh.getSubdomainIDs(block_names);
       std::copy(
@@ -114,7 +114,7 @@ MeshTally::MeshTally(const InputParameters & parameters)
       const auto & subdomains = _mesh.meshSubdomains();
       for (std::size_t b = 0; b < block_names.size(); ++b)
         if (subdomains.find(block_ids[b]) == subdomains.end())
-          mooseError("Block '" + block_names[b] + "' specified in 'blocks' not found in mesh!");
+          paramError("blocks", "Block '" + block_names[b] + "' specified in 'blocks' not found in mesh!");
     }
     else
     {
@@ -285,7 +285,7 @@ MeshTally::checkMeshTemplateAndTranslations() const
       }
 
       if (incorrect_scaling)
-        mooseError("The centroids of the 'mesh_template' differ from the "
+        paramError("mesh_template", "The centroids of the 'mesh_template' differ from the "
                    "centroids of the [Mesh] by a factor of " +
                    Moose::stringify(centroid_mesh(0) / centroid_template(0)) +
                    ".\nDid you forget that the 'mesh_template' must be in "
@@ -299,7 +299,7 @@ MeshTally::checkMeshTemplateAndTranslations() const
                             !MooseUtils::absoluteFuzzyEqual(centroid_mesh(j), centroid_template(j));
 
     if (different_centroids)
-      mooseError(
+      paramError("mesh_template",
           "Centroid for element " + Moose::stringify(elem_id) + " in the [Mesh] (cm): " +
           _openmc_problem.printPoint(centroid_mesh) + "\ndoes not match centroid for element " +
           Moose::stringify(e) + " in the 'mesh_template' with instance " +

--- a/src/tallies/TallyBase.C
+++ b/src/tallies/TallyBase.C
@@ -110,7 +110,8 @@ TallyBase::TallyBase(const InputParameters & parameters)
 
     // Photon heating tallies cannot use tracklength estimators.
     if (estimator == tally::tracklength && openmc::settings::photon_transport && heating)
-      paramError("estimator", "Tracklength estimators are currently incompatible with photon transport and "
+      paramError("estimator",
+                 "Tracklength estimators are currently incompatible with photon transport and "
                  "heating scores! For more information: https://tinyurl.com/3wre3kwt");
 
     _estimator = _openmc_problem.tallyEstimator(estimator);
@@ -137,7 +138,8 @@ TallyBase::TallyBase(const InputParameters & parameters)
         "Otherwise, you will underpredict the true energy deposition.");
 
   if (isParamValid("trigger") != isParamValid("trigger_threshold"))
-    paramError("trigger", "You must either specify none or both of 'trigger' and "
+    paramError("trigger",
+               "You must either specify none or both of 'trigger' and "
                "'trigger_threshold'. You have specified only one.");
 
   if (_tally_trigger)
@@ -146,21 +148,24 @@ TallyBase::TallyBase(const InputParameters & parameters)
     _tally_trigger_threshold = getParam<std::vector<Real>>("trigger_threshold");
 
     if (_tally_trigger->size() != _tally_score.size())
-      paramError("trigger", "'trigger' (size " + std::to_string(_tally_trigger->size()) +
-                 ") must have the same length as 'score' (size " +
-                 std::to_string(_tally_score.size()) + ")");
+      paramError("trigger",
+                 "'trigger' (size " + std::to_string(_tally_trigger->size()) +
+                     ") must have the same length as 'score' (size " +
+                     std::to_string(_tally_score.size()) + ")");
 
     if (_tally_trigger_threshold.size() != _tally_score.size())
-      paramError("trigger_threshold", "'trigger_threshold' (size " + std::to_string(_tally_trigger_threshold.size()) +
-                 ") must have the same length as 'score' (size " +
-                 std::to_string(_tally_score.size()) + ")");
+      paramError("trigger_threshold",
+                 "'trigger_threshold' (size " + std::to_string(_tally_trigger_threshold.size()) +
+                     ") must have the same length as 'score' (size " +
+                     std::to_string(_tally_score.size()) + ")");
 
     if (_trigger_ignore_zeros.size() > 1)
     {
       if (_tally_score.size() != _trigger_ignore_zeros.size())
-        paramError("trigger_ignore_zeros", "'trigger_ignore_zeros' (size " + std::to_string(_trigger_ignore_zeros.size()) +
-                   ") must have the same length as 'score' (size " +
-                   std::to_string(_tally_score.size()) + ")");
+        paramError("trigger_ignore_zeros",
+                   "'trigger_ignore_zeros' (size " + std::to_string(_trigger_ignore_zeros.size()) +
+                       ") must have the same length as 'score' (size " +
+                       std::to_string(_tally_score.size()) + ")");
     }
     else if (_trigger_ignore_zeros.size() == 1)
       _trigger_ignore_zeros.resize(_tally_score.size(), _trigger_ignore_zeros[0]);

--- a/src/tallies/TallyBase.C
+++ b/src/tallies/TallyBase.C
@@ -110,7 +110,7 @@ TallyBase::TallyBase(const InputParameters & parameters)
 
     // Photon heating tallies cannot use tracklength estimators.
     if (estimator == tally::tracklength && openmc::settings::photon_transport && heating)
-      mooseError("Tracklength estimators are currently incompatible with photon transport and "
+      paramError("estimator", "Tracklength estimators are currently incompatible with photon transport and "
                  "heating scores! For more information: https://tinyurl.com/3wre3kwt");
 
     _estimator = _openmc_problem.tallyEstimator(estimator);
@@ -137,7 +137,7 @@ TallyBase::TallyBase(const InputParameters & parameters)
         "Otherwise, you will underpredict the true energy deposition.");
 
   if (isParamValid("trigger") != isParamValid("trigger_threshold"))
-    mooseError("You must either specify none or both of 'trigger' and "
+    paramError("trigger", "You must either specify none or both of 'trigger' and "
                "'trigger_threshold'. You have specified only one.");
 
   if (_tally_trigger)
@@ -146,19 +146,19 @@ TallyBase::TallyBase(const InputParameters & parameters)
     _tally_trigger_threshold = getParam<std::vector<Real>>("trigger_threshold");
 
     if (_tally_trigger->size() != _tally_score.size())
-      mooseError("'trigger' (size " + std::to_string(_tally_trigger->size()) +
+      paramError("trigger", "'trigger' (size " + std::to_string(_tally_trigger->size()) +
                  ") must have the same length as 'score' (size " +
                  std::to_string(_tally_score.size()) + ")");
 
     if (_tally_trigger_threshold.size() != _tally_score.size())
-      mooseError("'trigger_threshold' (size " + std::to_string(_tally_trigger_threshold.size()) +
+      paramError("trigger_threshold", "'trigger_threshold' (size " + std::to_string(_tally_trigger_threshold.size()) +
                  ") must have the same length as 'score' (size " +
                  std::to_string(_tally_score.size()) + ")");
 
     if (_trigger_ignore_zeros.size() > 1)
     {
       if (_tally_score.size() != _trigger_ignore_zeros.size())
-        mooseError("'trigger_ignore_zeros' (size " + std::to_string(_trigger_ignore_zeros.size()) +
+        paramError("trigger_ignore_zeros", "'trigger_ignore_zeros' (size " + std::to_string(_trigger_ignore_zeros.size()) +
                    ") must have the same length as 'score' (size " +
                    std::to_string(_tally_score.size()) + ")");
     }
@@ -174,7 +174,7 @@ TallyBase::TallyBase(const InputParameters & parameters)
     for (const auto & filter_name : getParam<std::vector<std::string>>("filters"))
     {
       if (!_openmc_problem.hasFilter(filter_name))
-        mooseError("Filter with the name " + filter_name + " does not exist!");
+        paramError("filters", "Filter with the name " + filter_name + " does not exist!");
 
       _ext_filters.push_back(_openmc_problem.getFilter(filter_name));
     }
@@ -210,7 +210,7 @@ TallyBase::TallyBase(const InputParameters & parameters)
   }
 
   if (_tally_name.size() != _tally_score.size())
-    mooseError("'name' must be the same length as 'score'!");
+    paramError("name", "'name' must be the same length as 'score'!");
 
   // Modify the variable names so they take into account the bins in the external filters.
   auto all_var_names = _tally_name;

--- a/src/userobjects/OpenMCNuclideDensities.C
+++ b/src/userobjects/OpenMCNuclideDensities.C
@@ -62,7 +62,7 @@ void
 OpenMCNuclideDensities::setValue()
 {
   if (_names.size() == 0)
-    mooseError("'names' cannot be of length zero!");
+    paramError("names", "'names' cannot be of length zero!");
 
   if (_names.size() != _densities.size())
     mooseError("'names' and 'densities' must be the same length!");

--- a/src/userobjects/OpenMCVolumeCalculation.C
+++ b/src/userobjects/OpenMCVolumeCalculation.C
@@ -78,8 +78,21 @@ OpenMCVolumeCalculation::OpenMCVolumeCalculation(const InputParameters & paramet
   _upper_right = isParamValid("upper_right") ? getParam<Point>("upper_right") : box.max();
 
   if (_lower_left >= _upper_right)
-    paramError("upper_right", "The 'upper_right' (", _upper_right(0), ", ", _upper_right(1), ", ", _upper_right(2), ") "
-      "must be greater than the 'lower_left' (", _lower_left(0), ", ", _lower_left(1), ", ", _lower_left(2), ")!");
+    paramError("upper_right",
+               "The 'upper_right' (",
+               _upper_right(0),
+               ", ",
+               _upper_right(1),
+               ", ",
+               _upper_right(2),
+               ") "
+               "must be greater than the 'lower_left' (",
+               _lower_left(0),
+               ", ",
+               _lower_left(1),
+               ", ",
+               _lower_left(2),
+               ")!");
 }
 
 openmc::Position

--- a/src/userobjects/OpenMCVolumeCalculation.C
+++ b/src/userobjects/OpenMCVolumeCalculation.C
@@ -78,7 +78,7 @@ OpenMCVolumeCalculation::OpenMCVolumeCalculation(const InputParameters & paramet
   _upper_right = isParamValid("upper_right") ? getParam<Point>("upper_right") : box.max();
 
   if (_lower_left >= _upper_right)
-    mooseError("The 'upper_right' (", _upper_right(0), ", ", _upper_right(1), ", ", _upper_right(2), ") "
+    paramError("upper_right", "The 'upper_right' (", _upper_right(0), ", ", _upper_right(1), ", ", _upper_right(2), ") "
       "must be greater than the 'lower_left' (", _lower_left(0), ", ", _lower_left(1), ", ", _lower_left(2), ")!");
 }
 

--- a/src/userobjects/RadialBin.C
+++ b/src/userobjects/RadialBin.C
@@ -57,7 +57,8 @@ RadialBin::RadialBin(const InputParameters & parameters)
     _growth_r(getParam<Real>("growth_r"))
 {
   if (_rmax <= _rmin)
-    paramError("rmax", "Maximum radial coordinate 'rmax' must be greater than the minimum radial "
+    paramError("rmax",
+               "Maximum radial coordinate 'rmax' must be greater than the minimum radial "
                "coordinate 'rmin'!");
 
   Real first_width = _growth_r == 1.0 ? (_rmax - _rmin) / _nr

--- a/src/userobjects/RadialBin.C
+++ b/src/userobjects/RadialBin.C
@@ -57,7 +57,7 @@ RadialBin::RadialBin(const InputParameters & parameters)
     _growth_r(getParam<Real>("growth_r"))
 {
   if (_rmax <= _rmin)
-    mooseError("Maximum radial coordinate 'rmax' must be greater than the minimum radial "
+    paramError("rmax", "Maximum radial coordinate 'rmax' must be greater than the minimum radial "
                "coordinate 'rmin'!");
 
   Real first_width = _growth_r == 1.0 ? (_rmax - _rmin) / _nr

--- a/src/userobjects/SymmetryPointGenerator.C
+++ b/src/userobjects/SymmetryPointGenerator.C
@@ -56,11 +56,11 @@ SymmetryPointGenerator::SymmetryPointGenerator(const InputParameters & params)
 
     // the symmetry axis needs to be perpendicular to the plane normal
     if (!MooseUtils::absoluteFuzzyEqual(_rotational_axis * _normal, 0.0))
-      mooseError("The 'rotation_axis' must be perpendicular to the 'normal'!");
+      paramError("rotation_axis", "The 'rotation_axis' must be perpendicular to the 'normal'!");
 
     // unit circle must be divisible by angle
     if (!MooseUtils::absoluteFuzzyEqual(fmod(360.0, angle), 0))
-      mooseError("The unit circle must be evenly divisible by the 'rotation_angle'!");
+      paramError("rotation_angle", "The unit circle must be evenly divisible by the 'rotation_angle'!");
 
     _angle = angle * M_PI / 180.0;
 

--- a/src/userobjects/SymmetryPointGenerator.C
+++ b/src/userobjects/SymmetryPointGenerator.C
@@ -60,7 +60,8 @@ SymmetryPointGenerator::SymmetryPointGenerator(const InputParameters & params)
 
     // unit circle must be divisible by angle
     if (!MooseUtils::absoluteFuzzyEqual(fmod(360.0, angle), 0))
-      paramError("rotation_angle", "The unit circle must be evenly divisible by the 'rotation_angle'!");
+      paramError("rotation_angle",
+                 "The unit circle must be evenly divisible by the 'rotation_angle'!");
 
     _angle = angle * M_PI / 180.0;
 

--- a/test/tests/neutronics/adaptivity/tests
+++ b/test/tests/neutronics/adaptivity/tests
@@ -19,7 +19,7 @@
     input = mesh.i
     cli_args = "Problem/Tallies/Mesh/mesh_template='../meshes/sphere.e'"
     mesh_mode = 'replicated'
-    expect_err = "Adaptivity is only supported when tallying on the mesh in the \[Mesh\] block!"
+    expect_err = "Adaptivity is not supported when loading a mesh from 'mesh_template'!"
     requirement = "The system shall error if adaptivity is active and tallying on a mesh template instead of the"
                    " mesh block."
     required_objects = 'OpenMCCellAverageProblem'

--- a/test/tests/openmc_errors/mesh_tally/tests
+++ b/test/tests/openmc_errors/mesh_tally/tests
@@ -2,18 +2,14 @@
   [incorrect_scaling]
     type = RunException
     input = incorrect_scaling.i
-    expect_err = "The centroids of the 'mesh_template' differ from the centroids of the \[Mesh\] "
-                 "by a factor of 0.01.\n"
-                 "Did you forget that the 'mesh_template' must be in the same units as the [Mesh]?"
+    expect_err = "The centroids of the 'mesh_template' differ from the centroids of the"
     requirement = "The system shall error if the mesh template is not provided in the same units as the [Mesh]."
     required_objects = 'OpenMCCellAverageProblem'
   []
   [incorrect_order]
     type = RunException
     input = incorrect_order.i
-    expect_err = "Centroid for element 256 in the \[Mesh\] \(cm\): \(0.896826, 0.189852, 4.60886\)\n"
-                 "does not match centroid for element 0 in the 'mesh_template' with instance 1 \(cm\): \(0.896826, 0.189852, 8.60886\)!\n\n"
-                 "The copy transfer requires that the \[Mesh\] and 'mesh_template' be identical."
+    expect_err = "Centroid for element 256 in the"
     requirement = "The system shall error if the mesh template does not exactly match the [Mesh], such as when "
                   "the order of mesh translations does not match the order of inputs in a CombinerGenerator."
     required_objects = 'OpenMCCellAverageProblem'
@@ -21,9 +17,7 @@
   [incorrect_file]
     type = RunException
     input = incorrect_file.i
-    expect_err = "Centroid for element 0 in the \[Mesh\] \(cm\): \(0.896826, 0.189852, 0.608855\)\n"
-                 "does not match centroid for element 0 in the 'mesh_template' with instance 0 \(cm\): \(-0.0251736, -0.0667374, 0.0847458\)!\n\n"
-                 "The copy transfer requires that the \[Mesh\] and 'mesh_template' be identical."
+    expect_err = "Centroid for element 0 in the"
     requirement = "The system shall error if the mesh template does not exactly match the [Mesh], such as when "
                   "a totally different mesh is used (pincell versus pebbles)."
     required_objects = 'OpenMCCellAverageProblem'

--- a/test/tests/userobjects/volume_calculation/tests
+++ b/test/tests/userobjects/volume_calculation/tests
@@ -33,8 +33,7 @@
   [missing_vol]
     type = RunException
     input = no_vol.i
-    expect_err = "To display the actual OpenMC cell volumes, the \[Problem\] block needs to set the\n"
-                 "'volume_calculation' parameter."
+    expect_err = "To display the actual OpenMC cell volumes"
     requirement = "The system shall error if trying to view stochastic volumes without the stochastic "
                   "volume calculation having been created."
     required_objects = 'OpenMCCellAverageProblem'


### PR DESCRIPTION
This PR swaps `mooseError(...)` calls with `paramError(...)` calls where it makes sense to do so. Combined parameter errors (where two input parameters aren't compatible or something similar) don't work with the `paramError` paradigm, and so they were left as `mooseErrors`. This is a first pass over all of the generic and OpenMC objects; I haven't gone over the Nek objects to avoid any potential clashes in #987.

Annoyingly some `RunException` tests needed to be re-golded as they were failing pattern matching once the errors they tested were swapped to `paramErrors`. This is why a few test files are modified in this PR.