### PR TITLE
Remove unused params from mesh only tests

### DIFF
--- a/test/tests/neutronics/symmetry/rotational/solid_mesh.i
+++ b/test/tests/neutronics/symmetry/rotational/solid_mesh.i
@@ -71,7 +71,7 @@ height = 6.343                           # height of the full core (m)
     rotate_angle = 0
 
     background_block_id = '1'
-    background_block_names = 'graphite'
+    background_block_name = 'graphite'
     background_intervals = 1
   []
   [extrude]

--- a/test/tests/neutronics/symmetry/solid_mesh.i
+++ b/test/tests/neutronics/symmetry/solid_mesh.i
@@ -72,7 +72,7 @@ height = 6.343                           # height of the full core (m)
     rotate_angle = 0
 
     background_block_id = '1'
-    background_block_names = 'graphite'
+    background_block_name = 'graphite'
     background_intervals = 1
   []
   [extrude]

--- a/test/tests/neutronics/symmetry/tests
+++ b/test/tests/neutronics/symmetry/tests
@@ -17,6 +17,7 @@
   [wrong_uo]
     type = RunException
     input = wrong_uo.i
+    prereq = generate_mesh
     expect_err = "The 'symmetry_mapper' user object has to be of type SymmetryPointGenerator!"
     requirement = "The system shall error if the symmetry mapper is not of the correct type"
     required_objects = 'OpenMCCellAverageProblem'

--- a/test/tests/neutronics/symmetry/triso/solid_mesh.i
+++ b/test/tests/neutronics/symmetry/triso/solid_mesh.i
@@ -67,7 +67,7 @@ height = 0.25
     rotate_angle = 0
 
     background_block_id = '1'
-    background_block_names = 'graphite'
+    background_block_name = 'graphite'
     background_intervals = 1
   []
   [extrude]


### PR DESCRIPTION
I've added a feature in MOOSE that causes --mesh-only mode to error out if an unused / misspelled parameter exists in the input - https://github.com/idaholab/moose/pull/29824

This causes some Cardinal tests to fail (https://civet.inl.gov/job/2748234/), mainly because background_block_name should be used instead of background_block_names for PatternedHexMeshGenerator.

@aprilnovak this will likely cause some re-goldings, let me know if this is the preferred option here or to remove the background_block_names parameter entirely so that re-golding is not needed.