### PR TITLE
Dockerfiles to build both with and without conda

### DIFF
--- a/scripts/Dockerfile.cardinal-conda-build
+++ b/scripts/Dockerfile.cardinal-conda-build
@@ -1,0 +1,54 @@
+# Build and install Cardinal using the MOOSE conda environment in a Docker image
+#
+# Divided into the following targets:
+#
+# cardinal-conda-base: starting from an Ubuntu 24.04 image:
+#     * installs minimal packages
+#     * downloads and runs the miniforge installer
+#     * runs conda init and adds the INL channel
+#     * creats a moose environment
+#
+# cardinal-conda-deps:
+#     * clone cardinal repo
+#     * run the get-dependency script
+#
+# cardinal:
+#     * make cardinal using specific environment variables
+#
+FROM ubuntu:24.04 AS cardinal-conda-base
+
+RUN apt update --yes
+RUN apt install --yes curl cmake mpich git
+
+WORKDIR /cardinal_build
+
+RUN curl -L -O https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
+    bash Miniforge3-Linux-x86_64.sh -b -p ~/miniforge && \
+    rm Miniforge3-Linux-x86_64.sh
+
+ENV PATH=/cardinal_build/miniforge/bin:$PATH
+
+RUN echo $PATH
+RUN conda init --all 
+
+RUN conda update --all --yes && \
+    conda config --add channels https://conda.software.inl.gov/public && \
+    conda create -n moose moose
+
+FROM cardinal-conda-base AS cardinal-conda-deps
+
+RUN git clone https://github.com/neams-th-coe/cardinal.git
+
+WORKDIR /cardinal_build/cardinal
+SHELL ["/bin/bash", "-i", "-c"]
+
+RUN conda activate moose && \
+     ./scripts/get-dependencies.sh
+
+FROM cardinal-conda-deps AS cardinal
+
+RUN conda activate moose && \
+    export HDF5_ROOT=$CONDA_PREFIX && \
+    export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH && \
+    export ENABLE_NEK=false && \
+    make -j8

--- a/scripts/Dockerfile.cardinal-src-build
+++ b/scripts/Dockerfile.cardinal-src-build
@@ -1,0 +1,66 @@
+# Build and install Cardinal in a Docker image without conda
+#
+# Divided into the following targets:
+#
+# cardinal-base: starting from an Ubuntu 24.04 image:
+#     * installs all required packages
+#
+# cardinal-clone:
+#     * clone cardinal repo
+#
+# cardinal-deps:
+#     * run the get-dependency script
+#
+# cardinal-build:
+#     * make cardinal using specific environment variables
+#
+FROM ubuntu:24.04 AS cardinal-base
+
+# Install necessary dependencies
+RUN apt-get update --yes && \
+    apt-get install --yes \
+        git \
+        make \
+        autoconf \
+        automake \
+        libtool \
+        flex \
+        bison \
+        cmake \
+        g++ \
+        gfortran \
+        libhdf5-dev \
+        mpich \
+        libtirpc-dev \
+        python3 \
+        python3-pip \
+        python3-packaging \
+        python3-jinja2 \
+        python3-yaml \
+        python3-pkgconfig
+
+FROM cardinal-base AS cardinal-clone
+
+# COPY . /cardinal    
+WORKDIR /cardinal-build
+RUN git clone https://github.com/neams-th-coe/cardinal.git
+
+FROM cardinal-clone AS cardinal-deps
+
+WORKDIR /cardinal-build/cardinal
+
+ENV LIBMESH_JOBS=16
+
+RUN ./scripts/get-dependencies.sh && \
+    ./contrib/moose/scripts/update_and_rebuild_petsc.sh && \
+    ./contrib/moose/scripts/update_and_rebuild_libmesh.sh && \
+    ./contrib/moose/scripts/update_and_rebuild_wasp.sh
+
+FROM cardinal-deps AS cardinal-build
+
+WORKDIR /cardinal-build/cardinal
+
+RUN export NEKRS_HOME=/cardinal-build/cardinal/install && \
+    make -j8
+    
+    


### PR DESCRIPTION
These dockerfiles will build Cardinal according to the typical installation instructions, within an Ubuntu 24.04 docker image.