### PR TITLE
Allow initial condition to be set for `flux_integral`

### DIFF
--- a/include/base/NekRSProblem.h
+++ b/include/base/NekRSProblem.h
@@ -159,6 +159,9 @@ protected:
   /// Relative tolerance for checking flux/heat source normalizations
   const Real & _rel_tol;
 
+  /// Initial value to use for the total boundary power for ensuring power conservation
+  const Real & _initial_flux_integral;
+
   /**
    * \brief Total surface-integrated flux coming from the coupled MOOSE app.
    *

--- a/src/base/NekRSProblem.C
+++ b/src/base/NekRSProblem.C
@@ -84,7 +84,10 @@ NekRSProblem::NekRSProblem(const InputParameters & params)
   nekrs::setRelativeTol(getParam<Real>("normalization_rel_tol"));
 
   if (!_boundary)
-    checkUnusedParam(params, "conserve_flux_by_sideset", "coupling NekRS solely through a volume mesh mirror");
+  {
+    checkUnusedParam(params, "conserve_flux_by_sideset", "'boundary' is empty");
+    checkUnusedParam(parameters(), "initial_flux_integral", "'boundary' is empty");
+  }
 
   // Determine the usrwrk indexing; the ordering will always be as
   // follows (except that unused terms will be deleted if not needed for coupling)
@@ -772,9 +775,6 @@ NekRSProblem::addExternalVariables()
       addPostprocessor("Receiver", "flux_integral", pp_params);
     }
   }
-  else
-    checkUnusedParam(
-        parameters(), "initial_flux_integral", "not coupling NekRS through a 'boundary'");
 
   if (_volume && _has_heat_source)
   {

--- a/src/base/NekRSProblem.C
+++ b/src/base/NekRSProblem.C
@@ -86,7 +86,7 @@ NekRSProblem::NekRSProblem(const InputParameters & params)
   if (!_boundary)
   {
     checkUnusedParam(params, "conserve_flux_by_sideset", "'boundary' is empty");
-    checkUnusedParam(parameters(), "initial_flux_integral", "'boundary' is empty");
+    checkUnusedParam(params, "initial_flux_integral", "'boundary' is empty");
   }
 
   // Determine the usrwrk indexing; the ordering will always be as

--- a/src/base/NekRSProblem.C
+++ b/src/base/NekRSProblem.C
@@ -31,7 +31,16 @@ InputParameters
 NekRSProblem::validParams()
 {
   InputParameters params = NekRSProblemBase::validParams();
-  params.addParam<Real>("initial_flux_integral", 0, "Initial value to use for the 'flux_integral' postprocessor, to ensure power conservation; this initial value will be overridden once the coupled app executes its transfer of the boundary power into the 'flux_integral' postprocessor. You may want to use this parameter if NekRS runs first, or if you are running NekRS in isolation but still want to apply a heat flux boundary condition via Cardinal. Remember that this parameter is only used to normalize the 'avg_flux' variable, so you will need to populate an initial shape (magnitude is unimportant because it will be normalized by this parameter).");
+  params.addParam<Real>(
+      "initial_flux_integral",
+      0,
+      "Initial value to use for the 'flux_integral' postprocessor, to ensure power conservation; "
+      "this initial value will be overridden once the coupled app executes its transfer of the "
+      "boundary power into the 'flux_integral' postprocessor. You may want to use this parameter "
+      "if NekRS runs first, or if you are running NekRS in isolation but still want to apply a "
+      "heat flux boundary condition via Cardinal. Remember that this parameter is only used to "
+      "normalize the 'avg_flux' variable, so you will need to populate an initial shape (magnitude "
+      "is unimportant because it will be normalized by this parameter).");
 
   params.addParam<bool>("has_heat_source",
                         true,
@@ -745,7 +754,9 @@ NekRSProblem::addExternalVariables()
     if (_conserve_flux_by_sideset)
     {
       if (isParamSetByUser("initial_flux_integral"))
-        mooseWarning("The 'initial_flux_integral' capability is not yet supported when 'conserve_flux_by_sideset' is enabled. Please contact a Cardinal developer if this is hindering your use case.");
+        mooseWarning("The 'initial_flux_integral' capability is not yet supported when "
+                     "'conserve_flux_by_sideset' is enabled. Please contact a Cardinal developer "
+                     "if this is hindering your use case.");
 
       auto vpp_params = _factory.getValidParams("ConstantVectorPostprocessor");
 
@@ -762,7 +773,8 @@ NekRSProblem::addExternalVariables()
     }
   }
   else
-    checkUnusedParam(parameters(), "initial_flux_integral", "not coupling NekRS through a 'boundary'");
+    checkUnusedParam(
+        parameters(), "initial_flux_integral", "not coupling NekRS through a 'boundary'");
 
   if (_volume && _has_heat_source)
   {

--- a/src/base/NekRSProblemBase.C
+++ b/src/base/NekRSProblemBase.C
@@ -84,15 +84,6 @@ NekRSProblemBase::validParams()
       "disable_fld_file_output", false, "Whether to turn off all NekRS field file output writing "
       "(for the usual field file output - this does not affect writing the usrwrk with 'usrwrk_output')");
 
-  params.addParam<bool>("minimize_transfers_in",
-                        false,
-                        "Whether to only synchronize nekRS "
-                        "for the direction TO_EXTERNAL_APP on multiapp synchronization steps");
-  params.addParam<bool>("minimize_transfers_out",
-                        false,
-                        "Whether to only synchronize nekRS "
-                        "for the direction FROM_EXTERNAL_APP on multiapp synchronization steps");
-
   params.addParam<bool>("skip_final_field_file", false, "By default, we write a NekRS field file "
     "on the last time step; set this to true to disable");
 
@@ -129,14 +120,6 @@ NekRSProblemBase::NekRSProblemBase(const InputParameters & params)
     _scratch_counter(0),
     _n_uo_slots(0)
 {
-  if (params.isParamSetByUser("minimize_transfers_in"))
-    mooseError("The 'minimize_transfers_in' parameter has been replaced by "
-      "'synchronization_interval = parent_app'! Please update your input files.");
-
-  if (params.isParamSetByUser("minimize_transfers_out"))
-    mooseError("The 'minimize_transfers_out' parameter has been replaced by "
-      "'synchronization_interval = parent_app'! Please update your input files.");
-
   if (_n_usrwrk_slots == 0)
     checkUnusedParam(params, "first_reserved_usrwrk_slot", "not reserving any scratch space");
   else if (_first_reserved_usrwrk_slot >= _n_usrwrk_slots)

--- a/test/tests/cht/sfr_pincell/gold/nek_isolated_out.csv
+++ b/test/tests/cht/sfr_pincell/gold/nek_isolated_out.csv
@@ -1,0 +1,2 @@
+time,flux_integral,nek_flux
+0.02,10,-9.9750463261459

--- a/test/tests/cht/sfr_pincell/gold/solid_dummy_out_nek0.csv
+++ b/test/tests/cht/sfr_pincell/gold/solid_dummy_out_nek0.csv
@@ -1,2 +1,0 @@
-time,flux_integral,nek_flux
-0.02,10,-9.9750463261811

--- a/test/tests/cht/sfr_pincell/gold/solid_dummy_out_nek0.csv
+++ b/test/tests/cht/sfr_pincell/gold/solid_dummy_out_nek0.csv
@@ -1,0 +1,2 @@
+time,flux_integral,nek_flux
+0.02,10,-9.9750463261811

--- a/test/tests/cht/sfr_pincell/nek_isolated.i
+++ b/test/tests/cht/sfr_pincell/nek_isolated.i
@@ -1,0 +1,38 @@
+[Problem]
+  type = NekRSProblem
+  casename = 'sfr_pin'
+  initial_flux_integral = 10
+[]
+
+[Mesh]
+  type = NekRSMesh
+  boundary = '1'
+[]
+
+[ICs]
+  [avg_flux]
+    type = ConstantIC
+    variable = avg_flux
+    value = 1.0
+  []
+[]
+
+[Executioner]
+  type = Transient
+
+  [TimeStepper]
+    type = NekTimeStepper
+  []
+[]
+
+[Postprocessors]
+  [nek_flux]
+    type = NekHeatFluxIntegral
+    boundary = '1'
+  []
+[]
+
+[Outputs]
+  csv = true
+  execute_on = 'final'
+[]

--- a/test/tests/cht/sfr_pincell/sfr_pin.par
+++ b/test/tests/cht/sfr_pincell/sfr_pin.par
@@ -4,7 +4,7 @@
 
 [GENERAL]
   stopAt = numSteps
-  numSteps = 2000
+  numSteps = 4
   dt = 5e-3
   timeStepper = tombo2
   writeControl = steps

--- a/test/tests/cht/sfr_pincell/solid_dummy.i
+++ b/test/tests/cht/sfr_pincell/solid_dummy.i
@@ -1,0 +1,88 @@
+[Mesh]
+  [circle]
+    type = AnnularMeshGenerator
+    nr = 10
+    nt = 25
+    rmin = 0
+    rmax = 0.4e-2
+    growth_r = -1.3
+  []
+  [cylinder]
+    type = AdvancedExtruderGenerator
+    input = circle
+    heights = '0.05 0.7 0.05'
+    num_layers = '5 10 5'
+    direction = '0 0 1'
+  []
+  [transform]
+    type = TransformGenerator
+    input = cylinder
+    transform = translate
+    vector_value = '0 0 -0.4'
+  []
+[]
+
+[Problem]
+  type = FEProblem
+  solve = false
+[]
+
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+  dt = 0.02
+[]
+
+[MultiApps]
+  [nek]
+    type = TransientMultiApp
+    input_files = 'nek_isolated.i'
+    sub_cycling = true
+    execute_on = timestep_end
+  []
+[]
+
+[Transfers]
+  [flux]
+    type = MultiAppGeneralFieldNearestLocationTransfer
+    source_variable = flux
+    to_multi_app = nek
+    variable = avg_flux
+    from_boundaries = '1'
+    search_value_conflicts = false
+  []
+  [flux_integral]
+    type = MultiAppPostprocessorTransfer
+    to_postprocessor = flux_integral
+    from_postprocessor = flux_integral
+    to_multi_app = nek
+  []
+[]
+
+[AuxVariables]
+  [flux]
+    family = MONOMIAL
+    order = CONSTANT
+    initial_condition = 1.0
+  []
+[]
+
+[Materials]
+  [k]
+    type = GenericConstantMaterial
+    prop_names = 'thermal_conductivity'
+    prop_values = '1.5'
+  []
+[]
+
+[Postprocessors]
+  [flux_integral]
+    type = ConstantPostprocessor
+    value = 10
+  []
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/cht/sfr_pincell/tests
+++ b/test/tests/cht/sfr_pincell/tests
@@ -26,4 +26,12 @@
     required_objects = 'NekRSProblem'
     max_time = 500
   []
+  [impose_heat_flux]
+    type = CSVDiff
+    input = solid_dummy.i
+    csvdiff = solid_dummy_out_nek0.csv
+    min_parallel = 6
+    requirement = "The system shall allow imposing heat flux through a dummy main application, instead of coupling NekRS via conjugate heat transfer. This is verified by computing the heat flux on the NekRS mesh, which adequately matches an initial value set in a postprocessor."
+    required_objects = 'NekRSProblem'
+  []
 []

--- a/test/tests/cht/sfr_pincell/tests
+++ b/test/tests/cht/sfr_pincell/tests
@@ -1,4 +1,6 @@
 [Tests]
+  design = 'NekRSProblem.md'
+
   [sfr_pincell]
     type = Exodiff
     input = nek_master.i
@@ -28,10 +30,11 @@
   []
   [impose_heat_flux]
     type = CSVDiff
-    input = solid_dummy.i
-    csvdiff = solid_dummy_out_nek0.csv
+    input = nek_isolated.i
+    csvdiff = nek_isolated_out_nek0.csv
     min_parallel = 6
-    requirement = "The system shall allow imposing heat flux through a dummy main application, instead of coupling NekRS via conjugate heat transfer. This is verified by computing the heat flux on the NekRS mesh, which adequately matches an initial value set in a postprocessor."
+    requirement = "The system shall allow imposing heat flux through a dummy main application, instead of coupling NekRS via conjugate heat transfer. This is verified by computing the heat flux on the NekRS mesh, which adequately matches an initial value set in a postprocessor. This gold file is also identical to that obtained by running a dummy main app (solid_dummy) that passes in the desired flux_integral initial condition."
     required_objects = 'NekRSProblem'
+    issues = '#797'
   []
 []

--- a/test/tests/cht/sfr_pincell/tests
+++ b/test/tests/cht/sfr_pincell/tests
@@ -31,7 +31,7 @@
   [impose_heat_flux]
     type = CSVDiff
     input = nek_isolated.i
-    csvdiff = nek_isolated_out_nek0.csv
+    csvdiff = nek_isolated_out.csv
     min_parallel = 6
     requirement = "The system shall allow imposing heat flux through a dummy main application, instead of coupling NekRS via conjugate heat transfer. This is verified by computing the heat flux on the NekRS mesh, which adequately matches an initial value set in a postprocessor. This gold file is also identical to that obtained by running a dummy main app (solid_dummy) that passes in the desired flux_integral initial condition."
     required_objects = 'NekRSProblem'


### PR DESCRIPTION
We can use Cardinal to apply a heat flux to NekRS, even if we don't want to run a coupled CHT case. This PR allows you to easily apply such a condition given total power (as opposed to having to convert that to a heat flux applied in `scalarNeumannConditions`).)