### PR TITLE
Add MooseDocs SQA documents to website

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -91,3 +91,21 @@ Extensions:
         duplicates:
             - hales15homogenization
             - petersen
+
+    MooseDocs.extensions.sqa:
+        active: true
+        categories: # commented-out categories are not available
+            cardinal: !include ${ROOT_DIR}/doc/sqa_cardinal.yml
+            framework: !include ${MOOSE_DIR}/framework/doc/sqa_framework.yml
+            fluid_properties: !include ${MOOSE_DIR}/modules/fluid_properties/doc/sqa_fluid_properties.yml
+            heat_transfer: !include ${MOOSE_DIR}/modules/heat_transfer/doc/sqa_heat_transfer.yml
+            navier_stokes: !include ${MOOSE_DIR}/modules/navier_stokes/doc/sqa_navier_stokes.yml
+            ray_tracing: !include ${MOOSE_DIR}/modules/ray_tracing/doc/sqa_ray_tracing.yml
+            reactor: !include ${MOOSE_DIR}/modules/reactor/doc/sqa_reactor.yml
+            solid_mechanics: !include ${MOOSE_DIR}/modules/solid_mechanics/doc/sqa_solid_mechanics.yml
+            solid_properties: !include ${MOOSE_DIR}/modules/solid_properties/doc/sqa_solid_properties.yml
+            stochastic_tools: !include ${MOOSE_DIR}/modules/stochastic_tools/doc/sqa_stochastic_tools.yml
+            thermal_hydraulics: !include ${MOOSE_DIR}/modules/thermal_hydraulics/doc/sqa_thermal_hydraulics.yml
+        reports: !include ${ROOT_DIR}/doc/sqa_reports.yml
+        repos:
+            default: https://github.com/neams-th-coe/cardinal

--- a/doc/config.yml
+++ b/doc/config.yml
@@ -24,7 +24,10 @@ Content:
     modules:
         root_dir: ${MOOSE_DIR}/modules/doc/content
         content:
+            - help/development/VSCode.md
             - help/development/analyze_jacobian.md
+            - help/finite_element_concepts/nodal_patch_recovery.md
+            - application_development/performance_benchmarking.md
             - application_usage/restart_recover.md
             - application_usage/command_line_usage.md
     python:

--- a/doc/config.yml
+++ b/doc/config.yml
@@ -56,6 +56,10 @@ Extensions:
                 CFD Meshing: tutorials/meshing.md
                 Code Theory: theory/index.md
                 Doxygen: doxygen.md
+            Software Quality:
+                Software Quality Assurance (SQA) Information: /sqa/index.md
+                Code Standards: sqa/cardinal_scs.md
+                Code Coverage: https://mooseframework.inl.gov/cardinal/docs/coverage
             Publications: publications.md
             Contact: contact.md
             Help: faq.md

--- a/doc/content/cardinal_prereqs.md
+++ b/doc/content/cardinal_prereqs.md
@@ -1,0 +1,6 @@
+At a minimum, Cardinal requires all the prerequisites of the [MOOSE framework](minimum_requirements.md). Additional requirements optionally exist depending on
+whether each library is enabled:
+
+- [OpenMC](https://docs.openmc.org/en/stable/usersguide/install.html#prerequisites)
+- [NekRS](https://nekrsdoc.readthedocs.io/en/latest/requirements.html)
+- [DAGMC](https://svalinn.github.io/DAGMC/install/dependencies.html)

--- a/doc/content/cardinal_prereqs.md
+++ b/doc/content/cardinal_prereqs.md
@@ -2,5 +2,5 @@ At a minimum, Cardinal requires all the prerequisites of the [MOOSE framework](m
 whether each library is enabled:
 
 - [OpenMC](https://docs.openmc.org/en/stable/usersguide/install.html#prerequisites)
-- [NekRS](https://nekrsdoc.readthedocs.io/en/latest/requirements.html)
+- [NekRS](https://github.com/Nek5000/nekRS/tree/next)
 - [DAGMC](https://svalinn.github.io/DAGMC/install/dependencies.html)

--- a/doc/content/sqa/cardinal_cci.md
+++ b/doc/content/sqa/cardinal_cci.md
@@ -1,0 +1,13 @@
+!template load file=sqa/app_cci.md.template app=Cardinal category=cardinal
+
+!template item key=general-communication
+Please use the [{{app}} Discussion forum](https://github.com/neams-th-coe/cardinal/discussions) for all
+questions and inquiries.
+
+!template item key=problem-reporting
+If you are having a problem with a specific release of {{app}} please contact the team
+using the [{{app}} Discussion forum](https://github.com/neams-th-coe/cardinal/discussions) and be sure
+to include the release information with the inquiry.
+
+!template item key=contributing
+With the exception of the location of the [code repository for {{app}}](https://github.com/neams-th-coe/cardinal), the same processes outlined in the [instructions for contributing to the MOOSE framework](framework/contributing.md) apply for contributing to {{app}}.

--- a/doc/content/sqa/cardinal_far.md
+++ b/doc/content/sqa/cardinal_far.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_far.md.template app=Cardinal category=cardinal

--- a/doc/content/sqa/cardinal_rtm.md
+++ b/doc/content/sqa/cardinal_rtm.md
@@ -1,0 +1,13 @@
+!template load file=sqa/app_rtm.md.template app=Cardinal category=cardinal
+
+!template! item key=system-scope
+!include cardinal_srs.md start=system-scope-begin end=system-scope-finish
+!template-end!
+
+!template! item key=system-purpose
+!include cardinal_srs.md start=system-purpose-begin end=system-purpose-finish
+!template-end!
+
+!template! item key=log-revisions
+Currently, no errors in issue references related to the changelog have been discovered.
+!template-end!

--- a/doc/content/sqa/cardinal_scs.md
+++ b/doc/content/sqa/cardinal_scs.md
@@ -1,0 +1,26 @@
+!template load file=sqa/app_scs.md.template app=Cardinal category=cardinal
+
+## Clang Format
+
+!style halign=left
+Like MOOSE, Cardinal uses `clang-format` with a customized
+[config file](https://github.com/neams-th-coe/cardinal/blob/devel/.clang-format)
+for code formatting. If you have clang installed, you can run
+
+```
+git clang-format [<branch>]
+```
+
+to automatically format code changed between your currently checked-out branch
+and `<branch>` (if left out, it defaults to the `HEAD` commit). If you don't do
+this before submitting your code, don't worry! The continuous integration
+testing system, [CIVET](https://civet.inl.gov), that is triggered when
+you submit a pull request, will check your code and provide information on the
+changes needed to conform to the code style (if any).
+
+## Cardinal Code Standards
+
+!style halign=left
+Cardinal follows the MOOSE code standards for all development. For information on file guidelines,
+naming conventions, example code, doxygen documentation, and other tips, please see
+[the MOOSE standard](sqa/framework_scs.md).

--- a/doc/content/sqa/cardinal_sdd.md
+++ b/doc/content/sqa/cardinal_sdd.md
@@ -1,0 +1,77 @@
+!template load file=sqa/app_sdd.md.template app=Cardinal category=cardinal
+
+!template! item key=introduction
+Many of the phenomena related to nuclear energy systems depend on the solutions
+to multiple physics models, which can be described by partial differential equations
+that provide spatially- and temporally-varying values of solution variables. When
+these models for individual physics depend on one another, we call this "multiphysics."
+{{app}} relies on the [OpenMC Monte Carlo radiation transport code](https://docs.openmc.org/en/stable/) and the [NekRS spectral element Navier-Stokes code](https://nekrsdoc.readthedocs.io/en/latest/index.html) to perform high-fidelity multiphysics and
+multiscale simulation. {{app}} handles the couplings that may occur between these two
+codes, in addition to the numerous physics models provided by the MOOSE framework
+(such as solid mechanics, material science, and radiative heat transfer).
+This document describes the system design of {{app}}.
+!template-end!
+
+!template! item key=system-scope
+!include cardinal_srs.md start=system-scope-begin end=system-scope-finish
+!template-end!
+
+!template! item key=dependencies-and-limitations
+{{app}} inherits the software dependencies of:
+ - [MOOSE framework](framework_sdd.md#dependencies-and-limitations)
+ - [OpenMC](https://docs.openmc.org/en/stable/usersguide/install.html#prerequisites)
+ - [NekRS](https://nekrsdoc.readthedocs.io/en/latest/requirements.html)
+ - [DAGMC](https://svalinn.github.io/DAGMC/install/dependencies.html)
+
+No additional dependencies are present.
+
+!template-end!
+
+!template! item key=design-stakeholders
+Stakeholders for [!ac]({{app}}) include several of the funding sources including [!ac](DOE), [!ac](INL), and [!ac](ANL).
+However, since [!ac]({{app}}) is an open-source project, several universities, companies, and foreign
+governments have an interest in the development and maintenance of the [!ac]({{app}}) project.
+!template-end!
+
+!template! item key=system-design
+
+{{app}} relies on OpenMC to solve for neutron-photon transport (optionally on
+[!ac](CAD) geometries by relying on DAGMC). {{app}} also relies on NekRS to solve
+for fluid flow, heat transfer, and species transport. {{app}} integrates these
+external libraries within the structure of a MOOSE application, allowing these
+external libraries to be coupled to existing capabilities and interfaces in the MOOSE
+framework, such as for physics modeling (e.g., with the [MOOSE modules](modules/index.md) or with other MOOSE applications)
+or data processing. Because {{app}} is based upon MOOSE, it employs the same concept
+of modular code objects that define all aspects of the solutions for physics.
+
+{{app}} provides specialized
+
+ - [AuxKernels](syntax/AuxKernels/index.md) classes that extract internal solution fields in NekRS and OpenMC
+ - [Controls](syntax/Controls/index.md) classes that modify NekRS and OpenMC simulations on-the-fly
+ - [Mesh](syntax/Mesh/index.md) classes to build the NekRS and OpenMC geometries in a MOOSE-compatible format, and modify existing meshes useful for postprocessing NekRS and OpenMC simulations
+ - [Postprocessors](syntax/Postprocessors/index.md) classes that query the NekRS and OpenMC simulations at points, through spatial integrals, etc.
+ - [Problem](syntax/Problem/index.md) classes to execute NekRS and OpenMC as MOOSE applications and facilitate data transfer
+ - [TimeStepper](syntax/TimeStepper/index.md) classes to control time stepping based on NekRS's adaptive time stepping routines
+ - [UserObjects](syntax/UserObjects.md) classes that spatially process the NekRS and OpenMC simulations
+
+{{app}} also provides custom syntax for creating OpenMC tallies needed for multiphysics.
+!template-end!
+
+!template! item key=system-structure
+[!ac]({{app}}) relies on the MOOSE framework to provide the core functionality of solving multiphysics problems. {{app}} replaces the actual physics solves with external [!ac](API) calls to OpenMC and NekRS, but relies on MOOSE for timestepping, synchronization, data transfers, and overall parallelization. Additional physics needed beyond OpenMC and NekRS are obtained from the [MOOSE modules](modules/index.md).
+
+A summary listing of the current modules required for complete [!ac]({{app}}) operation are shown below:
+
+- [Reactor](reactor/index.md)
+
+{{app}}'s Makefile also includes other modules which are by default enabled, due to
+their common usage with Cardinal (though they are not strictly required).
+
+The structure of [!ac]({{app}}) is based on defining C++ classes that derive from classes in the MOOSE
+framework or modules that provide functionality that is specifically tailored to nuclear
+modeling and simulation. By using the interfaces defined in MOOSE base classes for these classes,
+[!ac]({{app}}) is able to rely on MOOSE to execute these models at the appropriate times during the
+simulation and use their results in the desired ways.
+!template-end!
+
+!syntax complete subsystems=False actions=False objects=False

--- a/doc/content/sqa/cardinal_sdd.md
+++ b/doc/content/sqa/cardinal_sdd.md
@@ -28,9 +28,9 @@ No additional dependencies are present.
 !template-end!
 
 !template! item key=design-stakeholders
-Stakeholders for [!ac]({{app}}) include several of the funding sources including [!ac](DOE), [!ac](INL), and [!ac](ANL).
-However, since [!ac]({{app}}) is an open-source project, several universities, companies, and foreign
-governments have an interest in the development and maintenance of the [!ac]({{app}}) project.
+Stakeholders for {{app}} include several of the funding sources including [!ac](DOE), [!ac](INL), and [!ac](ANL).
+However, since {{app}} is an open-source project, several universities, companies, and foreign
+governments have an interest in the development and maintenance of the {{app}} project.
 !template-end!
 
 !template! item key=system-design
@@ -40,10 +40,9 @@ governments have an interest in the development and maintenance of the [!ac]({{a
 for fluid flow, heat transfer, and species transport. {{app}} integrates these
 external libraries within the structure of a MOOSE application, allowing these
 external libraries to be coupled to existing capabilities and interfaces in the MOOSE
-framework, such as for physics modeling (e.g., with the [MOOSE modules](modules/index.md) or with other MOOSE applications)
+framework, such as for physics modeling (e.g., with the [MOOSE modules](Modules/index.md) or with other MOOSE applications)
 or data processing. Because {{app}} is based upon MOOSE, it employs the same concept
 of modular code objects that define all aspects of the solutions for physics.
-
 {{app}} provides specialized
 
  - [AuxKernels](syntax/AuxKernels/index.md) classes that extract internal solution fields in NekRS and OpenMC
@@ -51,26 +50,26 @@ of modular code objects that define all aspects of the solutions for physics.
  - [Mesh](syntax/Mesh/index.md) classes to build the NekRS and OpenMC geometries in a MOOSE-compatible format, and modify existing meshes useful for postprocessing NekRS and OpenMC simulations
  - [Postprocessors](syntax/Postprocessors/index.md) classes that query the NekRS and OpenMC simulations at points, through spatial integrals, etc.
  - [Problem](syntax/Problem/index.md) classes to execute NekRS and OpenMC as MOOSE applications and facilitate data transfer
- - [TimeStepper](syntax/TimeStepper/index.md) classes to control time stepping based on NekRS's adaptive time stepping routines
- - [UserObjects](syntax/UserObjects.md) classes that spatially process the NekRS and OpenMC simulations
+ - [TimeStepper](TimeStepper/index.md) classes to control time stepping based on NekRS's adaptive time stepping routines
+ - [UserObjects](syntax/UserObjects/index.md) classes that spatially process the NekRS and OpenMC simulations
 
 {{app}} also provides custom syntax for creating OpenMC tallies needed for multiphysics.
 !template-end!
 
 !template! item key=system-structure
-[!ac]({{app}}) relies on the MOOSE framework to provide the core functionality of solving multiphysics problems. {{app}} replaces the actual physics solves with external [!ac](API) calls to OpenMC and NekRS, but relies on MOOSE for timestepping, synchronization, data transfers, and overall parallelization. Additional physics needed beyond OpenMC and NekRS are obtained from the [MOOSE modules](modules/index.md).
+{{app}} relies on the MOOSE framework to provide the core functionality of solving multiphysics problems. {{app}} replaces the actual physics solves with external [!ac](API) calls to OpenMC and NekRS, but relies on MOOSE for timestepping, synchronization, data transfers, and overall parallelization. Additional physics needed beyond OpenMC and NekRS are obtained from the [MOOSE modules](Modules/index.md).
 
-A summary listing of the current modules required for complete [!ac]({{app}}) operation are shown below:
+A summary listing of the current modules required for complete {{app}} operation are shown below:
 
 - [Reactor](reactor/index.md)
 
 {{app}}'s Makefile also includes other modules which are by default enabled, due to
 their common usage with Cardinal (though they are not strictly required).
 
-The structure of [!ac]({{app}}) is based on defining C++ classes that derive from classes in the MOOSE
+The structure of {{app}} is based on defining C++ classes that derive from classes in the MOOSE
 framework or modules that provide functionality that is specifically tailored to nuclear
 modeling and simulation. By using the interfaces defined in MOOSE base classes for these classes,
-[!ac]({{app}}) is able to rely on MOOSE to execute these models at the appropriate times during the
+{{app}} is able to rely on MOOSE to execute these models at the appropriate times during the
 simulation and use their results in the desired ways.
 !template-end!
 

--- a/doc/content/sqa/cardinal_sdd.md
+++ b/doc/content/sqa/cardinal_sdd.md
@@ -20,7 +20,7 @@ This document describes the system design of {{app}}.
 {{app}} inherits the software dependencies of:
  - [MOOSE framework](framework_sdd.md#dependencies-and-limitations)
  - [OpenMC](https://docs.openmc.org/en/stable/usersguide/install.html#prerequisites)
- - [NekRS](https://nekrsdoc.readthedocs.io/en/latest/requirements.html)
+ - [NekRS](https://github.com/Nek5000/nekRS/tree/next)
  - [DAGMC](https://svalinn.github.io/DAGMC/install/dependencies.html)
 
 No additional dependencies are present.

--- a/doc/content/sqa/cardinal_sll.md
+++ b/doc/content/sqa/cardinal_sll.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_sll.md.template app=Cardinal category=cardinal

--- a/doc/content/sqa/cardinal_srs.md
+++ b/doc/content/sqa/cardinal_srs.md
@@ -1,0 +1,79 @@
+!template load file=sqa/app_srs.md.template app=Cardinal category=cardinal
+
+!template! item key=system-scope
+!! system-scope-begin
+Cardinal is an application for performing high-fidelity simulation of nuclear systems
+incorporating Monte Carlo neutron-photon transport and/or spectral element [!ac](CFD).
+These physics can be combined with one another and with the [MOOSE modules](modules/index.md) to accomplish "multiphysics" simulation. High-fidelity simulations can also be
+performed independently, for the purpose of data postprocessing, to generate constitutive
+models suitable for lower-fidelity tools, a process referred to as "multiscale" simulation.
+
+Interfaces to other MOOSE-based codes, including systems-level thermal-hydraulics (SAM),
+heat pipe flows (Sockeye), and fuel performance (Bison) are also optionally included
+to support Cardinal simulations. Cardinal enables high-fidelity modeling of
+heat transfer, fluid flow, passive scalar transport, fluid-structure interaction,
+nuclear heating, tritium breeding, shielding effectiveness, material activation,
+material damage, and sensor response. The [syntax/MultiApps/index.md]
+is leveraged to allow for the multiscale, multiphysics coupling. Further, other MOOSE capabilities in the [modules](modules/index.md), such as the [Stochastic Tools Module](stochastic_tools/index.md) enable engineering studies with uncertainty quantification
+and sensitivity analysis.
+Cardinal therefore supports design, safety, engineering, and research projects.
+!! system-scope-finish
+!template-end!
+
+!template! item key=system-purpose
+!! system-purpose-begin
+The purpose of Cardinal is to perform fully integrated, high-fidelity, multiphysics simulations of nuclear energy systems at high-fidelity with a
+variety of materials, system configurations,
+and component designs in order to better understand system performance.
+Cardinal's main goal is to bring together the combined multiphysics capabilities of
+the [!ac](MOOSE) ecosystem with leading high-performance tools for radiation transport
+(OpenMC) and Navier-Stokes fluid flow (NekRS) in an open platform for research,
+safety assessment, engineering, and design studies of nuclear energy systems.
+!! system-purpose-finish
+!template-end!
+
+!template! item key=assumptions-and-dependencies
+[!ac]({{app}}) has no constraints on hardware and software beyond those of the MOOSE framework, MOOSE modules, OpenMC, NekRS, and DAGMC, as listed in their
+respective [!ac](SRS) documents, which are accessible through the links at
+the beginning of this document.
+
+[!ac]({{app}}) provides access to a number of code objects that perform computations, such as particle
+transport, material behavior, and boundary conditions. These objects each make their own physics-based
+assumptions, such as the units of the inputs and outputs. Those assumptions are described in the
+documentation for those individual objects.
+!template-end!
+
+!template! item key=user-characteristics
+{{app}} has two main classes of users:
+
+- +{{app}} Developers+: These are the core developers of {{app}}. They are responsible
+  for designing, implementing, and maintaining the software, while following and enforcing its software development standards. These scientists and engineers modify or add capabilities to {{app}}
+  for their own purposes, which may include research or extending its capabilities. They will typically
+  have a background in thermal-fluids and/or radiation transport, as well as in modeling and simulation techniques.
+- +Analysts+: These are users that run {{app}} to run simulations, but do not develop code.
+  The primary interface of these users with {{app}} is the input files that define their
+  simulations. These users may interact with developers of the system requesting new features and
+  reporting bugs found.
+!template-end!
+
+!template! item key=information-management
+{{app}} as well as the core MOOSE framework, OpenMC, NekRS, and DAGMC are publicly available
+on an appropriate repository hosting site. Day-to-day backups and security services will be provided
+by the hosting service. More information about backups of the public repository on [!ac](INL)-hosted
+services can be found on the following page: [sqa/github_backup.md]
+!template-end!
+
+!template! item key=policies-and-regulations
+!include framework_srs.md start=policies-and-regulations-begin end=policies-and-regulations-finish
+!template-end!
+
+!template! item key=packaging
+No special requirements are needed for packaging or shipping any media containing the Cardinal source code. However, some other applications that use {{app}} may be export-controlled, in which case all export control restrictions must be adhered to when
+packaging and shipping media.
+!template-end!
+
+!template! item key=reliability
+The regression test suite will cover at least 90% of all lines of code at all times. Known
+regressions will be recorded and tracked (see [#maintainability]) to an independent and
+satisfactory resolution.
+!template-end!

--- a/doc/content/sqa/cardinal_srs.md
+++ b/doc/content/sqa/cardinal_srs.md
@@ -4,7 +4,7 @@
 !! system-scope-begin
 Cardinal is an application for performing high-fidelity simulation of nuclear systems
 incorporating Monte Carlo neutron-photon transport and/or spectral element [!ac](CFD).
-These physics can be combined with one another and with the [MOOSE modules](modules/index.md) to accomplish "multiphysics" simulation. High-fidelity simulations can also be
+These physics can be combined with one another and with the [MOOSE modules](Modules/index.md) to accomplish "multiphysics" simulation. High-fidelity simulations can also be
 performed independently, for the purpose of data postprocessing, to generate constitutive
 models suitable for lower-fidelity tools, a process referred to as "multiscale" simulation.
 
@@ -14,7 +14,7 @@ to support Cardinal simulations. Cardinal enables high-fidelity modeling of
 heat transfer, fluid flow, passive scalar transport, fluid-structure interaction,
 nuclear heating, tritium breeding, shielding effectiveness, material activation,
 material damage, and sensor response. The [syntax/MultiApps/index.md]
-is leveraged to allow for the multiscale, multiphysics coupling. Further, other MOOSE capabilities in the [modules](modules/index.md), such as the [Stochastic Tools Module](stochastic_tools/index.md) enable engineering studies with uncertainty quantification
+is leveraged to allow for the multiscale, multiphysics coupling. Further, other MOOSE capabilities in the [modules](Modules/index.md), such as the [Stochastic Tools Module](stochastic_tools/index.md) enable engineering studies with uncertainty quantification
 and sensitivity analysis.
 Cardinal therefore supports design, safety, engineering, and research projects.
 !! system-scope-finish
@@ -26,18 +26,18 @@ The purpose of Cardinal is to perform fully integrated, high-fidelity, multiphys
 variety of materials, system configurations,
 and component designs in order to better understand system performance.
 Cardinal's main goal is to bring together the combined multiphysics capabilities of
-the [!ac](MOOSE) ecosystem with leading high-performance tools for radiation transport
+the MOOSE ecosystem with leading high-performance tools for radiation transport
 (OpenMC) and Navier-Stokes fluid flow (NekRS) in an open platform for research,
 safety assessment, engineering, and design studies of nuclear energy systems.
 !! system-purpose-finish
 !template-end!
 
 !template! item key=assumptions-and-dependencies
-[!ac]({{app}}) has no constraints on hardware and software beyond those of the MOOSE framework, MOOSE modules, OpenMC, NekRS, and DAGMC, as listed in their
+{{app}} has no constraints on hardware and software beyond those of the MOOSE framework, MOOSE modules, OpenMC, NekRS, and DAGMC, as listed in their
 respective [!ac](SRS) documents, which are accessible through the links at
 the beginning of this document.
 
-[!ac]({{app}}) provides access to a number of code objects that perform computations, such as particle
+{{app}} provides access to a number of code objects that perform computations, such as particle
 transport, material behavior, and boundary conditions. These objects each make their own physics-based
 assumptions, such as the units of the inputs and outputs. Those assumptions are described in the
 documentation for those individual objects.
@@ -68,7 +68,8 @@ services can be found on the following page: [sqa/github_backup.md]
 !template-end!
 
 !template! item key=packaging
-No special requirements are needed for packaging or shipping any media containing the Cardinal source code. However, some other applications that use {{app}} may be export-controlled, in which case all export control restrictions must be adhered to when
+No special requirements are needed for packaging or shipping any media containing the {{app}} source code.
+However, some other applications that use {{app}} may be export-controlled, in which case all export control restrictions must be adhered to when
 packaging and shipping media.
 !template-end!
 

--- a/doc/content/sqa/cardinal_stp.md
+++ b/doc/content/sqa/cardinal_stp.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_stp.md.template app=Cardinal category=cardinal

--- a/doc/content/sqa/cardinal_vvr.md
+++ b/doc/content/sqa/cardinal_vvr.md
@@ -1,0 +1,5 @@
+!template load file=sqa/app_vvr.md.template app=Cardinal category=cardinal
+
+!template! item key=introduction
+The [!ac](VVR) for {{app}} provides evidence that {{app}} fulfills its intended purpose.
+!template-end!

--- a/doc/content/sqa/index.md
+++ b/doc/content/sqa/index.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_index.md.template app=Cardinal category=cardinal

--- a/doc/content/with_conda.md
+++ b/doc/content/with_conda.md
@@ -49,15 +49,7 @@ To get MOOSE's conda environment, follow the instructions [here](https://moosefr
 
 ## Prerequisites
 
-The basic prerequisites for building Cardinal are summarized in [prereq_table].
-
-!table id=prereq_table caption=Summary of prerequisites needed for Cardinal.
-|    | Building with NekRS | Building with OpenMC | Both |
-| :- | :- | :- | :- |
-| CMake | $\checkmark$ | $\checkmark$ | $\checkmark$ |
-| GNU fortran >= 9.0 compiler | $\checkmark$ | &nbsp; | $\checkmark$  |
-| HDF5 | &nbsp; | $\checkmark$ | $\checkmark$ |
-| MPI | $\checkmark$ | $\checkmark$ | $\checkmark$ |
+!include cardinal_prereqs.md
 
 !alert! tip title=How do I know if I have these dependencies?
 You will already have all of these if using MOOSE's conda environment.

--- a/doc/content/without_conda.md
+++ b/doc/content/without_conda.md
@@ -28,15 +28,7 @@ that follow.
 
 ## Prerequisites
 
-The basic prerequisites for building Cardinal are summarized in [prereq_table].
-
-!table id=prereq_table caption=Summary of prerequisites needed for Cardinal.
-|    | Building with NekRS | Building with OpenMC | Both |
-| :- | :- | :- | :- |
-| CMake | $\checkmark$ | $\checkmark$ | $\checkmark$ |
-| GNU fortran >= 9.0 compiler | $\checkmark$ | &nbsp; | $\checkmark$  |
-| HDF5 | &nbsp; | $\checkmark$ | $\checkmark$ |
-| MPI | $\checkmark$ | $\checkmark$ | $\checkmark$ |
+!include cardinal_prereqs.md
 
 !alert! tip title=How do I know if I have these dependencies?
 Most systems will already have these available.

--- a/doc/sqa_cardinal.yml
+++ b/doc/sqa_cardinal.yml
@@ -4,17 +4,11 @@ specs:
     - tests
 dependencies: # commented-out categories are not available
     - framework
-    #- chemical_reactions
-    - electromagnetics
     - fluid_properties
     - heat_transfer
-    - misc
     - navier_stokes
-    - phase_field
     - reactor
-    - rdg
     - ray_tracing
-    - scalar_transport
     - solid_mechanics
     - solid_properties
     - stochastic_tools

--- a/doc/sqa_cardinal.yml
+++ b/doc/sqa_cardinal.yml
@@ -4,11 +4,17 @@ specs:
     - tests
 dependencies: # commented-out categories are not available
     - framework
+    #- chemical_reactions
+    - electromagnetics
     - fluid_properties
     - heat_transfer
+    - misc
     - navier_stokes
-    - ray_tracing
+    - phase_field
     - reactor
+    - rdg
+    - ray_tracing
+    - scalar_transport
     - solid_mechanics
     - solid_properties
     - stochastic_tools

--- a/doc/sqa_cardinal.yml
+++ b/doc/sqa_cardinal.yml
@@ -1,0 +1,16 @@
+directories:
+    - ${ROOT_DIR}/test/tests
+specs:
+    - tests
+dependencies: # commented-out categories are not available
+    - framework
+    - fluid_properties
+    - heat_transfer
+    - navier_stokes
+    - ray_tracing
+    - reactor
+    - solid_mechanics
+    - solid_properties
+    - stochastic_tools
+    - thermal_hydraulics
+reports: !include ${ROOT_DIR}/doc/sqa_reports.yml

--- a/doc/sqa_reports.yml
+++ b/doc/sqa_reports.yml
@@ -1,0 +1,50 @@
+Applications:
+    cardinal:
+        app_types:
+            - Cardinal
+        content_directory: ${ROOT_DIR}/doc/content
+        remove:
+            - ${MOOSE_DIR}/framework/doc/remove.yml
+        show_warning: false
+
+Documents:
+    software_quality_plan: sqa/inl_records.md#software_quality_plan
+    enterprise_architecture_entry: sqa/inl_records.md#enterprise_architecture_entry
+    safety_software_determination: sqa/inl_records.md#safety_software_determination
+    quality_level_determination: sqa/inl_records.md#quality_level_determination
+    configuration_management_plan: sqa/inl_records.md#configuration_management_plan
+    asset_management_plan: sqa/inl_records.md#asset_management_plan
+    verification_validation_plan: sqa/inl_records.md#verification_and_validation_plan
+    software_requirements_specification: sqa/cardinal_srs.md
+    software_design_description: sqa/cardinal_sdd.md
+    software_test_plan: sqa/cardinal_stp.md
+    requirements_traceability_matrix: sqa/cardinal_rtm.md
+    verification_validation_report: sqa/cardinal_vvr.md
+    failure_analysis_report: sqa/cardinal_far.md
+    software_library_list: sqa/cardinal_sll.md
+    communication_and_contact_information: sqa/cardinal_cci.md
+    software_coding_standards: sqa/cardinal_scs.md
+    user_manual: sqa/user_manual.md
+    theory_manual: sqa/theory_manual.md
+    show_warning: false
+    working_dirs:
+        - ${ROOT_DIR}/doc/content
+        - ${MOOSE_DIR}/framework/doc/content
+
+Requirements:
+    cardinal:
+        working_dirs:
+            - ${ROOT_DIR}/doc/content
+            - ${MOOSE_DIR}/framework/doc/content
+            - ${MOOSE_DIR}/modules/fluid_properties/doc/content
+            - ${MOOSE_DIR}/modules/heat_transfer/doc/content
+            - ${MOOSE_DIR}/modules/navier_stokes/doc/content
+            - ${MOOSE_DIR}/modules/ray_tracing/doc/content
+            - ${MOOSE_DIR}/modules/reactor/doc/content
+            - ${MOOSE_DIR}/modules/solid_mechanics/doc/content
+            - ${MOOSE_DIR}/modules/solid_properties/doc/content
+            - ${MOOSE_DIR}/modules/stochastic_tools/doc/content
+            - ${MOOSE_DIR}/modules/thermal_hydraulics/doc/content
+        directories:
+            - ${ROOT_DIR}/test
+        show_warning: false

--- a/doc/sqa_reports.yml
+++ b/doc/sqa_reports.yml
@@ -36,17 +36,11 @@ Requirements:
         working_dirs:
             - ${ROOT_DIR}/doc/content
             - ${MOOSE_DIR}/framework/doc/content
-            - ${MOOSE_DIR}/modules/chemical_reactions/doc/content
-            - ${MOOSE_DIR}/modules/electromagnetics/doc/content
             - ${MOOSE_DIR}/modules/fluid_properties/doc/content
             - ${MOOSE_DIR}/modules/heat_transfer/doc/content
-            - ${MOOSE_DIR}/modules/misc/doc/content
             - ${MOOSE_DIR}/modules/navier_stokes/doc/content
-            - ${MOOSE_DIR}/modules/phase_field/doc/content
             - ${MOOSE_DIR}/modules/reactor/doc/content
-            - ${MOOSE_DIR}/modules/rdg/doc/content
             - ${MOOSE_DIR}/modules/ray_tracing/doc/content
-            - ${MOOSE_DIR}/modules/scalar_transport/doc/content
             - ${MOOSE_DIR}/modules/solid_mechanics/doc/content
             - ${MOOSE_DIR}/modules/solid_properties/doc/content
             - ${MOOSE_DIR}/modules/stochastic_tools/doc/content

--- a/doc/sqa_reports.yml
+++ b/doc/sqa_reports.yml
@@ -24,8 +24,8 @@ Documents:
     software_library_list: sqa/cardinal_sll.md
     communication_and_contact_information: sqa/cardinal_cci.md
     software_coding_standards: sqa/cardinal_scs.md
-    user_manual: sqa/user_manual.md
-    theory_manual: sqa/theory_manual.md
+    #user_manual: sqa/user_manual.md
+    #theory_manual: sqa/theory_manual.md
     show_warning: false
     working_dirs:
         - ${ROOT_DIR}/doc/content
@@ -36,11 +36,17 @@ Requirements:
         working_dirs:
             - ${ROOT_DIR}/doc/content
             - ${MOOSE_DIR}/framework/doc/content
+            - ${MOOSE_DIR}/modules/chemical_reactions/doc/content
+            - ${MOOSE_DIR}/modules/electromagnetics/doc/content
             - ${MOOSE_DIR}/modules/fluid_properties/doc/content
             - ${MOOSE_DIR}/modules/heat_transfer/doc/content
+            - ${MOOSE_DIR}/modules/misc/doc/content
             - ${MOOSE_DIR}/modules/navier_stokes/doc/content
-            - ${MOOSE_DIR}/modules/ray_tracing/doc/content
+            - ${MOOSE_DIR}/modules/phase_field/doc/content
             - ${MOOSE_DIR}/modules/reactor/doc/content
+            - ${MOOSE_DIR}/modules/rdg/doc/content
+            - ${MOOSE_DIR}/modules/ray_tracing/doc/content
+            - ${MOOSE_DIR}/modules/scalar_transport/doc/content
             - ${MOOSE_DIR}/modules/solid_mechanics/doc/content
             - ${MOOSE_DIR}/modules/solid_properties/doc/content
             - ${MOOSE_DIR}/modules/stochastic_tools/doc/content

--- a/test/tests/deformation/simple-cube/tests
+++ b/test/tests/deformation/simple-cube/tests
@@ -8,7 +8,7 @@
     requirement = "This test solves the steady state heat conduction equation "
                   "with a source term of 3*sin(x)*sin(y)*sin(z) and a conductivity"
                   "of 1. The temperature obtained should be sin(x)*sin(y)*sin(z)."
-                  "The domain is a cube over [-1,1]^3 that is deforming at each"
+                  "The domain is a cube that is deforming at each"
                   "time step in the to the arbitrary functions t*x*z*(2-z)*0.1 for x-coordinates,"
                   "t*x*z*(2-z)*0.05 in y coordinates, and t*(y+1)*(y-1)*0.1 in z coordinates."
                   "The gold solution was verified by comparing it"

--- a/test/tests/deformation/vol-areas/tests
+++ b/test/tests/deformation/vol-areas/tests
@@ -8,7 +8,7 @@
     requirement = "An arbitrary mesh displacement in the main app will displace the mesh"
                   "in the sub-app equivalently at each time-step. This shall be verified by"
                   "comparing the areas of each sideset in both the main and the sub-app."
-                  "The domain is a cube over [-1,1]^3, with the initial area of each of the"
+                  "The domain is a cube, with the initial area of each of the"
                   "sidesets being 4.0. The areas across the main and sub-app should match"
                   "exactly, provided we are using Gauss Lobatto quadrature for MOOSE's area"
                   "post-processors, in order to match NekRS's GLL quadrature."

--- a/test/tests/nek_errors/deformation/tests
+++ b/test/tests/nek_errors/deformation/tests
@@ -6,8 +6,7 @@
     required_objects = 'NekRSProblem'
     max_parallel = 64
     expect_err = "Your NekRSMesh has 'displacements', but 'nomesh_solver.par' does not have a"
-    requirement = "The system shall error if Cardinal has displacements associated with NekRSMesh, but there is no mesh solver"
-                  "in the nekRS [MESH] block."
+    requirement = "The system shall error if Cardinal has displacements associated with NekRSMesh, but there is no mesh solver."
   []
   [standalone]
     type = RunException
@@ -26,7 +25,7 @@
     max_parallel = 64
 
     expect_err = "For boundary-coupled moving mesh problems, you need at least one boundary in"
-    requirement = "The system shall error if the Nek .par file has a solver in the  [MESH] block"
+    requirement = "The system shall error if the Nek .par file has a mesh solver"
                   "but the nekRS .par file has no moving mesh (codedFixedValue) boundary in the"
                   " [Mesh] block."
   []
@@ -36,7 +35,7 @@
     cli_args = "Mesh/volume=true Mesh/displacements='disp_x disp_y disp_z'"
     required_objects = 'NekRSProblem'
     max_parallel = 64
-    expect_err = "'elast_nomv.par' has a solver in the \[MESH\] block. This solver uses"
+    expect_err = "'elast_nomv.par' has a solver in the"
     requirement = "The system shall error if Cardinal is using the NekRS mesh blending solver without indicating the moving boundary of interest"
   []
 []

--- a/test/tests/nek_errors/deformation/user/tests
+++ b/test/tests/nek_errors/deformation/user/tests
@@ -11,7 +11,7 @@
     input = nek.i
     cli_args = "Mesh/volume=false Mesh/displacements='disp_x disp_y disp_z'"
     required_objects = 'NekRSProblem'
-    expect_err ="'user.par' has 'solver = user' in the \[MESH\] block."
+    expect_err ="'user.par' has 'solver = user' in the"
     requirement = "The system shall error if Cardinal has solver=user in the par file's MESH block, but there is no volume mesh mirror."
   []
   [separate_domain]


### PR DESCRIPTION
This adds the MooseDocs software quality assurance (SQA) documents to the Cardinal website, using the MooseDocs SQA extension.