### PR TITLE
Add capabilities for dependencies, use capabilities within tests

### DIFF
--- a/src/base/CardinalApp.C
+++ b/src/base/CardinalApp.C
@@ -170,6 +170,33 @@ CardinalApp::registerApps()
 #ifdef ENABLE_IAPWS95
   IAPWS95App::registerApps();
 #endif
+
+  {
+    const std::string doc = "nekRS computational fluid dynamics coupling ";
+#ifdef ENABLE_NEK_COUPLING
+    addCapability("nekrs", true, doc + "is available.");
+#else
+    addCapability("nekrs", false, doc + "is not available.");
+#endif
+  }
+
+  {
+    const std::string doc = "OpenMC monte carlo particle transport coupling ";
+#ifdef ENABLE_OPENMC_COUPLING
+    addCapability("openmc", true, doc + "is available.");
+#else
+    addCapability("openmc", false, doc + "is not available.");
+#endif
+  }
+
+  {
+    const std::string doc = "DAGMC Direct Accelerated Geometry Monte Carlo coupling ";
+#ifdef ENABLE_DAGMC
+    addCapability("dagmc", true, doc + "is available.");
+#else
+    addCapability("dagmc", false, doc + "is not available.");
+#endif
+  }
 }
 
 void

--- a/test/tests/auxkernels/heat_transfer_coefficient/tests
+++ b/test/tests/auxkernels/heat_transfer_coefficient/tests
@@ -6,6 +6,6 @@
     input = nek.i
     csvdiff = nek_out.csv
     requirement = 'The system shall compute a convective heat transfer coefficient using userobjects for the wall heat flux, wall temperature, and bulk temperature.'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/auxkernels/nek_spatial_bin_component_aux/tests
+++ b/test/tests/auxkernels/nek_spatial_bin_component_aux/tests
@@ -4,13 +4,13 @@
     input = nek_bin_aux.i
     expect_err = "This auxkernel can only be combined with NekSpatialBinUserObject-derived classes!"
     requirement = "System shall error if auxkernel is not paired with a compatible bin user object."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [invalid_field]
     type = RunException
     input = invalid_field.i
     expect_err = "This auxkernel can only be used with a binning user object that sets 'field = velocity_component'!"
     requirement = "System shall error if auxkernel is not paired with a velocity vector bin user object."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/bison_coupling/bison_master/tests
+++ b/test/tests/bison_coupling/bison_master/tests
@@ -4,6 +4,6 @@
     input = bison.i
     requirement = "Cardinal shall be able to run BISON as a main application without any data transfers. "
                   "This test just ensures correct setup of BISON as a submodule with app registration."
-    required_applications = 'BisonApp'
+    capabilities = 'bisonapp'
   []
 []

--- a/test/tests/bison_coupling/bison_sub/tests
+++ b/test/tests/bison_coupling/bison_sub/tests
@@ -4,6 +4,6 @@
     input = cardinal.i
     requirement = "Cardinal shall be able to run BISON as a sub-application without any data transfers. "
                   "This test just ensures correct setup of BISON as a submodule with app registration."
-    required_applications = 'BisonApp'
+    capabilities = 'bisonapp'
   []
 []

--- a/test/tests/cht/multi_cht/tests
+++ b/test/tests/cht/multi_cht/tests
@@ -6,6 +6,6 @@
     requirement = "The system shall correctly evaluate volume postprocessors for a dimensional NekRS "
                   "solve on a conjugate heat transfer mesh. We test this by repeating the same integrals "
                   "of the mapped data on the MOOSE mesh, and show exact equivalence."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/cht/nondimensional/tests
+++ b/test/tests/cht/nondimensional/tests
@@ -18,7 +18,7 @@
                   "0.1% difference in temperatures (this is to be expected, though, because "
                   "the _solve_ is not exactly the same between a nondimensional and dimensional case - "
                   "the governing equation is the same, but not necessarily the number of iterations, etc. "
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [sfr_pincell_exact]
     type = CSVDiff
@@ -33,6 +33,6 @@
                   "the sfr_pincell case, and results are very similar with only small differences "
                   "due to the different mesh mirror representations. The usrwrk_output feature was "
                   "also used to check the correctness of the flux map into NekRS."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/cht/pebble/shift/tests
+++ b/test/tests/cht/pebble/shift/tests
@@ -9,6 +9,6 @@
                   "conjugate heat transfer when using an initial offset in the scratch space. "
                   "The gold file was created when using no offset to prove equivalence."
     rel_err = 1e-5
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/cht/pebble/tests
+++ b/test/tests/cht/pebble/tests
@@ -13,6 +13,6 @@
 
     requirement = "A coupled MOOSE-nekRS pebble flow problem shall predict physically realistic "
                   "conjugate heat transfer."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/cht/pincell_p_v/tests
+++ b/test/tests/cht/pincell_p_v/tests
@@ -6,7 +6,7 @@
     heavy = true
     requirement = "The system shall be able to output the pressure and velocity solution from NekRS "
                   "when coupling to MOOSE."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     max_time = 500
   []
 []

--- a/test/tests/cht/sfr_pincell/tests
+++ b/test/tests/cht/sfr_pincell/tests
@@ -12,7 +12,7 @@
                   "conservation of energy and realistic thermal solutions. Exact conservation of energy "
                   "(based on the power imposed in the solid) will not be observed because some heat flux "
                   "GLL points are also on Dirichlet boundaries, which win in boundary condition ties."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     max_time = 500
   []
   [sfr_pincell_vpp]
@@ -25,7 +25,7 @@
     requirement = "Individually conserving heat flux sideset by sideset shall give equivalent results "
                   "to the all-combined option when there is just one coupling sideset. The gold file "
                   "for this test is identical to that for the sfr_pincell case."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     max_time = 500
   []
   [impose_heat_flux]
@@ -34,7 +34,7 @@
     csvdiff = nek_isolated_out.csv
     min_parallel = 6
     requirement = "The system shall allow imposing heat flux through a dummy main application, instead of coupling NekRS via conjugate heat transfer. This is verified by computing the heat flux on the NekRS mesh, which adequately matches an initial value set in a postprocessor. This gold file is also identical to that obtained by running a dummy main app (solid_dummy) that passes in the desired flux_integral initial condition."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     issues = '#797'
   []
 []

--- a/test/tests/conduction/boundary_and_volume/prism/tests
+++ b/test/tests/conduction/boundary_and_volume/prism/tests
@@ -11,7 +11,7 @@
                   "flux is imposed in nekRS through a boundary. The same problem is created in a standalone "
                   "MOOSE simulation, in moose.i. Temperatures agree to within 0.2% degrees, and the agreement "
                   "can be made better by using finer meshes in the coupled Cardinal case."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [pyramid_exact]
     type = CSVDiff
@@ -23,7 +23,7 @@
                   "volumetric heating when using an exact mesh mirror. The solution is nearly identical "
                   "to the pyramid test and the usrwrk output for flux and volumetric heating match the "
                   "auxiliary variables in the Nek-wrapped input."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [duplicate_temp]
     type = RunException
@@ -31,6 +31,6 @@
     cli_args = "AuxVariables/heat_source/order=FIRST"
     expect_err = "Cardinal is trying to add an auxiliary variable named 'heat_source', but you already have a variable by this name."
     requirement = "The system shall error if the user specifies a duplicate variable with a name overlapping with special names reserved for Cardinal data transfers."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/conduction/identical_interface/cube/tests
+++ b/test/tests/conduction/identical_interface/cube/tests
@@ -14,6 +14,6 @@
                   "the 'visnek' script needs to be run to get the nekRS output results into the "
                   "exodus format. A heat conduction simulation performed with MOOSE over the combined nekRS-MOOSE "
                   "domain in the 'moose.i' input file also matches the coupled results very well."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/conduction/identical_interface/pyramid/tests
+++ b/test/tests/conduction/identical_interface/pyramid/tests
@@ -18,7 +18,7 @@
                   "the constant monomial surface heat flux is lowered). Even with the fairly coarse mesh "
                   "used in this test, the errors in temperature are less than 1% of the total temperature "
                   "range in the problem (but can locally be high relative differences)."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     max_time = 500
   []
 []

--- a/test/tests/conduction/identical_volume/cube/tests
+++ b/test/tests/conduction/identical_volume/cube/tests
@@ -19,6 +19,6 @@
                   "side- and volume-averaged temperature, as well as maximum temperature, match the "
                   "MOOSE standalone case to within 0.1%. To keep the gold files small here, this test "
                   "is only performed on a 10x10x10 nekRS mesh."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/conduction/nonidentical_interface/cylinders/tests
+++ b/test/tests/conduction/nonidentical_interface/cylinders/tests
@@ -19,7 +19,7 @@
                   "used in this test, the errors in temperature are less than 0.5%."
                   "As the BISON mesh is refined, the error continually decreases until the temperatures "
                   "are very close to those predicted by the standalone MOOSE case."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [cylinder_conduction_subcycle]
     type = CSVDiff
@@ -34,7 +34,7 @@
                   "1e-3 different from those for the cylinder_conduction case, so the simulation process "
                   "is equivalent. We don't use exactly the same CSV gold file because the number of time steps "
                   "differs, and would trigger a failure."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [cylinder_conduction_reversed]
     type = CSVDiff
@@ -46,7 +46,7 @@
                   "against those for the cylinder_conduction case, which match wo within 1e-5. We don't use "
                   "exactly the same CSV gold file because the number of time steps differ, and would trigger "
                   "a failure."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [cylinder_conduction_mini]
     type = CSVDiff
@@ -58,7 +58,7 @@
     requirement = "The same solution shall be obtained when nekRS is run as a sub-app with minimized transfers "
                   "for in the incoming and outgoing data transfers. We compare against the same CSV file used "
                   "for the cylinder_conduction_subcycle case because the results should be exactly the same."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [cylinder_conduction_exact]
     type = CSVDiff
@@ -67,6 +67,6 @@
     min_parallel = 8
     requirement = "The system shall support an exact NekRS mesh mirror. The solution is compared against "
                   "the cylinder_conduction case and nearly identical solutions are obtained."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/conduction/nonidentical_volume/cylinder/tests
+++ b/test/tests/conduction/nonidentical_volume/cylinder/tests
@@ -16,7 +16,7 @@
                   "heat source 'computed' by some other app. The solution matches the standalone MOOSE "
                   "case very well - postprocessors for the volume-averaged and maximum temperature match the "
                   "MOOSE standalone case to within 0.1%."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [cylinder_exact]
     type = CSVDiff
@@ -28,6 +28,6 @@
                   "exact mesh mirror. The output file was compared against the cylinder_heat_source "
                   "test, giving very similar answers. The heat source sent into NekRS was also checked "
                   "with the usrwrk_output feature."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/conduction/nonidentical_volume/nondimensional/tests
+++ b/test/tests/conduction/nonidentical_volume/nondimensional/tests
@@ -14,6 +14,6 @@
                   "and the nekRS solve is conducted in nondimensional scales. "
                   "Temperatures match to within 0.1% between the nondimensional version and the "
                   "dimensional version in ../cylinder."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/conduction/zero_flux/tests
+++ b/test/tests/conduction/zero_flux/tests
@@ -4,14 +4,14 @@
     input = main.i
     requirement = "The NekRS wrapping shall allow a zero total flux to be sent from MOOSE to NekRS "
                   "when all sidesets are conserved together."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [zero_flux_total_vpp]
     type = RunApp
     input = main_vpp.i
     requirement = "The NekRS wrapping shall allow a zero total flux to be sent from MOOSE to NekRS "
                   "when sidesets are individually conserved."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [vpp_disjoint]
     type = CSVDiff
@@ -19,7 +19,7 @@
     csvdiff = main_disjoint_out_nek0.csv
     requirement = "The NekRS wrapping shall allow unique sideset fluxes provided that the sidesets do not "
                   "share any nodes in the NekRS mesh."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [vpp_disjoint_zero]
     type = CSVDiff
@@ -27,7 +27,7 @@
     csvdiff = main_zero_out_nek0.csv
     requirement = "The NekRS wrapping shall allow unique sideset fluxes provided that the sidesets do not "
                   "share any nodes in the NekRS mesh, with some sidesets being zero flux."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [mismatch_length]
     type = RunException
@@ -35,7 +35,7 @@
     expect_err = "The sideset flux reporter transferred to NekRS must have a length equal to"
     requirement = "The system shall print a helpful error message if the sideset flux reporter does "
                   "not have the correct length."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [nodes_on_shared]
     type = RunException
@@ -43,6 +43,6 @@
     expect_err = "Flux normalization process failed!"
     requirement = "The system shall error if conserving flux on each unique sideset, but with nodes "
                   "shared across multiple sidesets."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/controls/openmc_nuclide_densities/tests
+++ b/test/tests/controls/openmc_nuclide_densities/tests
@@ -4,13 +4,13 @@
     input = error.i
     expect_err = 'The given UserObject does not exist or it is not a OpenMCNuclideDensities object'
     requirement = 'The system shall error if the controls is not used with the proper user object'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [mat]
     type = CSVDiff
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = 'The system shall change OpenMC material compositions via a controls'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/deformation/mesh-velocity-areas/tests
+++ b/test/tests/deformation/mesh-velocity-areas/tests
@@ -10,7 +10,7 @@
                   "NekRS meshes, which agree very well. Improved agreement is obtained by decreasing "
                   "the time step of the data transfers, due to the first-order finite difference "
                   "approximation made for velocity."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [volume]
     type = CSVDiff
@@ -21,6 +21,6 @@
     requirement = "A boundary displacement in the main app will displace the mesh in NekRS "
                   "when using a volume mesh mirror. We use the same gold file as for the boundary test, "
                   "proving equivalence."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/deformation/nek_standalone/tests
+++ b/test/tests/deformation/nek_standalone/tests
@@ -9,7 +9,7 @@
                   "changing, whereas the volume/area in MOOSE will not change because we currently do not "
                   "send displacements from NekRS to MOOSE."
     mesh_mode = 'replicated'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [boundary]
     type = CSVDiff
@@ -21,6 +21,6 @@
                   "changing, whereas the volume/area in MOOSE will not change because we currently do not "
                   "send displacements from NekRS to MOOSE."
     mesh_mode = 'replicated'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/deformation/simple-cube/tests
+++ b/test/tests/deformation/simple-cube/tests
@@ -13,6 +13,6 @@
                   "t*x*z*(2-z)*0.05 in y coordinates, and t*(y+1)*(y-1)*0.1 in z coordinates."
                   "The gold solution was verified by comparing it"
                   "to the analytic solution and a solution obtained by MOOSE's heat conduction solve."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/deformation/vol-areas/tests
+++ b/test/tests/deformation/vol-areas/tests
@@ -12,6 +12,6 @@
                   "sidesets being 4.0. The areas across the main and sub-app should match"
                   "exactly, provided we are using Gauss Lobatto quadrature for MOOSE's area"
                   "post-processors, in order to match NekRS's GLL quadrature."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/fluid_prop_subs/tests
+++ b/test/tests/fluid_prop_subs/tests
@@ -3,36 +3,36 @@
     type = RunApp
     input = sodium.i
     requirement = "Cardinal shall be able to use fluid properties from the sodium submodule (in a master app)."
-    required_applications = 'SodiumApp'
+    capabilities = 'sodiumapp'
   [../]
   [./potassium]
     type = RunApp
     input = potassium.i
     requirement = "Cardinal shall be able to use fluid properties from the potassium submodule (in a master app)."
-    required_applications = 'PotassiumApp'
+    capabilities = 'potassiumapp'
   [../]
   [./iapws95]
     type = RunApp
     input = iapws95.i
     requirement = "Cardinal shall be able to use fluid properties from the IAPWS95 submodule (in a master app)."
-    required_applications = 'IAPWS95App'
+    capabilities = 'iapws95app'
   [../]
   [./sodium_sub]
     type = RunApp
     input = sodium_master.i
     requirement = "Cardinal shall be able to use fluid properties from the sodium submodule (in a sub app)."
-    required_applications = 'SodiumApp'
+    capabilities = 'sodiumapp'
   [../]
   [./potassium_sub]
     type = RunApp
     input = potassium_master.i
     requirement = "Cardinal shall be able to use fluid properties from the potassium submodule (in a sub app)."
-    required_applications = 'PotassiumApp'
+    capabilities = 'potassiumapp'
   [../]
   [./iapws95_sub]
     type = RunApp
     input = iapws95_master.i
     requirement = "Cardinal shall be able to use fluid properties from the IAPWS95 submodule (in a sub app)."
-    required_applications = 'IAPWS95App'
+    capabilities = 'iapws95app'
   [../]
 []

--- a/test/tests/griffin_coupling/tests
+++ b/test/tests/griffin_coupling/tests
@@ -3,7 +3,6 @@
     type = RunApp
     input = AO_pps.i
     requirement = "Cardinal shall be able to run Griffin as the main application. "
-    required_applications = 'GriffinApp'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs & griffinapp'
   []
 []

--- a/test/tests/multiple_nek_apps/subdirectory/tests
+++ b/test/tests/multiple_nek_apps/subdirectory/tests
@@ -5,7 +5,7 @@
     check_files = 'pyramid/nek_out.csv pyramid/pyramid0.f00001'
     requirement = "Cardinal shall be able to run NekRS input files nested within subdirectories in the same "
                   "fashion that a standalone NekRS case will"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [invalid_directory]
     type = RunException
@@ -13,6 +13,6 @@
     cli_args = 'Problem/casename="invalid/pyramid"'
     expect_err = "Failed to find 'invalid/'! Did you set the 'casename' correctly?"
     requirement = "The system shall error if an invalid directory path is provided for the case"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/multiple_nek_apps/two_channels/tests
+++ b/test/tests/multiple_nek_apps/two_channels/tests
@@ -5,7 +5,7 @@
     expect_err = "The 'write_fld_files' setting should only be true when multiple Nek simulations "
                  "are run as sub-apps on a master app. Your input has Nek as the master app."
     requirement = "The system shall error if trying to write output files for a Nek input without sibling apps"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [two_channels]
     type = Exodiff
@@ -16,7 +16,7 @@
     requirement = "The system shall be able to run multiple Nek simulations translated throughout "
                   "a master app's domain. This test compares against a MOOSE standalone case, and "
                   "gives less than 0.3% difference in various temperature metrics."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [app_outputs]
     type = CheckFiles
@@ -26,6 +26,6 @@
     min_parallel = 2
     requirement = "The correct output files shall be written when writing separate output files for repeated "
                   "Nek simulation instances."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_errors/deformation/tests
+++ b/test/tests/nek_errors/deformation/tests
@@ -3,7 +3,7 @@
     type = RunException
     input = nek.i
     cli_args = "Mesh/displacements='disp_x disp_y disp_z' Problem/casename='nomesh_solver' --error"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     max_parallel = 64
     expect_err = "Your NekRSMesh has 'displacements', but 'nomesh_solver.par' does not have a"
     requirement = "The system shall error if Cardinal has displacements associated with NekRSMesh, but there is no mesh solver."
@@ -12,7 +12,7 @@
     type = RunException
     input = nek.i
     cli_args = "Mesh/volume=false Mesh/boundary='2' Mesh/displacements='disp_x disp_y disp_z'"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     max_parallel = 64
 
     expect_err = "For boundary-coupled moving mesh problems, you need at least one boundary in"
@@ -24,7 +24,7 @@
     type = RunException
     input = nek.i
     cli_args = "Mesh/volume=true Mesh/displacements='disp_x disp_y disp_z'"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     max_parallel = 64
     expect_err = "'elast_nomv.par' has a solver in the"
     requirement = "The system shall error if Cardinal is using the NekRS mesh blending solver without indicating the moving boundary of interest"

--- a/test/tests/nek_errors/deformation/user/tests
+++ b/test/tests/nek_errors/deformation/user/tests
@@ -2,15 +2,15 @@
   [displacements]
     type = RunException
     input = nek.i
-    required_objects = 'NekRSProblem'
     expect_err = "Moving mesh problems require 'displacements' in the \[Mesh\] block!"
+    capabilities = 'nekrs'
     requirement = "The system shall error if NekRSMesh is not paired with displacements for moving mesh problems."
   []
   [volume_for_user_solver]
     type = RunException
     input = nek.i
     cli_args = "Mesh/volume=false Mesh/displacements='disp_x disp_y disp_z'"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     expect_err ="'user.par' has 'solver = user' in the"
     requirement = "The system shall error if Cardinal has solver=user in the par file's MESH block, but there is no volume mesh mirror."
   []

--- a/test/tests/nek_errors/invalid_bid_postprocessor/tests
+++ b/test/tests/nek_errors/invalid_bid_postprocessor/tests
@@ -12,6 +12,6 @@
                  "Did you enter a valid 'boundary' in 'nek.i'?"
     requirement = "MOOSE shall throw an error if an invalid boundary is specified for the construction "
                   "of nekRS's mesh as a MooseMesh."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_errors/invalid_field/tests
+++ b/test/tests/nek_errors/invalid_field/tests
@@ -4,7 +4,7 @@
     input = nek.i
     expect_err = "Cannot find 'temperature' because your Nek case files do not have a temperature variable!"
     requirement = "The system shall throw an error if trying to use temperature as a field for cases that do not have a temperature variable"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [scalar01]
     type = RunException
@@ -12,7 +12,7 @@
     cli_args = 'Postprocessors/max/field=scalar01'
     expect_err = "Cannot find 'scalar01' because your Nek case files do not have a scalar01 variable!"
     requirement = "The system shall throw an error if trying to use scalar01 as a field for problems that don't have a scalar01 variable."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [scalar02]
     type = RunException
@@ -20,7 +20,7 @@
     cli_args = 'Postprocessors/max/field=scalar02'
     expect_err = "Cannot find 'scalar02' because your Nek case files do not have a scalar02 variable!"
     requirement = "The system shall throw an error if trying to use scalar02 as a field for problems that don't have a scalar02 variable."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [scalar03]
     type = RunException
@@ -28,7 +28,7 @@
     cli_args = 'Postprocessors/max/field=scalar03'
     expect_err = "Cannot find 'scalar03' because your Nek case files do not have a scalar03 variable!"
     requirement = "The system shall throw an error if trying to use scalar03 as a field for problems that don't have a scalar03 variable."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [usrwrk00]
     type = RunException
@@ -36,7 +36,7 @@
     cli_args = 'Postprocessors/max/field=usrwrk00 Problem/n_usrwrk_slots=0'
     expect_err = "Cannot find 'usrwrk00' because you have only allocated 'n_usrwrk_slots = 0'"
     requirement = "The system shall throw an error if trying to use usrwrk00 as a field for problems that don't have sufficient usrwrk slots."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [usrwrk01]
     type = RunException
@@ -44,7 +44,7 @@
     cli_args = 'Postprocessors/max/field=usrwrk01 Problem/n_usrwrk_slots=1'
     expect_err = "Cannot find 'usrwrk01' because you have only allocated 'n_usrwrk_slots = 1'"
     requirement = "The system shall throw an error if trying to use usrwrk01 as a field for problems that don't have sufficient usrwrk slots."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [usrwrk02]
     type = RunException
@@ -52,27 +52,27 @@
     cli_args = 'Postprocessors/max/field=usrwrk02 Problem/n_usrwrk_slots=2'
     expect_err = "Cannot find 'usrwrk02' because you have only allocated 'n_usrwrk_slots = 2'"
     requirement = "The system shall throw an error if trying to use usrwrk02 as a field for problems that don't have sufficient usrwrk slots."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [allocate_scratch_no_T]
     type = RunApp
     input = nek.i
     cli_args = "Postprocessors/active='' Problem/n_usrwrk_slots=2"
     requirement = "The system shall correctly allocate scratch by accessing only quantities on the flow mesh if there is no temperature variable"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [duplicate_auxvar]
     type = RunException
     input = auxvar.i
     expect_err = "Cardinal is trying to add an auxiliary variable named 'temp', but you already have a variable by this name."
     requirement = "The system shall error if the user manually specifies a duplicate name for an output field."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [duplicate_var]
     type = RunException
     input = nonlinear.i
     expect_err = "Cardinal is trying to add a nonlinear variable named 'temp', but you already have a variable by this name."
     requirement = "The system shall error if the user manually specifies a duplicate name for an output field."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_errors/invalid_settings/tests
+++ b/test/tests/nek_errors/invalid_settings/tests
@@ -8,7 +8,7 @@
     expect_err = "A 'Transient' executioner must be used with NekRSProblem, but you have specified the 'Steady' executioner!"
     requirement = "The system shall error if NekRSProblem is not paired with the correct executioner."
     max_parallel = 12
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [dimensionalize]
     type = RunException
@@ -16,7 +16,7 @@
     expect_err = "The \[Dimensionalize\] block can only be used with wrapped Nek cases!"
     requirement = "The system shall error if the Dimensionalize action is not paired with the correct problem."
     max_parallel = 12
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [mesh]
     type = RunException
@@ -24,7 +24,7 @@
     expect_err = "The mesh for NekRSProblem must be of type 'NekRSMesh', but you have specified a 'GeneratedMesh'!"
     requirement = "The system shall error if NekRSProblem is not paired with the correct mesh type."
     max_parallel = 12
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [problem_base]
     type = RunException
@@ -32,7 +32,7 @@
     expect_err = "NekBinnedVolumeAverage can only be used with NekRS-wrapped cases!"
     requirement = "The system shall error if a Nek object is not paired with the correct problem."
     max_parallel = 12
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [problem_mesh]
     type = RunException
@@ -41,7 +41,7 @@
     requirement = "The system shall error if a NekRSMesh is used without a corresponding Nek-wrapped"
                   "problem."
     max_parallel = 12
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [timestepper]
     type = RunException
@@ -50,7 +50,7 @@
                  "but you have specified the 'ConstantDT' time stepper!"
     requirement = "The system shall error if NekRSProblem is not paired with the correct time stepper."
     max_parallel = 12
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [missing_flux_bc]
     type = RunException
@@ -59,7 +59,7 @@
     requirement = "MOOSE shall throw an error if there is no receiving heat flux boundary condition "
                   "on the nekRS boundaries that are coupled to MOOSE."
     max_parallel = 12
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [boundary_id]
     type = RunException
@@ -70,7 +70,7 @@
     requirement = "MOOSE shall throw an error if an invalid boundary is specified for the construction "
                   "of nekRS's mesh as a MooseMesh."
     max_parallel = 12
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [scaling_mismatch]
     type = RunException
@@ -78,6 +78,6 @@
     expect_err = "If solving NekRS in nondimensional form, you must choose reference dimensional scales in the same units as expected by MOOSE,"
     requirement = "The system shall error if there is a mismatch between the scaling of the mesh and NekRS problem."
     max_parallel = 12
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_errors/invalid_transfer_pp/tests
+++ b/test/tests/nek_errors/invalid_transfer_pp/tests
@@ -7,6 +7,6 @@
         "postprocessor is not zero."
     requirement = "When using the minimized transfers setting, the default value for the "
                   "postprocessor in the master application must not be zero."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_errors/mpi_setup_multiple_inputs/tests
+++ b/test/tests/nek_errors/mpi_setup_multiple_inputs/tests
@@ -12,6 +12,6 @@
 
     expect_err = "NekRS does not currently support setting up multiple cases with the same MPI communicator."
     requirement = "The system shall error if the same MPI communicator is used to set up more than one Nek case."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_errors/no_occa_source_kernel/tests
+++ b/test/tests/nek_errors/no_occa_source_kernel/tests
@@ -9,6 +9,6 @@
     expect_err = "In order to send a volumetric heat source to NekRS, you must have an OCCA source kernel in the passive scalar equations"
     requirement = "The system shall throw an error if there is no heat source kernel when "
                   "using volume coupling"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_errors/no_temp_solve/tests
+++ b/test/tests/nek_errors/no_temp_solve/tests
@@ -9,7 +9,7 @@
     expect_err = "By setting 'solver = none' for temperature in 'brick.par', NekRS will not solve for temperature. The heat flux sent by this object will be unused."
     cli_args = '--error'
     requirement = "MOOSE shall throw a warning if there is no temperature passive scalar solve in NekRS when passing heat flux"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [source]
     type = RunException
@@ -21,6 +21,6 @@
     expect_err = "By setting 'solver = none' for temperature in 'brick.par', NekRS will not solve for temperature. The volumetric heat source sent by this object will be unused."
     cli_args = '--error'
     requirement = "MOOSE shall throw a warning if there is no temperature passive scalar solve in NekRS when passing heat flux"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_errors/no_temp_var/tests
+++ b/test/tests/nek_errors/no_temp_var/tests
@@ -5,7 +5,7 @@
     expect_err = "In order to send a boundary heat flux to NekRS, your case files must have a \[TEMPERATURE\] block. Note that you can set 'solver = none' in 'brick.par' if you don't want to solve for temperature."
     requirement = "MOOSE shall throw an error if there is no temperature passive scalar "
                   "variable initialized in nekRS for flux coupling."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [source]
     type = RunException
@@ -13,6 +13,6 @@
     expect_err = "In order to send a volumetric heat source to NekRS, your case files must have a \[TEMPERATURE\] block. Note that you can set 'solver = none' in 'brick.par' if you don't want to solve for temperature."
     requirement = "MOOSE shall throw an error if there is no temperature passive scalar "
                   "variable initialized in nekRS for source coupling."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_errors/used_scratch/tests
+++ b/test/tests/nek_errors/used_scratch/tests
@@ -5,6 +5,6 @@
     expect_err = "The nrs_t.usrwrk and nrs_t.o_usrwrk arrays are automatically allocated by Cardinal"
     requirement = "MOOSE shall throw an error if the user attempts to allocate the scratch space "
                   "arrays in NekRS, since they are automatically allocated by Cardinal."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_errors/usrwrk_transfers/tests
+++ b/test/tests/nek_errors/usrwrk_transfers/tests
@@ -5,7 +5,7 @@
     cli_args = 'Problem/FieldTransfers/flux/usrwrk_slot="1 1"'
     expect_err = "There are duplicate entries in 'usrwrk_slot': 1 1 ; duplicate entries are not allowed because the field transfer will overwrite itself."
     requirement = "MOOSE shall throw an error if a single transfer tries to occupy the same slot more than once"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [exceed_allocated_field]
     type = RunException
@@ -13,7 +13,7 @@
     cli_args = 'Problem/FieldTransfers/flux/usrwrk_slot="7"'
     expect_err = "Cannot write into usrwrk slot 7 because only 7 have been allocated with 'n_usrwrk_slots'. Slots are zero-indexed, so the maximum acceptable value in 'usrwrk_slot' is 6."
     requirement = "MOOSE shall throw an error if a attempting to write a field into a usrwrk slot which has not been allocated"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [exceed_allocated_scalar]
     type = RunException
@@ -21,7 +21,7 @@
     cli_args = 'Problem/ScalarTransfers/scalar/usrwrk_slot="7"'
     expect_err = "Cannot write into usrwrk slot 7 because only 7 have been allocated with 'n_usrwrk_slots'. Slots are zero-indexed, so the maximum acceptable value in 'usrwrk_slot' is 6."
     requirement = "MOOSE shall throw an error if a attempting to write a scalar into a usrwrk slot which has not been allocated"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [field_duplicated_by_field]
     type = RunException
@@ -29,21 +29,21 @@
     cli_args = 'Problem/FieldTransfers/flux/usrwrk_slot="2"'
     expect_err = "A duplicate slot, 2, is being used by another FieldTransfer."
     requirement = "MOOSE shall throw an error if a attempting to write a field into a usrwrk slot already claimed by another field transfer"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [scalar_duplicated_by_field]
     type = RunException
     input = scalar.i
     expect_err = "The usrwrk slot 3 is already used by the FieldTransfers for writing field data into NekRS. You cannot set 'usrwrk_slot' to any of: 3 4"
     requirement = "MOOSE shall throw an error if a attempting to write a scalar into a usrwrk slot already claimed by a field transfer"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [flux_no_boundary]
     type = RunException
     input = flux.i
     expect_err = "NekBoundaryFlux can only be used when there is boundary coupling of NekRS with MOOSE, i.e. when 'boundary' is provided in NekRSMesh."
     requirement = "The system shall error when a boundary flux transfer is applied when there is not boundary coupling"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [source_no_volume]
     type = RunException
@@ -51,7 +51,7 @@
     cli_args = 'Mesh/volume=false Mesh/boundary="6" Problem/FieldTransfers/source/usrwrk_slot="0"'
     expect_err = "The NekVolumetricSource object can only be used when there is volumetric coupling of NekRS with MOOSE, i.e. when 'volume = true' in NekRSMesh."
     requirement = "The system shall error when a volumetric source transfer is applied when there is not volume coupling"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [flux_slots]
     type = RunException
@@ -59,27 +59,27 @@
     cli_args = 'Mesh/boundary="6" Problem/FieldTransfers/flux/usrwrk_slot="1 2"'
     expect_err = "'usrwrk_slot' must be of length 1 for boundary flux transfers; you have entered a vector of length 2"
     requirement = "The system shall error when the usrwrk slot request does not match the needed number of slots for a flux transfer"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [source_slots]
     type = RunException
     input = source.i
     expect_err = "'usrwrk_slot' must be of length 1 for volumetric source transfers; you have entered a vector of length 2"
     requirement = "The system shall error when the usrwrk slot request does not match the needed number of slots for a source transfer"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [problem_field]
     type = RunException
     input = wrong_problem.i
     expect_err = "The \[FieldTransfers\] block can only be used with wrapped Nek cases! You need to change the \[Problem\] block to 'NekRSProblem'."
     requirement = "The system shall error if trying to use field transfer syntax only relevant for NekRS wrapped cases with a non-Nek case."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [problem_scalar]
     type = RunException
     input = wrong_problem_s.i
     expect_err = "The \[ScalarTransfers\] block can only be used with wrapped Nek cases! You need to change the \[Problem\] block to 'NekRSProblem'."
     requirement = "The system shall error if trying to use scalar transfer syntax only relevant for NekRS wrapped cases with a non-Nek case."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_file_output/avg_plugin/tests
+++ b/test/tests/nek_file_output/avg_plugin/tests
@@ -5,6 +5,6 @@
     check_files = 'avgturbPipe0.f00001 rm2turbPipe0.f00001 rmsturbPipe0.f00001 avgturbPipe0.f00002 rm2turbPipe0.f00002 rmsturbPipe0.f00002'
     min_parallel = 4
     requirement = "The correct output file writing sequence shall occur when relying on nrs->isOutputStep"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_file_output/nek_as_master/tests
+++ b/test/tests/nek_file_output/nek_as_master/tests
@@ -5,6 +5,6 @@
     check_files = 'pyramid0.f00001 pyramid0.f00002 pyramid0.f00003 pyramid0.f00004'
     requirement = "The correct output file writing sequence shall occur based on .par settings "
                   "when NekRS is the master application and when an uneven time step division occurs."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_file_output/nek_as_master_even/tests
+++ b/test/tests/nek_file_output/nek_as_master_even/tests
@@ -5,6 +5,6 @@
     check_files = 'pyramid0.f00001 pyramid0.f00002'
     requirement = "The correct output file writing sequence shall occur based on .par settings "
                   "when NekRS is the master application and when an even time step division occurs."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_file_output/nek_as_sub/tests
+++ b/test/tests/nek_file_output/nek_as_sub/tests
@@ -5,6 +5,6 @@
     check_files = 'pyramid0.f00001 pyramid0.f00002 pyramid0.f00003 pyramid0.f00004'
     requirement = "The correct output file writing sequence shall occur based on master executioner settings "
                   "when NekRS is the sub application and when an uneven time step division occurs."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_file_output/nek_as_sub_even/tests
+++ b/test/tests/nek_file_output/nek_as_sub_even/tests
@@ -5,6 +5,6 @@
     check_files = 'pyramid0.f00001 pyramid0.f00002'
     requirement = "The correct output file writing sequence shall occur based on master executioner settings "
                   "when NekRS is the sub application and when the time steps are evenly divisible."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_file_output/usrwrk/tests
+++ b/test/tests/nek_file_output/usrwrk/tests
@@ -4,6 +4,6 @@
     input = nek.i
     check_files = 'aaabrick0.f00001 aaabrick0.f00002 aaabrick0.f00003 cccbrick0.f00001 cccbrick0.f00002 cccbrick0.f00003'
     requirement = "The system shall allow the user to write the user scratch space slots to field files."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_mesh/exact/tests
+++ b/test/tests/nek_mesh/exact/tests
@@ -5,7 +5,7 @@
     exodiff = exact_in.e
     cli_args = '--mesh-only'
     requirement = "The system shall be able to generate an exact first-order boundary mesh mirror."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [volume_exact]
     type = Exodiff
@@ -13,7 +13,7 @@
     exodiff = exact_volume_in.e
     cli_args = '--mesh-only'
     requirement = "The system shall be able to generate an exact first-order volume mesh mirror."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [second_exact]
     type = RunException
@@ -21,6 +21,6 @@
     cli_args = 'Mesh/order=SECOND'
     expect_err = "When building an exact mesh mirror, the 'order' must be FIRST!"
     requirement = "The system shall error if trying to build an exact mesh mirror that is second order."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_mesh/first_order/tests
+++ b/test/tests/nek_mesh/first_order/tests
@@ -5,7 +5,7 @@
     exodiff = nek_out.e
     requirement = "NekRSMesh shall construct a first-order surface mesh from a list of boundary IDs. "
                   "The ordering for the nodes shall be based on the libMesh ordering."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [first_order_volume_mesh]
     type = Exodiff
@@ -13,6 +13,6 @@
     exodiff = nek_volume_out.e
     requirement = "NekRSMesh shall construct a first-order volume mesh. "
                   "The ordering for the nodes shall be based on the libMesh ordering."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_mesh/second_order/tests
+++ b/test/tests/nek_mesh/second_order/tests
@@ -5,7 +5,7 @@
     exodiff = 'nek_out.e'
     requirement = "NekRSMesh shall construct a second-order surface mesh from a list of boundary IDs. "
                   "The ordering of the nodes for each element shall also be based on the libMesh ordering."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [second_order_volume_mesh]
     type = 'Exodiff'
@@ -13,6 +13,6 @@
     exodiff = 'nek_volume_out.e'
     requirement = "NekRSMesh shall construct a second-order volume mesh. "
                   "The ordering of the nodes for each element shall also be based on the libMesh ordering."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_mesh/sidesets/cube/tests
+++ b/test/tests/nek_mesh/sidesets/cube/tests
@@ -11,7 +11,7 @@
     requirement = "NekRSMesh shall correctly assign sideset IDs based on the nekRS boundary IDs. "
                   "This is verified here by performing area integrals on sidesets defined in MOOSE, "
                   "which exactly match area integrals performed internally in nekRS."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [cube_sidesets_exact]
     type = CSVDiff
@@ -24,6 +24,6 @@
 
     requirement = "NekRSMesh shall correctly assign sideset IDs based on the nekRS boundary IDs "
                   "when using an exact mesh mirror. The areas are matched to the 'cube_sidesets' test."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_mesh/sidesets/pyramid/tests
+++ b/test/tests/nek_mesh/sidesets/pyramid/tests
@@ -6,7 +6,7 @@
     requirement = "NekRSMesh shall correctly assign sideset IDs based on the nekRS boundary IDs. "
                   "This is verified here by performing area integrals on sidesets defined in MOOSE, "
                   "which exactly match area integrals performed internally in nekRS."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [pyramid_sidesets_exact]
     type = CSVDiff
@@ -14,6 +14,6 @@
     csvdiff = nek_volume_out.csv
     requirement = "NekRSMesh shall correctly assign sideset IDs based on the nekRS boundary IDs "
                   "when using an exact mesh mirror. The areas are matched to the 'pyramid_sidesets' test."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_output/tests
+++ b/test/tests/nek_output/tests
@@ -6,7 +6,7 @@
     abs_zero = 1e-8
     requirement = "Nek-wrapped MOOSE cases shall be able to output the "
                   "passive scalars from the Nek solution onto the mesh mirror."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [other_output]
     type = CSVDiff
@@ -21,7 +21,7 @@
     input = nek_fld.i
     expect_err = "Cannot write field file for usrwrk slot greater than the total number of allocated slots: 2!"
     requirement = "The system shall error if trying to write a usrwrk slot greater than the total number of allocated slots"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [mismatch_length]
     type = RunException
@@ -29,7 +29,7 @@
     cli_args = 'Problem/usrwrk_output="0 1" Problem/usrwrk_output_prefix="abc"'
     expect_err = "The length of 'usrwrk_output' must match the length of 'usrwrk_output_prefix'!"
     requirement = "The system shall error if there is a mismatch between parameter lengths for writing usrwrk field files"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [bad_name]
     type = RunException

--- a/test/tests/nek_output/tests
+++ b/test/tests/nek_output/tests
@@ -14,7 +14,7 @@
     csvdiff = velocity_out.csv
     abs_zero = 1e-8
     requirement = "Nek-wrapped MOOSE cases shall be able to output any quantity in the field enumeration from NekRS onto the mesh mirror."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [too_high_slot]
     type = RunException
@@ -36,6 +36,6 @@
     input = bad_name.i
     expect_err = "We tried to choose a default 'field' as 'temp', but this value is not an option in the 'field' enumeration. Please provide the 'field' parameter."
     requirement = "The system shall error if the default choice for the field cannot be matched from the object name."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_standalone/adaptive_dt/tests
+++ b/test/tests/nek_standalone/adaptive_dt/tests
@@ -4,7 +4,7 @@
     input = nek.i
     csvdiff = nek_out.csv
     requirement = "The system shall support adaptive time stepping in NekRS when running as the main application."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [variable_dt_nondim]
     type = CSVDiff
@@ -12,6 +12,6 @@
     csvdiff = nek_nondim_out.csv
     requirement = "The system shall support adaptive time stepping in NekRS when running as the main application "
                   "and with a non-dimensional formulation."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_standalone/channel/tests
+++ b/test/tests/nek_standalone/channel/tests
@@ -13,6 +13,6 @@
                   "require that all the postprocessors match between these two renderings of the "
                   "solution (on the GLL points versus on the mesh mirror). This verifies "
                   "correct extraction of the NekRS solution with the 'output' parameter feature."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_standalone/conj_ht/tests
+++ b/test/tests/nek_standalone/conj_ht/tests
@@ -6,7 +6,7 @@
     min_parallel = 4
     requirement = "Cardinal shall be able to run the conj_ht NekRS example with a thin wrapper while "
                   "using postprocessors acting on either the fluid mesh or fluid+solid mesh."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [invalid_mesh_solid]
     type = RunException
@@ -14,6 +14,6 @@
     cli_args = 'Postprocessors/Area_BC3_flow/mesh="solid"'
     expect_err = "This object does not support operations on the solid part of the NekRS mesh!"
     requirement = "The system shall throw an error if trying to act on only the NekRS solid mesh for side postprocessors."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_standalone/ethier/tests
+++ b/test/tests/nek_standalone/ethier/tests
@@ -6,6 +6,6 @@
     min_parallel = 4
     requirement = "Cardinal shall be able to run the ethier NekRS example with a thin wrapper. "
                   "We add postprocessors to let us compare min/max values printed to the screen by NekRS."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_standalone/from_restart/tests
+++ b/test/tests/nek_standalone/from_restart/tests
@@ -7,6 +7,6 @@
                   "a simulation. Here, we compare several postprocessors from a case restarted "
                   "from a field file against the identical case where variables are instead "
                   "initialized in the .udf from functions."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_standalone/ktauChannel/tests
+++ b/test/tests/nek_standalone/ktauChannel/tests
@@ -6,6 +6,6 @@
     heavy = true
     requirement = "Cardinal shall be able to run the ktauChannel NekRS example with a thin wrapper "
                   "when using a volume mesh mirror. "
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_standalone/lowMach/tests
+++ b/test/tests/nek_standalone/lowMach/tests
@@ -15,7 +15,7 @@
                   "require that all the postprocessors match between these two renderings of the "
                   "solution (on the GLL points versus on the mesh mirror). This verifies "
                   "correct extraction of the NekRS solution with the 'output' parameter feature."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [boundary]
     type = CSVDiff
@@ -32,6 +32,6 @@
                   "require that all the postprocessors match between these two renderings of the "
                   "solution (on the GLL points versus on the mesh mirror). This verifies "
                   "correct extraction of the NekRS solution with the 'output' parameter feature."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_standalone/start_time/tests
+++ b/test/tests/nek_standalone/start_time/tests
@@ -5,7 +5,7 @@
     csvdiff = force_start_out.csv
     requirement = "The system shall properly modify both the NekRS start time and the time recognized "
                   "by the MOOSE wrapping."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [manual_start_time]
     type = CheckFiles
@@ -14,6 +14,6 @@
     requirement = "The system shall be able to force NekRS to start on a MOOSE-specified start time. "
                   "This is checked by looking for the existence of an output file that NekRS only writes "
                   "at t = 1.0005, which is only reached if MOOSE properly sets a custom start time."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_stochastic/device/tests
+++ b/test/tests/nek_stochastic/device/tests
@@ -3,7 +3,7 @@
     type = RunCommand
     command = '${NEKRS_HOME}/bin/nrspre pyramid 1'
     requirement = "The system shall precompile a NekRS case."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     use_shell = True
   []
   [device]
@@ -15,7 +15,7 @@
                   "random values from MOOSE to NekRS. The values of the random variables are used to apply a "
                   "Dirichlet boundary condition on temperature, which we confirm by looking at the value of "
                   "temperature on the boundary using postprocessors."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     mesh_mode = replicated
   []
 []

--- a/test/tests/nek_stochastic/quiet_init/tests
+++ b/test/tests/nek_stochastic/quiet_init/tests
@@ -3,7 +3,7 @@
     type = RunCommand
     command = 'rm -rf .cache/'
     requirement = "The system shall clear the cache before attempting the test with another set of ranks."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     use_shell = True
   []
   [driver_multi_1]
@@ -17,13 +17,13 @@
                   "3 unique NekRS solves, without any restart or overlap of MPI communicators. We check that the values "
                   "are properly received in the scratch space by using that value to set a dummy scalar01. We purposefully "
                   "put this test in its own directory to prove that there are no requirements on precompilation."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [clear1]
     type = RunCommand
     command = 'rm -rf .cache/'
     requirement = "The system shall clear the cache before attempting the test with another set of ranks."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     use_shell = True
   []
   [driver_multi_2]
@@ -38,14 +38,14 @@
                   "3 unique NekRS solves, without any restart or overlap of MPI communicators. We check that the values "
                   "are properly received in the scratch space by using that value to set a dummy scalar01. We purposefully "
                   "put this test in its own directory to prove that there are no requirements on precompilation."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [clear2]
     type = RunCommand
     command = 'rm -rf .cache/'
     prereq = driver_multi_2
     requirement = "The system shall clear the cache before attempting the test with another set of ranks."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     use_shell = True
   []
   [driver_multi_3]
@@ -60,14 +60,14 @@
                   "3 unique NekRS solves, without any restart or overlap of MPI communicators. We check that the values "
                   "are properly received in the scratch space by using that value to set a dummy scalar01. We purposefully "
                   "put this test in its own directory to prove that there are no requirements on precompilation."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [clear3]
     type = RunCommand
     command = 'rm -rf .cache/'
     prereq = driver_multi_3
     requirement = "The system shall clear the cache before attempting the test with another set of ranks."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     use_shell = True
   []
   [driver_multi_4]
@@ -81,7 +81,7 @@
                   "3 unique NekRS solves, without any restart or overlap of MPI communicators. We check that the values "
                   "are properly received in the scratch space by using that value to set a dummy scalar01. We purposefully "
                   "put this test in its own directory to prove that there are no requirements on precompilation."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     skip = 'Need to resolve random failure'
   []
 []

--- a/test/tests/nek_stochastic/shift/tests
+++ b/test/tests/nek_stochastic/shift/tests
@@ -8,6 +8,6 @@
                   'this by using the first slot in the scratch space to set the value of scalar01, but use '
                   'the subsequent slots to obtain data from MOOSE. We show that the scalar01 is unaffected '
                   'by the Cardinal copy into the other part of the scratch space.'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_stochastic/tests
+++ b/test/tests/nek_stochastic/tests
@@ -9,7 +9,7 @@
                   "The values of the random variables are used to fill SCALAR02 with a constant value, which we "
                   "then measure by outputting the scalar and applying postprocessors to it. This confirms that "
                   "the random data we send to NekRS does correctly make it to device"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [driver_multi_fld]
     type = CheckFiles
@@ -25,7 +25,7 @@
     requirement = "The system shall stochastic values to be sent from MOOSE to NekRS and write unique "
                   "NekRS field files for each. By limiting this test to fewer MPI ranks than Apps, we "
                   "also check that we still get the correct naming scheme"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [read0]
     type = CSVDiff
@@ -38,7 +38,7 @@
                   "files created by the driver_multi_fld test into new NekRS runs (the read0, read1, "
                   "and read2 tests) tests as initial conditions "
                   "and check that the values of the loaded fields match the stochastic values sent there."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [read1]
     type = CSVDiff
@@ -52,7 +52,7 @@
                   "files created by the driver_multi_fld test into new NekRS runs (the read0, read1, "
                   "and read2 tests) tests as initial conditions "
                   "and check that the values of the loaded fields match the stochastic values sent there."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [read2]
     type = CSVDiff
@@ -66,6 +66,6 @@
                   "files created by the driver_multi_fld test into new NekRS runs (the read0, read1, "
                   "and read2 tests) tests as initial conditions "
                   "and check that the values of the loaded fields match the stochastic values sent there."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_temp/exact/tests
+++ b/test/tests/nek_temp/exact/tests
@@ -8,7 +8,7 @@
                   "for temperature on the nekRS side and then setting 'solver = none', we show "
                   "that the max/min error in that reconstructed temperature compared to a MOOSE "
                   "function of the same form is O(1e-16)."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [exact_volume_temperature]
     type = Exodiff
@@ -19,6 +19,6 @@
                   "for temperature on the nekRS side and then setting 'solver = none', we show "
                   "that the max/min error in that reconstructed temperature compared to a MOOSE "
                   "function of the same form is O(1e-16)."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_temp/first_order/tests
+++ b/test/tests/nek_temp/first_order/tests
@@ -10,7 +10,7 @@
                   "for temperature on the nekRS side and then setting 'solver = none', we show "
                   "that the max/min error in that reconstructed temperature compared to a MOOSE "
                   "function of the same form is O(1e-16)."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [first_order_volume_temperature]
     type = Exodiff
@@ -21,6 +21,6 @@
                   "for temperature on the nekRS side and then setting 'solver = none', we show "
                   "that the max/min error in that reconstructed temperature compared to a MOOSE "
                   "function of the same form is O(1e-16)."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_temp/second_order/tests
+++ b/test/tests/nek_temp/second_order/tests
@@ -10,7 +10,7 @@
                   "for temperature on the nekRS side and then setting 'solver = none', we show "
                   "that the max/min error in that reconstructed temperature compared to a MOOSE "
                   "function of the same form is O(1e-16)."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [second_order_volume_temperature]
     type = Exodiff
@@ -21,6 +21,6 @@
                   "for temperature on the nekRS side and then setting 'solver = none', we show "
                   "that the max/min error in that reconstructed temperature compared to a MOOSE "
                   "function of the same form is O(1e-16)."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/neutronics/adaptivity/tests
+++ b/test/tests/neutronics/adaptivity/tests
@@ -7,7 +7,7 @@
     input = cell.i
     exodiff = cell_out.e
     requirement = "The system shall allow problems which contain adaptivity on the mesh mirror for cell tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [adaptive_mesh]
     type = Exodiff
@@ -15,7 +15,7 @@
     exodiff = mesh_out.e
     mesh_mode = 'replicated'
     requirement = "The system shall allow problems which contain adaptivity on the mesh mirror for mesh tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [adaptive_mesh_template]
     type = RunException
@@ -25,7 +25,7 @@
     expect_err = "Adaptivity is not supported when loading a mesh from 'mesh_template'!"
     requirement = "The system shall error if adaptivity is active and tallying on a mesh template instead of the"
                    " mesh block."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [adaptive_relaxation]
     type = RunException
@@ -34,7 +34,7 @@
     expect_err = "When adaptivity is requested or a displaced problem is used, the mapping from the "
                  "OpenMC model to the \[Mesh\] may vary in time."
     requirement = "The system shall error if adaptivity is active and a relaxation scheme is requested."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []
 
@@ -48,7 +48,7 @@
     exodiff = unchanged_mesh_out.e
     mesh_mode = 'replicated'
     requirement = "The system shall skip running OpenMC when the mesh is unchanged by adaptivity."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [skip_openmc_unchanged_picard]
     type = Exodiff
@@ -57,6 +57,6 @@
     requirement = "The system shall run OpenMC on the first Picard iteration regardless of the mesh being previously"
                   "unchanged by adaptivity. This test relies on noise in the solution; if OpenMC runs more than once"
                   "per Picard iteration the PRNG seed changes and so the tally results will be different."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/dagmc/cell_tallies/tests
+++ b/test/tests/neutronics/dagmc/cell_tallies/tests
@@ -8,7 +8,7 @@
                   "input file run with the skinner disabled. The CSG file used for comparison is in "
                   "the csg_step_1 directory."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [skin]
     type = Exodiff
@@ -19,7 +19,7 @@
                   "as compared to a CSG-equivalent version of the geometry, which is in the csg_step_2 "
                   "directory."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [skin_null_density]
     type = Exodiff
@@ -28,7 +28,7 @@
     exodiff = openmc_out.e
     requirement = "The system shall give identical Monte Carlo solution (file mesh tallies and k) when skinning with a single density bin when compared to a case without any density skinning at all."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [scale_mesh]
     type = RunApp
@@ -44,7 +44,7 @@
     cli_args = 'Outputs/hide="cell_instance"'
     requirement = "The system shall give identical results when scaling the Mesh by an arbitrary multiplier. The gold file was compared against a case with no scaling (scaling = 1) to get identical results."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [unmapped_cells]
     type = RunException
@@ -54,6 +54,6 @@
                  " model maps one to one to the mesh mirror; if that is not the case the skinner may delete some parts of your "
                  "OpenMC model when the underlying geometry is regenerated. You have 1 unmapped DAGMC cells out of 3 DAGMC cells."
     requirement = "The system shall warn the user when there is a mismatch between the mesh mirror and the initial OpenMC DAGMC geometry."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/neutronics/dagmc/density_skin/tests
+++ b/test/tests/neutronics/dagmc/density_skin/tests
@@ -7,7 +7,7 @@
                   "by density as compared to a CSG-equivalent version of the geometry, which is in the csg_step_2 "
                   "directory."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [disjoint_bins]
     type = Exodiff
@@ -17,7 +17,7 @@
                   "as compared to a CSG-equivalent version of the geometry, which is in the csg_step_2 "
                   "directory. For this case, a bin is split across disjoint elements."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [cannot_skin_solid]
     type = RunException
@@ -25,6 +25,6 @@
     expect_err = "Detected inconsistent settings for density skinning and 'density_blocks'"
     requirement = "The system shall error if attempting to apply density skinning without any fluid blocks ready to receive variable density."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/neutronics/dagmc/incompatible_geom/mismatch/tests
+++ b/test/tests/neutronics/dagmc/incompatible_geom/mismatch/tests
@@ -8,6 +8,6 @@
     requirement = "The system shall error if there is an obvious mismatch between the [Mesh] and "
                   "DAGMC model for the case where the number of DAGMC materials which map to each "
                   "[Mesh] subdomain do not match."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/neutronics/dagmc/mesh_tallies/tests
+++ b/test/tests/neutronics/dagmc/mesh_tallies/tests
@@ -8,7 +8,7 @@
                   "input file run with the skinner disabled. The CSG file used for comparison is in "
                   "the csg_step_1 directory."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [skin]
     type = Exodiff
@@ -19,7 +19,7 @@
                   "as compared to a CSG-equivalent version of the geometry, which is in the csg_step_2 "
                   "directory."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [skin_direct]
     type = Exodiff
@@ -30,7 +30,7 @@
                   "as compared to a CSG-equivalent version of the geometry, which is in the csg_step_2 "
                   "directory."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [disjoint_bins]
     type = Exodiff
@@ -41,7 +41,7 @@
                   "as compared to a CSG-equivalent version of the geometry, which is in the csg_step_2 "
                   "directory. For this case, a bin is split across disjoint elements."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [scale_mesh]
     type = RunApp
@@ -57,6 +57,6 @@
     cli_args = 'Outputs/hide="cell_instance"'
     requirement = "The system shall give identical results when scaling the Mesh by an arbitrary multiplier. The gold file was compared against a case with no scaling (scaling = 1) to get identical results."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/neutronics/dagmc/tests
+++ b/test/tests/neutronics/dagmc/tests
@@ -4,7 +4,7 @@
     input = wrong_uo.i
     expect_err = "The 'skinner' user object must be of type MoabSkinner!"
     requirement = "The system shall error if the skinner user object is not the correct type"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [missing_graveyard]
     type = RunException
@@ -12,7 +12,7 @@
     cli_args = '--error'
     expect_err = "Overriding graveyard setting from false to true.\nTo hide this warning, set 'build_graveyard = true'"
     requirement = "The system shall warn if the graveyard is missing for OpenMC skinned models"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [no_symmetry]
     type = RunException
@@ -20,13 +20,13 @@
     expect_err = "Cannot combine the 'skinner' with 'symmetry_mapper'!"
     requirement = "The system shall error if applying a symmetry mapping to an OpenMC model which must "
                   "already exactly match the mesh."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [properties]
     type = RunException
     input = properties.i
     expect_err = "Cannot load initial temperature and density properties from HDF5 files"
     requirement = "The system shall error if loading properties from HDF5 for skinned problems"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/neutronics/dagmc/with_csg/dag_cell_not_root/tests
+++ b/test/tests/neutronics/dagmc/with_csg/dag_cell_not_root/tests
@@ -7,6 +7,6 @@
     requirement = "The system shall error if the cell containing the DAGMC universe is not contained in the "
                   "root universe. If so, we cannot guarantee that the DAGMC geometry is not replicated and "
                   "the skinner may produce an incorrect skin."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/neutronics/dagmc/with_csg/dag_lattice/tests
+++ b/test/tests/neutronics/dagmc/with_csg/dag_lattice/tests
@@ -5,6 +5,6 @@
     expect_err = "The 'skinner' cannot be used when the DAGMC universe is contained in lattice geometry."
     requirement = "The system shall error if the DAGMC universe is used as a lattice element. If so, the "
                   "DAGMC geometry may be replicated and so the skinner may produce an incorrect skin."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/neutronics/dagmc/with_csg/dag_lattice_outer/tests
+++ b/test/tests/neutronics/dagmc/with_csg/dag_lattice_outer/tests
@@ -5,6 +5,6 @@
     expect_err = "The 'skinner' cannot be used when the DAGMC universe is used as the outer universe of a lattice."
     requirement = "The system shall error if the DAGMC universe is used as a lattice element. If so, the "
                   "DAGMC geometry may be replicated and so the skinner may produce an incorrect skin."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/neutronics/dagmc/with_csg/mixed_feedback/tests
+++ b/test/tests/neutronics/dagmc/with_csg/mixed_feedback/tests
@@ -5,6 +5,6 @@
     expect_err = "At present, the 'skinner' can only be used when the only OpenMC geometry which maps to "
                  "the MOOSE mesh is DAGMC geometry. Your geometry contains CSG cells which map to the MOOSE mesh."
     requirement = "The system shall error if the user attempts to map both CSG and DAGMC geometry to the MOOSE mesh."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/neutronics/dagmc/with_csg/multi_cell_dag/tests
+++ b/test/tests/neutronics/dagmc/with_csg/multi_cell_dag/tests
@@ -6,6 +6,6 @@
                  "fill at most once."
     requirement = "The system shall error if the DAGMC universe is used by multiple cells. If so, the "
                   "DAGMC geometry is replicated and so the skinner will produce an incorrect skin."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/neutronics/dagmc/with_csg/multiple_dag/tests
+++ b/test/tests/neutronics/dagmc/with_csg/multiple_dag/tests
@@ -5,6 +5,6 @@
     expect_err = "The 'skinner' can only be used when the OpenMC geometry contains a single DAGMC universe."
     requirement = "The system shall error if there are more than one DAGMC universe. If so, the universe "
                   "to skin cannot be automatically determined."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/neutronics/dagmc/with_csg/tests
+++ b/test/tests/neutronics/dagmc/with_csg/tests
@@ -5,7 +5,7 @@
     csvdiff = openmc_out.csv
     requirement = "The system shall allow for the use of CSG and DAGMC geometry when using the MOABSkinner."
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
     skip = 'Non-deterministic!'
   []
 []

--- a/test/tests/neutronics/density/tests
+++ b/test/tests/neutronics/density/tests
@@ -4,7 +4,7 @@
     input = openmc.i
     exodiff = openmc_out.e
     requirement = "The system shall allow arbitrary combination of density-only, temperature-only, both, or no coupling. The file was compared against a standalone OpenMC run and gave identical values for k."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [warn_T_rho]
     type = RunException
@@ -12,7 +12,7 @@
     cli_args = 'Mesh/scale/vector_value="50.0 0.0 0.0" --error'
     expect_err = "The \[Mesh\] has 86 elements providing temperature and density feedback \(the elements in the intersection of 'temperature_blocks' and 'density_blocks'\), but only 0 got mapped to OpenMC cells."
     requirement = "The system shall give a warning when T+rho feedback is specified, but not all specified elements mapped into OpenMC"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [warn_T]
     type = RunException
@@ -20,7 +20,7 @@
     cli_args = 'Mesh/scale/vector_value="-50.0 0.0 0.0" --error'
     expect_err = "The \[Mesh\] has 94 elements providing temperature feedback \(the elements in 'temperature_blocks'\), but only 0 got mapped to OpenMC cells."
     requirement = "The system shall give a warning when T feedback is specified, but not all specified elements mapped into OpenMC"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [warn_rho]
     type = RunException
@@ -28,6 +28,6 @@
     cli_args = 'Mesh/scale/vector_value="0.0 -25.0 0.0" --error'
     expect_err = "The \[Mesh\] has 102 elements providing density feedback \(the elements in 'density_blocks'\), but only 0 got mapped to OpenMC cells."
     requirement = "The system shall give a warning when rho feedback is specified, but not all specified elements mapped into OpenMC"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/different_units/tests
+++ b/test/tests/neutronics/feedback/different_units/tests
@@ -8,7 +8,7 @@
                   "by ensuring exact agreement between two versions of the same problem - one with "
                   "a length scale of centimeters (openmc_master_cm.i), and the other with a length "
                   "scale of meters (openmc_master.i)."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [different_units_null_fixed_mesh]
     type = Exodiff
@@ -17,6 +17,6 @@
     cli_args = 'MultiApps/openmc/cli_args="Problem/fixed_mesh=false"'
     requirement = "The system shall correctly re-initialize the same mapping when the MooseMesh does not change "
                   "during a simulation."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/interchangeable/tests
+++ b/test/tests/neutronics/feedback/interchangeable/tests
@@ -6,7 +6,7 @@
     requirement = 'The system shall allow OpenMC tallies to be extracted on cell blocks which do not correspond to any '
                   'multiphysics feedback settings. The tallies were compared against separate standalone OpenMC runs to '
                   'confirm that the presence/absence of feedback does not change their values.'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [T_feedback_tally]
     type = CSVDiff
@@ -15,7 +15,7 @@
     csvdiff = T.csv
     requirement = 'The system shall allow OpenMC tallies to be extracted on cell blocks which also have temperature feedback.'
                   'The tallies were compared against separate standalone OpenMC runs.'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [rho_feedback_tally]
     type = CSVDiff
@@ -24,7 +24,7 @@
     csvdiff = rho.csv
     requirement = 'The system shall allow OpenMC tallies to be extracted on cell blocks which also have temperature/density feedback.'
                   'The tallies were compared against separate standalone OpenMC runs.'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [no_data_flow]
     type = CSVDiff
@@ -32,7 +32,7 @@
     csvdiff = no_data_flow_out.csv
     requirement = 'The system shall allow OpenMC to be run within Cardinal without any data transfers '
                   'in or out of the code.'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [T_feedback_no_tally]
     type = CSVDiff
@@ -41,7 +41,7 @@
     csvdiff = T_no_tally.csv
     requirement = 'The system shall allow OpenMC tallies to be extracted on cell blocks which also have temperature feedback.'
                   'The tallies were compared against separate standalone OpenMC runs.'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [rho_feedback_no_tally]
     type = CSVDiff
@@ -50,6 +50,6 @@
     csvdiff = rho_no_tally.csv
     requirement = 'The system shall allow OpenMC tallies to be extracted on cell blocks which also have temperature/density feedback.'
                   'The tallies were compared against separate standalone OpenMC runs.'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/lattice/tests
+++ b/test/tests/neutronics/feedback/lattice/tests
@@ -7,7 +7,7 @@
                   "and MOOSE and a solid pincell model when the model is set up with distributed cells. "
                   "The solution for temperature, density, and heat source show an exact agreement with "
                   "a case built without distributed cells in ../single_level."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [pincell_null_mat]
     type = Exodiff
@@ -18,7 +18,7 @@
                   "and MOOSE and a solid pincell model when the model is set up with distributed cells, "
                   "but with material feedback applied by material. The gold file is identical to a cell-based "
                   "feedback because we still have one unique material per cell."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [pincell_null_fixed_mesh]
     type = Exodiff
@@ -27,7 +27,7 @@
     cli_args = 'MultiApps/openmc/cli_args=Problem/fixed_mesh=false'
     requirement = "The system shall correctly re-initialize the same mapping when the MooseMesh does not change "
                   "during a simulation."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [heating]
     type = CSVDiff
@@ -35,7 +35,7 @@
     csvdiff = heating_out.csv
     cli_args = 'Outputs/file_base=heating_out'
     requirement = "The system shall allow the user to specify a 'heating' score in the OpenMC tally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [heating_local]
     type = CSVDiff
@@ -43,7 +43,7 @@
     csvdiff = heating_local_out.csv
     cli_args = 'Problem/Tallies/Cell/score=heating_local Outputs/file_base=heating_local_out'
     requirement = "The system shall allow the user to specify a 'heating-local' score in the OpenMC tally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [damage_energy]
     type = CSVDiff
@@ -51,7 +51,7 @@
     csvdiff = damage_energy_out.csv
     cli_args = "Problem/Tallies/Cell/score='damage_energy kappa_fission' Problem/Tallies/Cell/name='heat_source kappa_fission' Problem/source_rate_normalization=kappa_fission Outputs/file_base=damage_energy_out"
     requirement = "The system shall allow the user to specify a 'damage-energy' score in the OpenMC tally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [fission_q_prompt]
     type = CSVDiff
@@ -59,7 +59,7 @@
     csvdiff = fission_q_prompt_out.csv
     cli_args = 'Problem/Tallies/Cell/score=fission_q_prompt Outputs/file_base=fission_q_prompt_out'
     requirement = "The system shall allow the user to specify a 'fission-q-prompt' score in the OpenMC tally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [fission_q_recoverable]
     type = CSVDiff
@@ -67,7 +67,7 @@
     csvdiff = fission_q_recoverable_out.csv
     cli_args = 'Problem/Tallies/Cell/score=fission_q_recoverable Outputs/file_base=fission_q_recoverable_out'
     requirement = "The system shall allow the user to specify a 'fission-q-recoverable' score in the OpenMC tally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [duplicate_variable]
     type = RunException
@@ -75,13 +75,13 @@
     cli_args = "AuxVariables/heat_source/order=FIRST"
     expect_err = "Cardinal is trying to add an auxiliary variable named 'heat_source', but you already have a variable by this name."
     requirement = "The system shall error if the user adds a duplicate variable with a name Cardinal reserves for OpenMC coupling."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [nonmaterial_fluid]
     type = RunException
     input = non_material_fluid.i
     expect_err = "Density transfer does not currently support cells filled with universes or lattices!"
     requirement = "The system shall error if trying to set density in a cell filled by a universe or lattice."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/materials/tests
+++ b/test/tests/neutronics/feedback/materials/tests
@@ -6,6 +6,6 @@
     requirement = "The system shall allow density feedback in OpenMC models by material, as opposed to individual "
                   "cell mappings. This model was compared against an OpenMC standalone case where the density of "
                   "the water was manually set to the average value applied from MOOSE."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/multi_component_density/multi/tests
+++ b/test/tests/neutronics/feedback/multi_component_density/multi/tests
@@ -4,14 +4,14 @@
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall allow reading density from user-defined names, with one density variable per cell. Reference values were obtained by running OpenMC standalone."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_vars]
     type = CSVDiff
     input = multi_vars.i
     csvdiff = multi_vars_out.csv
     requirement = "The system shall allow reading density from user-defined names, with more than one density variable per cell"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_vars_alt]
     type = CSVDiff
@@ -19,6 +19,6 @@
     csvdiff = multi_vars_out.csv
     cli_args = "Outputs/file_base=multi_vars_out"
     requirement = "The system shall allow lumping of subdomains together, equivalent to explicitly listing density correspondence to blocks"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/multi_component_density/tests
+++ b/test/tests/neutronics/feedback/multi_component_density/tests
@@ -4,7 +4,7 @@
     input = openmc_incorrect_length.i
     expect_err = "'density_variables' and 'density_blocks' must be the same length!"
     requirement = "The system shall error if the blocks and variables are not the same length"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [empty]
     type = RunException
@@ -12,7 +12,7 @@
     cli_args = 'Problem/density_blocks=" ; 2"'
     expect_err = "Entries in 'density_blocks' cannot be empty!"
     requirement = "The system shall error if a sub-vector is empty"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_temp]
     type = RunException
@@ -20,7 +20,7 @@
     cli_args = 'Problem/density_variables="density1 density2; density3"'
     expect_err = "Each entry in 'density_variables' must be of length 1. Entry 0 is of length 2."
     requirement = "The system shall error if an entry in density_variables is not of unity length"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [block_already_used]
     type = RunException
@@ -28,6 +28,6 @@
     cli_args = 'Problem/density_variables="solid_density; solid_density; solid_density; solid_density" Problem/density_blocks="1; 2; 2; 3"'
     expect_err = "Subdomains cannot be repeated in 'density_blocks'! Subdomain '2' is duplicated."
     requirement = "The system shall error if trying to collate multiple density variables onto the same block due to undefined behavior"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/multi_component_temp/tests
+++ b/test/tests/neutronics/feedback/multi_component_temp/tests
@@ -4,7 +4,7 @@
     input = openmc_incorrect_length.i
     expect_err = "'temperature_variables' and 'temperature_blocks' must be the same length!"
     requirement = "The system shall error if the blocks and variables are not the same length"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [empty]
     type = RunException
@@ -12,7 +12,7 @@
     cli_args = 'Problem/temperature_blocks=" ; 2"'
     expect_err = "Entries in 'temperature_blocks' cannot be empty!"
     requirement = "The system shall error if a sub-vector is empty"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_temp]
     type = RunException
@@ -20,7 +20,7 @@
     cli_args = 'Problem/temperature_variables="solid_temp solid_temp; fluid_temp"'
     expect_err = "Each entry in 'temperature_variables' must be of length 1. Entry 0 is of length 2."
     requirement = "The system shall error if an entry in temperature_variables is not of unity length"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [block_already_used]
     type = RunException
@@ -28,21 +28,21 @@
     cli_args = 'Problem/temperature_variables="solid_temp; solid_temp; solid_temp; solid_temp" Problem/temperature_blocks="1; 2; 2; 3"'
     expect_err = "Subdomains cannot be repeated in 'temperature_blocks'! Subdomain '2' is duplicated."
     requirement = "The system shall error if trying to collate multiple temperature variables onto the same block due to undefined behavior"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [collate_temps]
     type = CSVDiff
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall allow reading temperature from user-defined names, with one temperature variable per cell"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_vars]
     type = CSVDiff
     input = multi_vars.i
     csvdiff = multi_vars_out.csv
     requirement = "The system shall allow reading temperature from user-defined names, with more than one temperature variable per cell"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_vars_alt]
     type = CSVDiff
@@ -50,6 +50,6 @@
     csvdiff = multi_vars_out.csv
     cli_args = "Problem/temperature_variables='solid_temp; solid_temp; fluid_temp; other_temp' Problem/temperature_blocks='1; 3; 2; 10'"
     requirement = "The system shall allow lumping of subdomains together, equivalent to explicitly listing temperature correspondence to blocks"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/multiple_levels/tests
+++ b/test/tests/neutronics/feedback/multiple_levels/tests
@@ -8,6 +8,6 @@
                   "This input sets up a pincell with lattices where all cells of interest are on level 1. "
                   "Surrounding this pincell is an exterior cell on level 0. Cell IDs, instances, and temperatures "
                   "all correctly reflect using the lowest available level in the exterior region."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/single_level/tests
+++ b/test/tests/neutronics/feedback/single_level/tests
@@ -5,7 +5,7 @@
     exodiff = 'openmc_master_out.e openmc_master_out_openmc0.e'
     requirement = "Temperatures, densities, and a heat source shall be coupled between OpenMC "
                   "and MOOSE and a solid pincell model."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [pincell_null_fixed_mesh]
     type = Exodiff
@@ -14,6 +14,6 @@
     cli_args = 'MultiApps/openmc/cli_args="Problem/fixed_mesh=false"'
     requirement = "The system shall correctly re-initialize the same mapping when the MooseMesh does not change "
                   "during a simulation."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/temperature/one_one/tests
+++ b/test/tests/neutronics/feedback/temperature/one_one/tests
@@ -4,6 +4,6 @@
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall exactly predict eigenvalue when sending temperatures which map 1:1 between subdomain and cell to OpenMC. We compare against a standalone OpenMC case to exactly match k."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/temperature/one_two/tests
+++ b/test/tests/neutronics/feedback/temperature/one_two/tests
@@ -4,6 +4,6 @@
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall exactly predict eigenvalue when sending temperatures which map from one subdomain to multiple cells. We compare against a standalone OpenMC case to exactly match k."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/temperature/two_one/tests
+++ b/test/tests/neutronics/feedback/temperature/two_one/tests
@@ -4,7 +4,7 @@
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall exactly predict eigenvalue when sending temperatures which map from multiple subdomains to one cell. We compare against a standalone OpenMC case to exactly match k."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [two_to_one_multi]
     type = CSVDiff
@@ -12,7 +12,7 @@
     cli_args = 'Outputs/file_base=openmc_out'
     csvdiff = openmc_out.csv
     requirement = "The system shall exactly predict eigenvalue when sending temperatures which map from multiple subdomains to one cell, when different temperature variables are used on each subdomain. This gold file exactly matches that used in the 'two_to_one' test."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [default]
     type = CSVDiff
@@ -20,6 +20,6 @@
     cli_args = 'Outputs/file_base=openmc_out'
     csvdiff = openmc_out.csv
     requirement = "The system shall exactly predict eigenvalue when sending temperatures which map from multiple subdomains to one cell, when using the default name of 'temp' for the temperature field."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/triso/cache/tests
+++ b/test/tests/neutronics/feedback/triso/cache/tests
@@ -7,7 +7,7 @@
     requirement = "The system shall allow any cell which maps to a particular subdomain to be set with an identical "
                   "cell fill. Here, the gold files were created using an input which does not use this feature "
                   "(which we also compare to a standalone OpenMC run)."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [warn_unused]
     type = RunException
@@ -16,6 +16,6 @@
     expect_err = "You specified 'identical_cell_fills', but all cells which mapped to these subdomains"
     requirement = "The system shall warn the user if the identical cell fill is unused because all mapped "
                   "cells are simple, material-fills."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/triso/different_fill_univs/tests
+++ b/test/tests/neutronics/feedback/triso/different_fill_univs/tests
@@ -5,7 +5,7 @@
     expect_err = "Not all cells contain cell ID 2."
     requirement = "The system shall error if trying to utilize identical cell fills "
                   "but the filling cell IDs are not identical among the cells"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [non_solid]
     type = RunException
@@ -13,7 +13,7 @@
     cli_args = 'Problem/temperature_blocks="1 2" Problem/density_blocks="2" Problem/identical_cell_fills="2"'
     expect_err = "Entries in 'identical_cell_fills' cannot be contained in 'density_blocks'"
     requirement = "The system shall error if trying to utilize identical cell fills for a non-solid block"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [inconsistent_map]
     type = RunException
@@ -22,6 +22,6 @@
     expect_err = "Cell id 22, instance  0 \(of  1\) mapped to inconsistent 'identical_cell_fills' settings.\n"
                  "Subdomain 2 is in 'identical_cell_fills', but 1 is not."
     requirement = "The system shall error if inconsistent settings are applied for the identical cell mapping"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/triso/missing_triso_fill/tests
+++ b/test/tests/neutronics/feedback/triso/missing_triso_fill/tests
@@ -5,6 +5,6 @@
     expect_err = "The cell caching failed to get correct instances for material cell ID 1302"
     requirement = "The system shall error if the single-increment applied to the tally cell contained "
                   "material instances fails, such as when a TRISO universe is not being tallied."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/universes/fill_in_flat/tests
+++ b/test/tests/neutronics/feedback/universes/fill_in_flat/tests
@@ -4,6 +4,6 @@
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = 'The system shall correctly apply unique temperature feedback to an identical universe filled into multiple (non-lattice) cells. The reference solution from an identical OpenMC-only case is in the standalone directory.'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/universes/lattice_in_flat/tests
+++ b/test/tests/neutronics/feedback/universes/lattice_in_flat/tests
@@ -4,6 +4,6 @@
     input = openmc.i
     expect_err = "Cell 10, instance 0 has already had its temperature set by Cardinal to 625"
     requirement = "The system shall error if Cardinal tries to change the temperature of a given OpenMC cell more than once, since this indicates a problem with model setup."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/feedback/unmapped_moose/tests
+++ b/test/tests/neutronics/feedback/unmapped_moose/tests
@@ -4,6 +4,6 @@
     input = openmc_master.i
     exodiff = 'openmc_master_out.e openmc_master_out_openmc0.e'
     requirement = "OpenMC postprocessors shall evaluate to -1 for unmapped MOOSE elements."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/filters/azimuthal/tests
+++ b/test/tests/neutronics/filters/azimuthal/tests
@@ -6,7 +6,7 @@
     cli_args = 'Problem/Filters/Azimuthal/azimuthal_angle_boundaries="${fparse -pi} 0.0 ${fparse pi}" Outputs/file_base=cell_provided_out'
     requirement = "The system shall be capable of adding an AzimuthalAngleFilter to a CellTally with bins that are provided. "
                   "This test also ensures the binned fluxes sum to the total flux through the use of global normalization."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [azimuthal_cell_equally_spaced_bins]
     type = CSVDiff
@@ -15,14 +15,14 @@
     cli_args = 'Problem/Filters/Azimuthal/num_equal_divisions=2 Outputs/file_base=cell_equal_out'
     requirement = "The system shall be capable of adding an AzimuthalAngleFilter to a CellTally with equally spaced bins. "
                   "This test also ensures the binned fluxes sum to the total flux through the use of global normalization."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [azimuthal_mesh]
     type = CSVDiff
     input = mesh.i
     csvdiff = mesh_out.csv
     requirement = "The system shall be capable of adding an AzimuthalAngleFilter to a MeshTally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [bin_sum]
     type = Exodiff
@@ -31,7 +31,7 @@
     requirement = "The system shall correctly compute azimuthal binned fluxes with mesh tallies such that the "
                   "sum of the flux over each bin equals the total flux. The gold file was generated "
                   "with an input file that scored the flux without a AzimuthalAngleFilter."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [not_enough_provided_bnds]
     type = RunException
@@ -39,7 +39,7 @@
     cli_args = 'Problem/Filters/Azimuthal/azimuthal_angle_boundaries="0.0"'
     expect_err = 'At least two azimuthal angles are required to create bins!'
     requirement = "The system shall error if 'azimuthal_angle_boundaries' doesn't contain enough boundaries to form bins."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [bnds_wrong_order]
     type = CSVDiff
@@ -47,7 +47,7 @@
     cli_args = 'Problem/Filters/Azimuthal/azimuthal_angle_boundaries="${fparse pi} 0.0 ${fparse -pi}" Outputs/file_base=cell_provided_out'
     csvdiff = cell_provided_out.csv
     requirement = "The system shall automatically sort bins to ensure they're monotonically increasing."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [no_bins]
     type = RunException
@@ -56,7 +56,7 @@
                  "specified a bin option! Please specify either 'num_equal_divisions' or "
                  "'azimuthal_angle_boundaries'."
     requirement = "The system shall error if neither 'num_equal_divisions' or 'azimuthal_angle_boundaries' are provided."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [both_bins]
     type = RunException
@@ -66,6 +66,6 @@
                  "specified a bin option! Please specify either 'num_equal_divisions' or "
                  "'azimuthal_angle_boundaries'."
     requirement = "The system shall error if both 'num_equal_divisions' and 'azimuthal_angle_boundaries' are provided."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/filters/energy/tests
+++ b/test/tests/neutronics/filters/energy/tests
@@ -7,7 +7,7 @@
     requirement = "The system shall be capable of adding an EnergyFilter (with energy boundaries provided) "
                   "to a CellTally. This test also ensures multi-group fluxes sum to the total flux for "
                   "cell tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [energy_cell_structure]
     type = CSVDiff
@@ -17,14 +17,14 @@
     requirement = "The system shall be capable of adding an EnergyFilter (with a group structure) "
                   "to a CellTally. This test also ensures multi-group fluxes sum to the total flux for "
                   "cell tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [energy_mesh]
     type = CSVDiff
     input = mesh.i
     csvdiff = mesh_out.csv
     requirement = "The system shall be capable of adding an EnergyFilter to a MeshTally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [group_sum]
     type = Exodiff
@@ -33,7 +33,7 @@
     requirement = "The system shall correctly compute multi-group fluxes with mesh tallies such that the "
                   "sum of the flux over each group equals the total flux. The gold file was generated "
                   "with an input file that scored the flux without an EnergyFilter."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [not_enough_bnds]
     type = RunException
@@ -41,7 +41,7 @@
     cli_args = 'Problem/Filters/Energy/energy_boundaries="1.0"'
     expect_err = "At least two energy values are required to create energy bins!"
     requirement = "The system shall error if there aren't enough energy boundaries to form an EnergyTally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [bnds_wrong_order]
     type = CSVDiff
@@ -49,7 +49,7 @@
     cli_args = 'Problem/Filters/Energy/energy_boundaries="2.0e7 6.25e-1 0.0"'
     csvdiff = cell_out.csv
     requirement = "The system shall automatically sort bins to ensure they're monotonically increasing."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_bins]
     type = RunException
@@ -58,7 +58,7 @@
                  "specified a bin option. Please specify either 'energy_boundaries' or "
                  "'group_structure'."
     requirement = "The system shall error if no energy bins are provided."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [both_bins]
     type = RunException
@@ -68,7 +68,7 @@
                  "specified a bin option. Please specify either 'energy_boundaries' or "
                  "'group_structure'."
     requirement = "The system shall error if no energy bins are provided."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [duplicate_bnds]
     type = RunException
@@ -76,7 +76,7 @@
     cli_args = 'Problem/Filters/Energy/energy_boundaries="0.0 6.25e-1 6.25e-1 2.0e7"'
     expect_err = "You have added duplicate energy boundaries!"
     requirement = "The system shall error if duplicate energy boundaries are provided."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [negative_bnds]
     type = RunException
@@ -84,6 +84,6 @@
     cli_args = 'Problem/Filters/Energy/energy_boundaries="-1.0 0.0 6.25e-1 2.0e7"'
     expect_err = "Energy group boundaries must be positive to create energy bins!"
     requirement = "The system shall error if negative energy boundaries are provided."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/filters/energy_out/tests
+++ b/test/tests/neutronics/filters/energy_out/tests
@@ -8,7 +8,7 @@
     csvdiff = cell_out.csv
     cli_args = 'Problem/Filters/EnergyOut/energy_boundaries="0.0 6.25e-1 2.0e7"'
     requirement = "The system shall be capable of adding an EnergyOutFilter (with energy boundaries provided)."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [energy_cell_structure]
     type = CSVDiff
@@ -16,7 +16,7 @@
     csvdiff = cell_out.csv
     cli_args = 'Problem/Filters/EnergyOut/group_structure=CASMO_2'
     requirement = "The system shall be capable of adding an EnergyOutFilter (with a group structure)."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [force_analog]
     type = RunException
@@ -24,6 +24,6 @@
     cli_args = 'Problem/Filters/EnergyOut/group_structure=CASMO_2 Problem/Tallies/Scattering/estimator=collision'
     expect_err = "The filter EnergyOut requires an analog estimator!"
     requirement = "The system shall error if the user attempts to use a non-analog estimator with an EnergyOutFilter."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/filters/legendre/tests
+++ b/test/tests/neutronics/filters/legendre/tests
@@ -7,7 +7,7 @@
     input = cell.i
     csvdiff = cell_out.csv
     requirement = "The system shall support Legendre filters in the scattering angle."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [l0_in_l1_vs_no_legendre]
     type = CSVDiff
@@ -16,7 +16,7 @@
     requirement = "The L0 Legendre moment in a L>0 Legendre expansion shall match the scattering reaction rate computed "
                   "without a Legendre filter. This ensures that the L>0 Legendre moments are skipped during normalization."
                   "The gold file for this test was generated without a Legendre filter."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [force_analog]
     type = RunException
@@ -24,6 +24,6 @@
     cli_args = 'Problem/Tallies/Scattering/estimator=collision'
     expect_err = "The filter Legendre requires an analog estimator!"
     requirement = "The system shall error if the user attempts to use a non-analog estimator with an AngularLegendreFilter."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/filters/particle/tests
+++ b/test/tests/neutronics/filters/particle/tests
@@ -7,6 +7,6 @@
     input = cell.i
     csvdiff = cell_out.csv
     requirement = "The system shall be capable of adding a ParticleFilter for all particle types supported in OpenMC."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/filters/polar/tests
+++ b/test/tests/neutronics/filters/polar/tests
@@ -6,7 +6,7 @@
     cli_args = 'Problem/Filters/Polar/polar_angle_boundaries="0.0 1.5708 ${fparse pi}" Outputs/file_base=cell_provided_out'
     requirement = "The system shall be capable of adding an PolarAngleFilter to a CellTally with bins that are provided. "
                   "This test also ensures the binned fluxes sum to the total flux through the use of global normalization."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [polar_cell_equally_spaced_bins]
     type = CSVDiff
@@ -15,14 +15,14 @@
     cli_args = 'Problem/Filters/Polar/num_equal_divisions=2 Outputs/file_base=cell_equal_out'
     requirement = "The system shall be capable of adding an PolarAngleFilter to a CellTally with equally spaced bins. "
                   "This test also ensures the binned fluxes sum to the total flux through the use of global normalization."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [polar_mesh]
     type = CSVDiff
     input = mesh.i
     csvdiff = mesh_out.csv
     requirement = "The system shall be capable of adding an PolarAngleFilter to a MeshTally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [bin_sum]
     type = Exodiff
@@ -31,7 +31,7 @@
     requirement = "The system shall correctly compute polar binned fluxes with mesh tallies such that the "
                   "sum of the flux over each bin equals the total flux. The gold file was generated "
                   "with an input file that scored the flux without a PolarAngleFilter."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [not_enough_provided_bnds]
     type = RunException
@@ -39,7 +39,7 @@
     cli_args = 'Problem/Filters/Polar/polar_angle_boundaries="0.0"'
     expect_err = 'At least two polar angles are required to create bins!'
     requirement = "The system shall error if 'polar_angle_boundaries' doesn't contain enough boundaries to form bins."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [bnds_wrong_order]
     type = CSVDiff
@@ -47,7 +47,7 @@
     cli_args = 'Problem/Filters/Polar/polar_angle_boundaries="${fparse pi} 1.5708 0.0" Outputs/file_base=cell_provided_out'
     csvdiff = cell_provided_out.csv
     requirement = "The system shall automatically sort bins to ensure they're monotonically increasing."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [no_bins]
     type = RunException
@@ -56,7 +56,7 @@
                  "specified a bin option! Please specify either 'num_equal_divisions' or "
                  "'polar_angle_boundaries'."
     requirement = "The system shall error if neither 'num_equal_divisions' or 'polar_angle_boundaries' are provided."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [both_bins]
     type = RunException
@@ -66,6 +66,6 @@
                  "specified a bin option! Please specify either 'num_equal_divisions' or "
                  "'polar_angle_boundaries'."
     requirement = "The system shall error if both 'num_equal_divisions' and 'polar_angle_boundaries' are provided."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/filters/sh/tests
+++ b/test/tests/neutronics/filters/sh/tests
@@ -7,14 +7,14 @@
     input = openmc_l1.i
     csvdiff = openmc_l1_out.csv
     requirement = "The system shall support spherical harmonics filters."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [sh_l1_mult]
     type = CSVDiff
     input = openmc_l1_mult.i
     csvdiff = openmc_l1_mult_out.csv
     requirement = "The system shall support spherical harmonics filters composed with other filters."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [sh_l0_in_l1_vs_no_sh]
     type = CSVDiff
@@ -23,6 +23,6 @@
     requirement = "The L0 spherical harmonics moment in a L>0 SH expansion shall match the scalar fluxes computed "
                   "without a spherical harmonics filter. This ensures that the L>0 SH moments are skipped during normalization."
                   "The gold file for this test was generated without a SH filter."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/filters/tests
+++ b/test/tests/neutronics/filters/tests
@@ -4,7 +4,7 @@
     input = multi_filter.i
     csvdiff = multi_filter_out.csv
     requirement = "The system shall support multiple filters within a tally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [no_norm_score]
     type = CSVDiff
@@ -12,7 +12,7 @@
     csvdiff = filter_no_norm_score_out.csv
     requirement = "The system shall support the automatic addition of the requested source rate normalization score to a single tally when"
                   " using filters."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_filter]
     type = RunException
@@ -20,13 +20,13 @@
     cli_args = 'Problem/Tallies/Flux/filters="blank"'
     expect_err = "Filter with the name blank does not exist!"
     requirement = "The system shall error if a non-existent filter is requested by a tally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [wrong_problem]
     type = RunException
     input = wrong_problem.i
     expect_err = "The simulation must use an OpenMCCellAverageProblem when using the filter system!"
     requirement = "The system shall error if a filter is added when an OpenMCCellAverageProblem is not present."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/filters/xml/tests
+++ b/test/tests/neutronics/filters/xml/tests
@@ -4,14 +4,14 @@
     input = cell.i
     csvdiff = cell_out.csv
     requirement = "The system shall allow cell tallies to access filters added in the OpenMC tallies XML file."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [arbitrary_mesh]
     type = CSVDiff
     input = mesh.i
     csvdiff = mesh_out.csv
     requirement = "The system shall allow mesh tallies to access filters added in the OpenMC tallies XML file."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_filter]
     type = RunException
@@ -20,7 +20,7 @@
     expect_err = "A filter with the id 30 does not exist in the OpenMC model! Please make sure the filter has been added "
                  "in the OpenMC model and you've supplied the correct filter id."
     requirement = "The system shall error if a filter with the id requested has not been added by the tallie xml file."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [spatial_filter_error]
     type = RunException
@@ -30,7 +30,7 @@
                  "spatial filters from the OpenMC XML files because they would clash with the OpenMC -> MOOSE mapping "
                  "performed by Cardinal's tally objects."
     requirement = "The system shall error if the user selects a spatial filter."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [func_exp_warning]
     type = RunException
@@ -40,7 +40,7 @@
                  "as the sum over all tally bins may not be well posed if any bins contain functional expansion coefficients."
     requirement = "The system shall warn the user if they have selected a functional expansion filter and set "
                   "allow_expansion_filters = true."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [func_exp_error]
     type = RunException
@@ -52,6 +52,6 @@
                  "'allow_expansion_filters' to true."
     requirement = "The system shall error if the user selected a functional expansion filter without setting "
                   "allow_expansion_filters = true."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/fixed_source/tests
+++ b/test/tests/neutronics/fixed_source/tests
@@ -5,7 +5,7 @@
     csvdiff = overlap_all_out.csv
     requirement = "The system shall correctly normalize tallies from a fixed source simulation when there "
                   "is perfect overlap between the OpenMC model and the MOOSE mesh."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [normalize_unused]
     type = RunException
@@ -14,7 +14,7 @@
     expect_err = "When running OpenMC in fixed source mode, the 'normalize_by_global_tally' parameter is unused"
     requirement = "The system shall notify the user that the settings related to normalizing by global "
                   "or local tallies are inconsequential for fixed source mode."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_power]
     type = RunException
@@ -23,7 +23,7 @@
     expect_err = "kappa-fission tallies do not match the global kappa-fission tally"
     requirement = "The system shall error if the total tally sum does not match the system-wide value for "
                   "fixed source simulations."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [overlap_solid]
     type = CSVDiff
@@ -31,13 +31,13 @@
     csvdiff = overlap_solid_out.csv
     requirement = "The system shall correctly normalize tallies from a fixed source simulation when there "
                   "is only partial overlap between the OpenMC model and MOOSE domain."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [flux]
     type = CSVDiff
     input = flux.i
     csvdiff = flux_out.csv
     requirement = "The system shall correctly normalize flux tallies for fixed source simulations."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/flux/tests
+++ b/test/tests/neutronics/flux/tests
@@ -4,7 +4,7 @@
     input = flux.i
     csvdiff = flux_out.csv
     requirement = "The system shall correctly normalize flux tallies for eigenvalue simulations."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [flip_order]
     type = CSVDiff
@@ -12,7 +12,7 @@
     cli_args = 'Problem/Tallies/Cell/score="flux heating"'
     csvdiff = flux_out.csv
     requirement = "The system shall correctly normalize flux tallies for eigenvalue simulations when listed in an arbitrary order."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [flip_order_and_name]
     type = CSVDiff
@@ -20,7 +20,7 @@
     cli_args = 'Problem/Tallies/Cell/score="flux heating" Problem/Tallies/Cell/name="flux0 heating0" Postprocessors/flux_pebble1/variable=flux0 Postprocessors/flux_pebble2/variable=flux0 Postprocessors/flux_pebble3/variable=flux0 Postprocessors/flux_fluid/variable=flux0 Problem/source_rate_normalization="heating"'
     csvdiff = flux_out.csv
     requirement = "The system shall correctly normalize flux tallies for eigenvalue simulations when listed in an arbitrary order and with user-defined names."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [not_already_added]
     type = CSVDiff
@@ -28,7 +28,7 @@
     cli_args = 'Problem/Tallies/Cell/score="flux" Problem/source_rate_normalization=heating'
     csvdiff = flux_out.csv
     requirement = "The system shall correctly normalize flux tallies for eigenvalue simulations when the source rate normalization tally is not already added."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_name]
     type = RunException
@@ -37,13 +37,13 @@
     expect_err = "When specifying 'name', the score indicated in 'source_rate_normalization' must be\n"
                  "listed in 'score' so that we know what you want to name that score \(heating\)"
     requirement = "The system shall error if the user tries to name only a partial set of the total tally scores."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_norm]
     type = RunException
     input = missing_norm.i
     expect_err = "When using a non-heating tally \(flux, H3_production\) in eigenvalue mode"
     requirement = "The system shall error if the user omits the required normalization tally for non-heating scores in eigenvalue mode"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/gen_mgxs/mgxs_aux/tests
+++ b/test/tests/neutronics/gen_mgxs/mgxs_aux/tests
@@ -10,7 +10,7 @@
       input = mg_diffusion_coeff.i
       csvdiff = mg_diffusion_coeff_out.csv
       detail = "The system shall calculate multi-group particle diffusion coefficients."
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
     [catch_zero_flux]
       type = CSVDiff
@@ -19,7 +19,7 @@
       cli_args = "Outputs/file_base='diff_zero_flux_out' AuxKernels/comp_diff_g1/scalar_flux='zero_flux'"
       detail = "The system shall prevent divide by zeros when calculating multi-group diffusion coefficients. "
                "This also checks for cases where the transport cross section is zero."
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
   []
 
@@ -32,7 +32,7 @@
       input = mg_tc_scatter_xs.i
       csvdiff = mg_tc_scatter_xs_out.csv
       detail = "The system shall calculate multi-group transport corrected P0 scattering cross sections."
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
     [catch_zero_flux]
       type = CSVDiff
@@ -40,7 +40,7 @@
       csvdiff = zero_flux_out.csv
       cli_args = "Outputs/file_base='zero_flux_out' AuxKernels/comp_scatter_g1_g1_l0/scalar_flux='zero_flux'"
       detail = "The system shall prevent divide by zeros when calculating transport corrected P0 scattering cross sections."
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
   []
 
@@ -53,7 +53,7 @@
       input = generic_mgxs.i
       csvdiff = generic_mgxs_out.csv
       detail = "The system shall calculate multi-group cross sections using an arbitrary reaction rate and normalization factor."
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
     [catch_zero_flux]
       type = CSVDiff
@@ -61,7 +61,7 @@
       csvdiff = zero_flux_out.csv
       cli_args = "Outputs/file_base='zero_flux_out' AuxKernels/comp_total_g1/normalize_by='zero_flux'"
       detail = "The system shall prevent divide by zeros when calculating cross sections."
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
   []
 []

--- a/test/tests/neutronics/gen_mgxs/photon_xs/tests
+++ b/test/tests/neutronics/gen_mgxs/photon_xs/tests
@@ -7,6 +7,6 @@
     input = mgxs_photon.i
     csvdiff = mgxs_photon_out.csv
     requirement = "The system shall be capable of setting up MGXS generation for all relevant cross section types for photon."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/gen_mgxs/tests
+++ b/test/tests/neutronics/gen_mgxs/tests
@@ -7,21 +7,21 @@
     input = all_mgxs_cell.i
     csvdiff = all_mgxs_cell_out.csv
     requirement = "The system shall be capable of setting up MGXS generation for all relevant cross section types using mapped distributed cell tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [l0_scatter_no_tc]
     type = CSVDiff
     input = all_mgxs_cell_l0.i
     csvdiff = all_mgxs_cell_l0_out.csv
     requirement = "The system shall be capable of generating L = 0 scattering cross sections without a transport correction."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [l1_scatter]
     type = CSVDiff
     input = all_mgxs_cell_l1.i
     csvdiff = all_mgxs_cell_l1_out.csv
     requirement = "The system shall be capable of generating L > 0 scattering MGXS generation."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [collision]
     type = CSVDiff
@@ -29,7 +29,7 @@
     cli_args = "Problem/MGXS/estimator='collision' Outputs/file_base='collision_out'"
     csvdiff = collision_out.csv
     requirement = "The system shall be capable of generating certain multi-group cross sections with a collision estimator."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [tracklength]
     type = CSVDiff
@@ -37,7 +37,7 @@
     cli_args = "Problem/MGXS/estimator='tracklength' Outputs/file_base='tracklength_out'"
     csvdiff = tracklength_out.csv
     requirement = "The system shall be capable of generating certain multi-group cross sections with a tracklength estimator."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [all_mesh]
     type = CSVDiff
@@ -45,14 +45,14 @@
     csvdiff = all_mgxs_mesh_out.csv
     mesh_mode = 'replicated'
     requirement = "The system shall be capable of setting up MGXS generation for all relevant cross section types using unstructured mesh tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [hide_tally_vars]
     type = Exodiff
     input = hide_tally_vars.i
     exodiff = hide_tally_vars_out.e
     requirement = "The system shall be hide tally variables added for MGXS generation unless requested by the user."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [electron]
     type = RunException
@@ -60,7 +60,7 @@
     cli_args = "Problem/MGXS/particle='electron'"
     expect_err = "Multi-group cross sections can only be generated for neutrons or photons."
     requirement = "The system shall error if the user requests electron cross sections."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [positron]
     type = RunException
@@ -68,7 +68,7 @@
     cli_args = "Problem/MGXS/particle='positron'"
     expect_err = "Multi-group cross sections can only be generated for neutrons or photons."
     requirement = "The system shall error if the user requests positron cross sections."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [photon_fission_xs]
     type = RunException
@@ -76,7 +76,7 @@
     cli_args = "Problem/MGXS/particle='photon' Problem/MGXS/add_fission_heating='false'"
     expect_err = "Multi-group fission cross sections"
     requirement = "The system shall error if the user requests photon cross sections and includes fission."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [photon_fission_heating]
     type = RunException
@@ -84,7 +84,7 @@
     cli_args = "Problem/MGXS/particle='photon' Problem/MGXS/add_fission='false'"
     expect_err = "Multi-group fission heating"
     requirement = "The system shall error if the user requests photon cross sections and includes fission."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [l1_scatter_with_transport_corr]
     type = RunException
@@ -92,7 +92,7 @@
     cli_args = "--error Problem/MGXS/transport_correction=true"
     expect_err = "Transport-corrected scattering cross sections can only be used with isotropic scattering"
     requirement = "The system shall warn the user if they request transport corrected scattering cross sections with L > 0."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [error_mesh_with_tracklength]
     type = RunException
@@ -100,7 +100,7 @@
     cli_args = "--error Problem/MGXS/estimator='tracklength'"
     expect_err = "You've selected an unstructured mesh tally discretization"
     requirement = "The system shall warn the user if they select a mesh tally and request a tracklength estimator."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [error_non_analog]
     type = RunException
@@ -109,6 +109,6 @@
     expect_err = "You've requested the generation of scattering"
     requirement = "The system shall warn the user if they wish to generate scattering / fission / diffusion group properties"
                   " without an analog estimator."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/heat_source/distrib_cell/tests
+++ b/test/tests/neutronics/heat_source/distrib_cell/tests
@@ -9,6 +9,6 @@
     max_parallel = 4
     requirement = "The heat source shall be correctly mapped if the solid cell level is not "
                   "the highest level."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/heat_source/tests
+++ b/test/tests/neutronics/heat_source/tests
@@ -9,7 +9,7 @@
     max_parallel = 8
     requirement = "The heat source shall be extracted and normalized correctly from OpenMC "
                   "for perfect model overlap with fissile fluid and solid phases."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [from_postprocessor]
     type = Exodiff
@@ -24,7 +24,7 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The power shall be provided by a postprocessor"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [overlap_solid]
     type = CSVDiff
@@ -36,7 +36,7 @@
     requirement = "The heat source shall be extracted and normalized correctly from OpenMC "
                   "for perfect model overlap with fissile fluid and solid phases, but "
                   "heat source coupling only performed for the solid phase."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [custom_name]
     type = CSVDiff
@@ -47,7 +47,7 @@
     max_parallel = 8
     requirement = "The system shall allow the user to specify a custom tally variable name. This test is "
                   "identical to the overlap_solid test, but with a different name for the auxiliary variable."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [overlap_fluid]
     type = CSVDiff
@@ -59,7 +59,7 @@
     requirement = "The heat source shall be extracted and normalized correctly from OpenMC "
                   "for perfect model overlap with fissile fluid and solid phases, but "
                   "heat source coupling only performed for the fluid phase."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [partial_overlap_openmc_union]
     type = CSVDiff
@@ -71,7 +71,7 @@
     requirement = "The heat source shall be extracted and normalized correctly from OpenMC "
                   "for partial overlap of the OpenMC and MOOSE meshes, where all MOOSE "
                   "elements map to OpenMC cells, but some OpenMC cells are not mapped."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [partial_overlap_moose_union_msg]
     type = RunException
@@ -80,7 +80,7 @@
     expect_err = "The \[Mesh\] has 1024 elements providing temperature feedback \(the elements in 'temperature_blocks'\), but only 768 got mapped to OpenMC cells."
     requirement = "A warning shall be printed if any portion of the MOOSE solid blocks did not "
                   "get mapped to OpenMC cells."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [partial_overlap_moose_union]
     type = CSVDiff
@@ -92,7 +92,7 @@
     requirement = "The heat source shall be extracted and normalized correctly from OpenMC "
                   "for partial overlap of the OpenMC and MOOSE meshes, where all OpenMC "
                   "cells map to MOOSE elements, but some MOOSE elements are not mapped."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [default_tally_blocks]
     type = Exodiff
@@ -105,7 +105,7 @@
     requirement = "For single-level geometries, tallies shall be added to all MOOSE blocks "
                   "if tally blocks are not specified. The gold file for this test is simply "
                   "a copy of overlap_all_out.e."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [cell_volumes]
     type = Exodiff
@@ -116,7 +116,7 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The mapped cell volumes shall be correctly computed by the wrapping."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_tally]
     type = CSVDiff
@@ -126,7 +126,7 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The system shall be able to write multiple different tally scores with normalization by a global tally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_tally_local]
     type = CSVDiff
@@ -136,7 +136,7 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The system shall be able to write multiple different tally scores with normalization by a local tally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_tally_local_assume_separate]
     type = CSVDiff
@@ -147,7 +147,7 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The system shall be able to write multiple different tally scores with normalization by a local tally with the spatial separate assumption."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_tally_global]
     type = CSVDiff
@@ -158,7 +158,7 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The system shall be able to write multiple different tally scores with normalization by a global tally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_tally_global_mesh]
     type = CSVDiff
@@ -168,7 +168,7 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The system shall be able to write multiple different tally scores with normalization by a global tally for mesh tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_tally_local_mesh]
     type = CSVDiff
@@ -179,6 +179,6 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The system shall be able to write multiple different tally scores with normalization by a local tally for mesh tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/indicators/tests
+++ b/test/tests/neutronics/indicators/tests
@@ -8,7 +8,7 @@
     exodiff = 'openmc_out.e'
     requirement = 'The system shall allow for the calculation of the optical depth using the min/max vertex separation or the cube root of the element volume.'
     mesh_mode = 'replicated'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [not_rxn_rate]
     type = RunException
@@ -17,7 +17,7 @@
     requirement = 'The system shall error if a non-reaction rate score is provided to ElementOpticalDepthIndicator.'
     expect_err = 'At present the ElementOpticalDepthIndicator only works with reaction rate scores. kappa_fission is not a valid reaction rate score.'
     mesh_mode = 'replicated'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_score]
     type = RunException
@@ -26,7 +26,7 @@
     requirement = 'The system shall error if a a reaction rate score is requested, but not available in a tally.'
     expect_err = 'The problem does not contain any score named fission!'
     mesh_mode = 'replicated'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_flux]
     type = RunException
@@ -35,6 +35,6 @@
     requirement = 'The system shall error if the flux is not available in a tally.'
     expect_err = 'In order to use an ElementOpticalDepthIndicator one of your'
     mesh_mode = 'replicated'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/kinetics/non_eigen/tests
+++ b/test/tests/neutronics/kinetics/non_eigen/tests
@@ -7,6 +7,6 @@
     input = openmc.i
     expect_err = "Kinetic parameters can only be calculated in k-eigenvalue mode!"
     requirement = "The system shall error if the problem attempts to enable IFP calculations when running in fixed source mode."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/kinetics/tests
+++ b/test/tests/neutronics/kinetics/tests
@@ -7,7 +7,7 @@
     input = both.i
     csvdiff = both_out.csv
     requirement = "The system shall be able to calculate neutron kinetics parameters."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [no_ifp_lambda]
     type = RunException
@@ -15,14 +15,14 @@
     cli_args = 'Problem/calc_kinetics_params=false'
     expect_err = "LambdaEffective can only be used if the OpenMC problem is computing kinetics parameters!"
     requirement = "The system shall error if the problem does not enable IFP calculations and attempts to add an LambdaEffective post processor."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [no_ifp_beta]
     type = RunException
     input = beta.i
     expect_err = "BetaEffective can only be used if the OpenMC problem is computing kinetics parameters!"
     requirement = "The system shall error if the problem does not enable IFP calculations and attempts to add a BetaEffective post processor."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [more_ifp_gen_then_inactive]
     type = RunException
@@ -30,6 +30,6 @@
     cli_args = 'Problem/ifp_generations=20'
     expect_err = "'ifp_generations' must be less than or equal to the number of inactive batches!"
     requirement = "The system shall error if the problem does not enable IFP calculations and attempts to add a BetaEffective post processor."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/mesh_tally/tests
+++ b/test/tests/neutronics/mesh_tally/tests
@@ -5,7 +5,7 @@
     csvdiff = no_coupling_out.csv
     requirement = "The system shall allow a mesh tally for coupling OpenMC, without any physics feedback."
     mesh_mode = 'replicated'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [one_mesh]
     type = Exodiff
@@ -17,7 +17,7 @@
     max_parallel = 32
     requirement = "The heat source shall be tallied on an unstructured mesh and normalized against "
                   "a local tally when a single mesh is used."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [one_mesh_no_input_file]
     type = Exodiff
@@ -30,7 +30,7 @@
     requirement = "This test is nearly identical to one_mesh. The difference lies in having no mesh_template "
                   "in the input file. Without one, the system should be able to directly tally on a moose "
                   "mesh instead of a file "
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [moose_mesh_tally_distributed]
     type = RunException
@@ -40,7 +40,7 @@
                  "for distributed meshes!"
     requirement = "The system shall error if attempting to directly tally on a MOOSE mesh that is "
                   "distributed, since all meshes are always replicated in OpenMC."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [scaling]
     type = RunException
@@ -48,7 +48,7 @@
     cli_args = 'Problem/scaling=2.0'
     expect_err = "Directly tallying on the \[Mesh\] is only supported for 'scaling' of unity."
     requirement = "The system shall error if attempting to directly tally on a MOOSE mesh that has a scaling not equal to 1.0."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [one_mesh_global]
     type = Exodiff
@@ -61,7 +61,7 @@
                   "a global tally when a single mesh is used. This test was run with successively finer "
                   "meshes (from 256 elements to 94k elements) to show that the power of the mesh tally "
                   "approaches the value of a cell tally as the difference in volume decreases."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [block_restrict]
     type = Exodiff
@@ -71,7 +71,7 @@
     # on a particular process
     max_parallel = 32
     requirement = "Mesh tallies shall allow for block restrictions to be applied."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multiple_meshes]
     type = Exodiff
@@ -82,7 +82,7 @@
     max_parallel = 32
     requirement = "The heat source shall be tallied on an unstructured mesh and normalized against "
                   "a local tally when multiple identical meshes are used."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multiple_meshes_global]
     type = Exodiff
@@ -95,7 +95,7 @@
                   "a global tally when multiple identical meshes are used. This test was run with successively finer "
                   "meshes (from 256 elements to 94k elements) to show that the power of the mesh tally "
                   "approaches the value of a cell tally as the difference in volume decreases."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [different_units]
     type = Exodiff
@@ -106,7 +106,7 @@
     max_parallel = 32
     requirement = "The heat source shall be correctly projected onto a [Mesh] in units of meters "
                   "when the tally mesh template is in units of centimeters."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [different_units_and_translations]
     type = Exodiff
@@ -119,7 +119,7 @@
                   "when the tally mesh template and translations are in units of centimeters. "
                   "The output was compared against the multiple_meshes case, which used an input "
                   "entirely specified in terms of centimeters."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [fission_tally_std_dev]
     type = CSVDiff
@@ -130,7 +130,7 @@
     max_parallel = 32
     requirement = "The fission tally standard deviation shall be output correctly for unstructured "
                   "mesh tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [disable_renumbering]
     type = RunException
@@ -138,7 +138,7 @@
     cli_args = 'Mesh/allow_renumbering=true --distributed-mesh'
     expect_err = "Mesh tallies currently require 'allow_renumbering = false' to be set in the \[Mesh\]!"
     requirement = "Mesh tallies shall temporarily require disabled renumbering until capability is available"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [file_mesh_block_restrict]
     type = RunException
@@ -146,7 +146,7 @@
     cli_args = 'Problem/Tallies/Mesh/block=100'
     expect_err = "Block restriction is currently not supported for mesh tallies which load a mesh from a file!"
     requirement = "Mesh tallies shall error if the user attempts to apply a block restriction when using a mesh template."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [block_restrict_no_blocks]
     type = RunException
@@ -154,6 +154,6 @@
     cli_args = "Problem/Tallies/Mesh/block='' Mesh/parallel_type=replicated"
     expect_err = "Subdomain names must be provided if using 'block'!"
     requirement = "Mesh tallies shall error if the user attempts to apply a block restriction with no blocks."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/openmc_xml/tests
+++ b/test/tests/neutronics/openmc_xml/tests
@@ -11,7 +11,7 @@
                   "While the XML files set 100 particles, we change the number of particles to 200 in "
                   "the Cardinal input file, and compare the eigenvalue against a standalone OpenMC run "
                   "(with 'openmc --particles 200') to ensure correctness."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [inactive]
     type = CSVDiff
@@ -25,7 +25,7 @@
                   "While the XML files set 10 inactive batches, we change the number of inactive batches to 20 in "
                   "the Cardinal input file, and compare the eigenvalue against a standalone OpenMC run "
                   "(with 20 inactive batches) to ensure correctness."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [batches]
     type = CSVDiff
@@ -39,13 +39,13 @@
                   "While the XML files set 50 batches, we change the number of batches to 60 in "
                   "the Cardinal input file, and compare the eigenvalue against a standalone OpenMC run "
                   "(with 60 batches) to ensure correctness."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [skip_statepoint]
     type = CheckFiles
     input = skip_statepoint.i
     check_not_exists = 'statepoint.8.h5'
     requirement = 'The system shall allow skipping of statepoint output files'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/output/tests
+++ b/test/tests/neutronics/output/tests
@@ -5,7 +5,7 @@
     csvdiff = cell_rel_error_out.csv
     cli_args = 'Problem/Tallies/Cell/output=unrelaxed_tally_rel_error Postprocessors/total_flux/variable=flux_rel_error Outputs/file_base=cell_rel_error_out'
     requirement = "The system shall allow for the output of the unrelaxed tally relative error for cell tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [unrelaxed_tally_rel_error_mesh]
     type = CSVDiff
@@ -14,6 +14,6 @@
     cli_args = 'Problem/Tallies/Mesh/output=unrelaxed_tally_rel_error Postprocessors/total_flux/variable=flux_rel_error Outputs/file_base=mesh_rel_error_out'
     mesh_mode = 'replicated'
     requirement = "The system shall allow for the output of the unrelaxed tally relative error for mesh tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/photon/tests
+++ b/test/tests/neutronics/photon/tests
@@ -4,7 +4,7 @@
     input = openmc.i
     expect_err = "Tracklength estimators are currently incompatible with photon transport and heating scores!"
     requirement = "The system shall error if using incompatible tally estimator with a photon transport heating score."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
     issues = '#1114'
     design = 'AddTallyAction.md'
   []
@@ -15,7 +15,7 @@
     expect_err = "A single tally cannot score both nu_scatter and heating when photon transport is enabled"
     requirement = "The system shall error if using a single tally with a photon transport heating score and nu-scatter score."
     cli_args = 'Problem/Tallies/Cell/score="nu_scatter heating" Problem/Tallies/Cell/estimator=""'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
     issues = '#1089'
     design = 'AddTallyAction.md'
   []

--- a/test/tests/neutronics/relaxation/cell_tallies/tests
+++ b/test/tests/neutronics/relaxation/cell_tallies/tests
@@ -6,7 +6,7 @@
     cli_args = "Problem/relaxation=constant Problem/relaxation_factor=1.0"
     requirement = "A unity relaxation factor shall be equivalent to an unrelaxed case with "
                   "globally-normalzed cell tallies on a model with perfect alignment between OpenMC model and the mesh mirror"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [global_with_alignment_relax]
     type = CSVDiff
@@ -17,7 +17,7 @@
                   "with perfect alignment between the OpenMC model and the mesh mirror. This test is verified by "
                   "comparing the heat source computed via relaxation with the un-relaxed iterations from the "
                   "openmc.i run (without any command line parameter settings)."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [global_with_alignment_rm_relax]
     type = CSVDiff
@@ -28,7 +28,7 @@
                   "with perfect alignment between the OpenMC model and the mesh mirror. This test is verified by "
                   "comparing the heat source computed via relaxation with the un-relaxed iterations from the "
                   "openmc.i run (without any command line parameter settings)."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [global_with_alignment_dg_relax]
     type = CSVDiff
@@ -39,7 +39,7 @@
                   "comparing the heat source computed via relaxation with the un-relaxed iterations from the "
                   "same input file, but with the relaxation part commented out in the source code (so that we can compare "
                   "directly against runs that only differ by changing the number of particles."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 
   [local_with_alignment_unity_relax]
@@ -49,7 +49,7 @@
     cli_args = "Problem/normalize_by_global_tally=false Problem/relaxation=constant Problem/relaxation_factor=1.0"
     requirement = "A unity relaxation factor shall be equivalent to an unrelaxed case with "
                   "locally-normalzed cell tallies on a model with perfect alignment between OpenMC model and the mesh mirror"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [local_with_alignment_relax]
     type = CSVDiff
@@ -60,7 +60,7 @@
                   "with perfect alignment between the OpenMC model and the mesh mirror. This test is verified by "
                   "comparing the heat source computed via relaxation with the un-relaxed iterations from the "
                   "openmc.i case with normalize_by_global_tally=false."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 
   [global_without_alignment_unity_relax]
@@ -71,7 +71,7 @@
     requirement = "A unity relaxation factor shall be equivalent to an unrelaxed case with "
                   "globally-normalzed cell tallies on a model with imperfect alignment between OpenMC model and the "
                   "mesh mirror."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [global_without_alignment_relax]
     type = CSVDiff
@@ -82,7 +82,7 @@
                   "with imperfect alignment between the OpenMC model and the mesh mirror. This test is verified by "
                   "comparing the heat source computed via relaxation with the un-relaxed iterations from the "
                   "openmc_nonaligned.i case (without additional command line parameters)"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 
   [local_without_alignment_unity_relax]
@@ -93,7 +93,7 @@
     min_parallel = 2
     requirement = "A unity relaxation factor shall be equivalent to an unrelaxed case with "
                   "locally-normalzed cell tallies on a model with imperfect alignment between OpenMC model and the mesh mirror"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [local_without_alignment_relax]
     type = CSVDiff
@@ -105,7 +105,7 @@
                   "with imperfect alignment between the OpenMC model and the mesh mirror. This test is verified by "
                   "comparing the heat source computed via relaxation with the un-relaxed iterations from the "
                   "openmc_nonaligned.i case with normalize_by_global_tally=false"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [none_fixed_mesh]
     type = CSVDiff
@@ -115,7 +115,7 @@
     min_parallel = 2
     requirement = "The system shall correctly re-initialize the same mapping when the MooseMesh does not change "
                   "during a simulation."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [output_fission_tally_cell]
     type = Exodiff
@@ -123,20 +123,20 @@
     exodiff = output_fission_tally_out.e
     cli_args = 'Problem/output_cell_mapping=false'
     requirement = "The wrapping shall allow output of the unrelaxed heat source for cell tallies"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_tally]
     type = CSVDiff
     input = multi_tally.i
     csvdiff = multi_tally_out.csv
     requirement = "The wrapping shall allow output of multiple tally scores, with relaxation applied independently to each score"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [no_relax_with_fixed_mesh]
     type = RunException
     input = openmc_adapt.i
     expect_err = "When adaptivity is requested or a displaced problem is used, the mapping from the OpenMC model to the \[Mesh\] may vary in time."
     requirement = "The system shall correctly error if trying to use relaxation with a time-varying mesh."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/relaxation/mesh_tallies/tests
+++ b/test/tests/neutronics/relaxation/mesh_tallies/tests
@@ -6,7 +6,7 @@
     cli_args = "Problem/relaxation=constant Problem/relaxation_factor=1.0 Problem/output_cell_mapping=false"
     requirement = "A unity relaxation factor shall be equivalent to an unrelaxed case with "
                   "globally-normalized mesh tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [global_without_alignment_relax]
     type = Exodiff
@@ -17,7 +17,7 @@
                   "mesh tallies. This test is verified by comparing the heat source computed via "
                   "relaxation with the un-relaxed iterations from the openmc.i run (without any "
                   "additional command line parameters)."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [none_fixed_mesh]
     type = Exodiff
@@ -26,7 +26,7 @@
     cli_args = "Problem/relaxation=none Problem/fixed_mesh=false Problem/output_cell_mapping=false"
     requirement = "The system shall correctly re-initialize the same mapping when the MooseMesh does not change "
                   "during a simulation."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 
   [local_without_alignment_unity_relax]
@@ -36,7 +36,7 @@
     cli_args = "Problem/normalize_by_global_tally=false Problem/relaxation=constant Problem/relaxation_factor=1.0 Outputs/file_base=out Problem/output_cell_mapping=false"
     requirement = "A unity relaxation factor shall be equivalent to an unrelaxed case with "
                   "locally-normalized mesh tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [local_without_alignment_relax]
     type = Exodiff
@@ -47,7 +47,7 @@
                   "mesh tallies. This test is verified by comparing the heat source computed via "
                   "relaxation with the un-relaxed iterations from the openmc.i run with "
                   "normalize_by_global_tally=false."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [output_fission_tally_mesh]
     type = Exodiff
@@ -55,6 +55,6 @@
     exodiff = output_fission_tally_out.e
     cli_args = 'Problem/output_cell_mapping=false'
     requirement = "The wrapping shall allow output of the unrelaxed heat source for mesh tallies"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/solid/tests
+++ b/test/tests/neutronics/solid/tests
@@ -13,7 +13,7 @@
                   "simulation of the same problem with zero heat source. The gold file was "
                   "created with the zero_power.i input file, which does not have OpenMC as "
                   "a sub-app."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_pebble]
     type = RunException
@@ -23,6 +23,6 @@
     expect_err = "kappa-fission tallies do not match the global kappa-fission tally"
     requirement = "The system shall error if the heating tallies are missing power from other parts "
                   "of the problem."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/source/tests
+++ b/test/tests/neutronics/source/tests
@@ -11,6 +11,6 @@
     prereq = mesh
     check_files = 'initial_source_0.h5 initial_source_1.h5 initial_source_2.h5'
     requirement = "The correct source files shall be created when re-using the source between iterations"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/symmetry/rotational/tests
+++ b/test/tests/neutronics/symmetry/rotational/tests
@@ -4,7 +4,7 @@
     input = solid_mesh.i
     cli_args = '--mesh-only'
     requirement = "The system shall create the mesh mirror for later steps of these tests"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [symmetry_sector]
     type = CSVDiff
@@ -12,6 +12,6 @@
     csvdiff = openmc_out.csv
     prereq = generate_mesh
     requirement = "The system shall correctly reflect points about a partial symmetry sector"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/symmetry/tests
+++ b/test/tests/neutronics/symmetry/tests
@@ -4,7 +4,7 @@
     input = solid_mesh.i
     cli_args = '--mesh-only'
     requirement = "The system shall create the mesh mirror for later steps of these tests"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [symmetry_plane]
     type = CSVDiff
@@ -12,7 +12,7 @@
     csvdiff = openmc_out.csv
     prereq = generate_mesh
     requirement = "The system shall correctly reflect points about a symmetry plane"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [wrong_uo]
     type = RunException
@@ -20,6 +20,6 @@
     prereq = generate_mesh
     expect_err = "The 'symmetry_mapper' user object has to be of type SymmetryPointGenerator!"
     requirement = "The system shall error if the symmetry mapper is not of the correct type"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/symmetry/triso/tests
+++ b/test/tests/neutronics/symmetry/triso/tests
@@ -4,7 +4,7 @@
     input = solid_mesh.i
     cli_args = '--mesh-only'
     requirement = "The system shall create the mesh mirror for later steps of these tests"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [symmetry_plane]
     type = Exodiff
@@ -12,6 +12,6 @@
     exodiff = openmc_out.e
     prereq = generate_mesh
     requirement = "The system shall correctly reflect points about a symmetry plane"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/tallies/reaction_rates/tests
+++ b/test/tests/neutronics/tallies/reaction_rates/tests
@@ -4,7 +4,7 @@
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall allow tallying of absorption/fission/scattering/total reaction rates in fixed source mode."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
     issues = '#912'
     design = 'AddTallyAction.md'
   []
@@ -19,13 +19,13 @@
       input = openmc_mgxs_rxn.i
       detail = "The system shall compute nu-scatter, nu-fission, and inverse-velocity scores fixed source mode."
       csvdiff = openmc_mgxs_rxn_out.csv
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
     [nu_scatter_analog]
       type = RunException
       input = openmc_mgxs_rxn.i
       detail = "The system shall error if the user attempts to specify a nu-scatter score without an analog estimator."
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
       cli_args = 'Problem/Tallies/Cell/estimator=tracklength'
       expect_err = 'Non-analog estimators are not supported for nu_scatter scores!'
     []

--- a/test/tests/neutronics/tallies/tritium/tests
+++ b/test/tests/neutronics/tallies/tritium/tests
@@ -4,6 +4,6 @@
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall allow tallying of tritium production rates in fixed source mode."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/tally_grad/finite_diff/tests
+++ b/test/tests/neutronics/tally_grad/finite_diff/tests
@@ -8,7 +8,7 @@
     exodiff = 'openmc_out.e'
     requirement = 'The system shall allow for the approximation of tally gradients using finite differences.'
     mesh_mode = 'replicated'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [not_const_mon]
     type = RunException
@@ -17,7 +17,7 @@
     requirement = 'The system shall error if the variable provided to FDTallyGradAux is not of type CONSTANT MONOMIAL_VEC.'
     expect_err = 'FDTallyGradAux only supports CONSTANT MONOMIAL_VEC shape functions.'
     mesh_mode = 'replicated'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_score]
     type = RunException
@@ -26,7 +26,7 @@
     requirement = 'The system shall error if a score is requested, but not available in a tally.'
     expect_err = 'The problem does not contain any score named fission!'
     mesh_mode = 'replicated'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [invalid_bin_index]
     type = RunException
@@ -35,6 +35,6 @@
     requirement = 'The system shall error if the external filter bin provided by the user is out of bounds for the filters applied to the given score.'
     expect_err = 'The external filter bin provided is invalid'
     mesh_mode = 'replicated'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/tally_system/tests
+++ b/test/tests/neutronics/tally_system/tests
@@ -5,14 +5,14 @@
     csvdiff = cell_with_unmapped_out.csv
     requirement = "The system shall correctly label elements in blocks which don't contain temperature feedback, density feedback, "
                   "or a cell tally as unmapped."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_global_estimator]
     type = CSVDiff
     input = multi_estimator.i
     csvdiff = multi_estimator_out.csv
     requirement = "The system shall correctly normalize local tallies with different estimators using multiple global tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multiple_tallies_cell]
     type = CSVDiff
@@ -20,7 +20,7 @@
     csvdiff = multi_cell_out.csv
     requirement = "The system shall correctly apply and normalize two different CellTally objects with different scores. "
                   "The gold file was generated using an input that had a single CellTally with multiple scores."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multiple_tallies_mesh]
     type = Exodiff
@@ -28,7 +28,7 @@
     exodiff = multi_mesh_out.e
     requirement = "The system shall correctly apply and normalize two different MeshTally objects with different scores. "
                   "The gold file was generated using an input that had a single MeshTally with multiple scores."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multiple_tallies_cell_triggers]
     type = CSVDiff
@@ -36,7 +36,7 @@
     csvdiff = multi_cell_triggers_out.csv
     requirement = "The system shall correctly apply and normalize two different CellTally objects with different scores and triggers. "
                   "The gold file was generated using an input that had a single CellTally with multiple scores and triggers."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multiple_tallies_mesh_triggers]
     type = Exodiff
@@ -44,7 +44,7 @@
     exodiff = multi_mesh_triggers_out.e
     requirement = "The system shall correctly apply and normalize two different MeshTally objects with different scores and triggers. "
                   "The gold file was generated using an input that had a single MeshTally with multiple scores and triggers."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multiple_tallies_cell_relax]
     type = CSVDiff
@@ -52,7 +52,7 @@
     csvdiff = multi_cell_relax_out.csv
     requirement = "The system shall correctly apply and normalize two different CellTally objects with different scores when using relaxation. "
                   "The gold file was generated using an input that had a single CellTally with multiple scores when using relaxation."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multiple_tallies_mesh_relax]
     type = Exodiff
@@ -60,7 +60,7 @@
     exodiff = multi_mesh_relax_out.e
     requirement = "The system shall correctly apply and normalize two different MeshTally objects with different scores when using relaxation. "
                   "The gold file was generated using an input that had a single MeshTally with multiple scores when using relaxation."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [duplicate_scores]
     type = RunException
@@ -68,7 +68,7 @@
     cli_args = 'Problem/Tallies/Cell_2/score="flux kappa_fission"'
     expect_err = "You have added 2 tallies which score kappa-fission!"
     requirement = "The system shall error if the user provides multiple tallies with overlapping scores."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_no_norm]
     type = RunException
@@ -77,14 +77,14 @@
     expect_err = "The local tallies added in the \[Tallies\] block do not contain the requested heating score"
     requirement = "The system shall error if more than one tally is provided and the requested heating score is in "
                   "none of the tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multiple_different_tallies]
     type = Exodiff
     input = multi_diff.i
     exodiff = multi_diff_out.e
     requirement = "The system shall allow calculations with multiple different tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multiple_different_outputs]
     type = Exodiff
@@ -92,6 +92,6 @@
     exodiff = multi_diff_outputs.e
     cli_args = 'Problem/Tallies/Cell/output="unrelaxed_tally_std_dev unrelaxed_tally" Problem/Tallies/Mesh/output="unrelaxed_tally_std_dev" Outputs/file_base=multi_diff_outputs'
     requirement = "The system shall allow calculations with multiple different tally outputs."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/triggers/ignore_zeros/tests
+++ b/test/tests/neutronics/triggers/ignore_zeros/tests
@@ -7,7 +7,7 @@
                   "by measuring the maximum tally relative error of the H3 score. A smaller tally "
                   "relative error indicates the simulation ran to max batches and didn't ignore the "
                   "zero bin. If the zero bin is ignored, the simulation should only run 50 batches."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [length_igore_zero]
     type = RunException
@@ -15,7 +15,7 @@
     cli_args = 'Problem/Tallies/Cell/trigger_ignore_zeros="true true"'
     requirement = "The system shall enforce correct trigger ignore zero length"
     expect_err = "'trigger_ignore_zeros' \(size 2\) must have the same length as 'score' \(size 1\)"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [set_trigger_ignore_zero]
     type = RunException
@@ -23,6 +23,6 @@
     cli_args = 'Problem/Tallies/Cell/trigger_ignore_zeros=""'
     requirement = "The system shall ensure that the users provide values of trigger_ignore_zeros when the parameter is set."
     expect_err = "trigger_ignore_zeros cannot be empty!"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/neutronics/triggers/tests
+++ b/test/tests/neutronics/triggers/tests
@@ -5,7 +5,7 @@
     csvdiff = k_std_dev_out.csv
     requirement = "The system shall correctly terminate the OpenMC simulation once reaching a desired "
       "k standard deviation."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [k_std_dev_cutoff]
     type = CSVDiff
@@ -14,7 +14,7 @@
     csvdiff = k_std_dev_cutoff_out.csv
     requirement = "The system shall terminate the OpenMC simulation once reaching a desired "
       "k standard deviation unless first reaching a maximum number of batches."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [k_variance]
     type = CSVDiff
@@ -23,7 +23,7 @@
     csvdiff = k_variance_out.csv
     requirement = "The system shall terminate the OpenMC simulation once reaching a desired "
       "k variance."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [k_rel_err]
     type = CSVDiff
@@ -32,7 +32,7 @@
     csvdiff = k_rel_err_out.csv
     requirement = "The system shall terminate the OpenMC simulation once reaching a desired "
       "k relative error."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [tally_rel_err]
     type = CSVDiff
@@ -40,7 +40,7 @@
     csvdiff = tally_rel_err_out.csv
     requirement = "The system shall correctly terminate the OpenMC simulation once reaching a desired "
       "tally relative error with cell tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [tally_rel_err_collision]
     type = CSVDiff
@@ -48,7 +48,7 @@
     cli_args = "Outputs/file_base=collision_out Problem/Tallies/Cell/estimator=collision"
     csvdiff = collision_out.csv
     requirement = "The system shall allow the user to customize the tally estimator for cell tallies"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [mesh_tally_rel_err]
     type = CSVDiff
@@ -56,7 +56,7 @@
     csvdiff = mesh_tally_rel_err_out.csv
     requirement = "The system shall correctly terminate the OpenMC simulation once reaching a desired "
       "tally relative error with mesh tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_rel_err]
     type = CSVDiff
@@ -64,7 +64,7 @@
     csvdiff = multi_rel_err_out.csv
     requirement = "The system shall correctly terminate the OpenMC simulation once reaching a desired "
       "tally relative error when applying the same trigger to multiple scores."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [length_trigger]
     type = RunException
@@ -72,7 +72,7 @@
     cli_args = 'Problem/Tallies/Cell/trigger="rel_err"'
     requirement = "The system shall enforce correct trigger length"
     expect_err = "'trigger' \(size 1\) must have the same length as 'score' \(size 2\)"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [length_threshold]
     type = RunException
@@ -80,7 +80,7 @@
     cli_args = 'Problem/Tallies/Cell/trigger_threshold="1e-2"'
     requirement = "The system shall enforce correct trigger threshold length"
     expect_err = "'trigger_threshold' \(size 1\) must have the same length as 'score' \(size 2\)"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_diff_rel_err]
     type = CSVDiff
@@ -89,7 +89,7 @@
     cli_args = 'Outputs/file_base=diff_out Problem/Tallies/Cell/trigger_threshold="1e-2 5e-2"'
     requirement = "The system shall correctly terminate the OpenMC simulation once reaching a desired "
       "tally relative error when applying a different trigger to multiple scores."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_diff_rel_err_b]
     type = CSVDiff
@@ -98,6 +98,6 @@
     cli_args = 'Outputs/file_base=diffb_out Problem/Tallies/Cell/trigger_threshold="5e-2 1e-2"'
     requirement = "The system shall correctly terminate the OpenMC simulation once reaching a desired "
       "tally relative error when applying a different trigger to multiple scores."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/block_mappings/tests
+++ b/test/tests/openmc_errors/block_mappings/tests
@@ -4,7 +4,7 @@
     input = nonexistent_block.i
     expect_err = "Block 'who' specified in 'block' not found in mesh!"
     requirement = "The system shall error if the user specifies a block for coupling that does not exist."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [empty_block]
     type = RunException
@@ -12,14 +12,14 @@
     cli_args = 'Problem/temperature_blocks=""'
     expect_err = "'temperature_blocks' cannot be empty!"
     requirement = "The system shall error if an empty vector is provided for the blocks"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [no_overlap]
     type = RunException
     input = no_overlap.i
     expect_err = "Did not find any overlap between MOOSE elements and OpenMC cells for the specified blocks!"
     requirement = "The system shall error if the MOOSE blocks and OpenMC cells don't overlap"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [skipping_moose_feedback]
     type = RunException
@@ -27,7 +27,7 @@
     cli_args = '--error'
     expect_err = "The \[Mesh\] has 1024 elements providing temperature feedback \(the elements in 'temperature_blocks'\), but only 768 got mapped to OpenMC cells."
     requirement = "The system shall print a warning if some MOOSE elements are unmapped"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multiple_phases]
     type = RunException
@@ -38,21 +38,21 @@
                  "  3486  elements with both temperature and density feedback\n"
                  "     0  uncoupled elements"
     requirement = "The system shall error if one OpenMC cell maps to more than one type of feedback"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multiple_tally_settings]
     type = RunException
     input = multiple_tally_settings.i
     expect_err = "cell id 4, instance 0 \(of 1\) maps to blocks with different tally settings!\nBlock 100 is in 'block', but block 200 is not."
     requirement = "The system shall error if one OpenMC cell maps to multiple subdomains that don't all have the same tally setting"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [absent_solid_block]
     type = RunException
     input = absent_solid_block.i
     expect_err = "Feedback was specified using 'temperature_blocks' and/or 'density_blocks', but no MOOSE elements mapped to OpenMC cells!"
     requirement = "The system shall error if the user sets feedback blocks, but none of the elements map to OpenMC"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [unequal_volumes]
     type = RunException
@@ -61,6 +61,6 @@
                  " cell id 1, instance 0 \(of 1\) maps to a volume of 13.2213 \(cm3\)\n"
                  " cell id 2, instance 0 \(of 1\) maps to a volume of 10.6346 \(cm3\)."
     requirement = "The system shall error if the user enforces equal mapped tally volumes but the mapped volumes are not identical across tally bins"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/cell_instances/insufficient_materials/tests
+++ b/test/tests/openmc_errors/cell_instances/insufficient_materials/tests
@@ -5,7 +5,7 @@
     expect_err = "material 2 is present in more than one density feedback cell.\n"
     requirement = "The system shall error if we attempt to set a density in a material that is repeated "
                   "throughout our list of fluid cells."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [no_error_for_solid]
     type = RunApp
@@ -13,6 +13,6 @@
     check_input = true
     requirement = "If the same material appears in more than one solid cell, there should be no error "
                   "like there is for the fluid case, because we do not change the density of solid cells."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/cell_instances/lattice_outer/tests
+++ b/test/tests/openmc_errors/cell_instances/lattice_outer/tests
@@ -4,6 +4,6 @@
     input = temp.i
     expect_err = "mapped to cell 2 in the OpenMC model is inside a universe used as the 'outer' universe of a lattice."
     requirement = "The system shall error if attempting to pass temperature feedback to a lattice outer universe due to lack of instance support in OpenMC"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/densities/tests
+++ b/test/tests/openmc_errors/densities/tests
@@ -5,13 +5,13 @@
     expect_err = "Densities less than or equal to zero cannot be set in the OpenMC model!\n\n"
                  " cell id 1, instance 0 \(of 1\) set to density 0 \(kg/m3\)"
     requirement = "The system shall error if we attempt to set a density less than or equal to zero in OpenMC"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [void_density]
     type = RunException
     input = void_density.i
     expect_err = "Cannot set density for cell id 2, instance 0 \(of 1\) because this cell is void \(vacuum\)!"
     requirement = "The system shall error if we attempt to set a density in a void OpenMC cell"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/fixed_source/tests
+++ b/test/tests/openmc_errors/fixed_source/tests
@@ -5,7 +5,7 @@
     expect_err = "Eigenvalues are only computed when running OpenMC in eigenvalue mode!"
     requirement = "The system shall error if attempting to extract the eigenvalue from an OpenMC run that is "
                   "not run with eigenvalue mode."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [k_std_dev]
     type = RunException
@@ -14,7 +14,7 @@
     expect_err = "Eigenvalues are only computed when running OpenMC in eigenvalue mode!"
     requirement = "The system shall error if attempting to extract the eigenvalue standard deviation from an "
                   "OpenMC run that is not run with eigenvalue mode."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [k_trigger]
     type = RunException
@@ -22,6 +22,6 @@
     expect_err = "Cannot specify a 'k_trigger' for OpenMC runs that are not eigenvalue mode!"
     requirement = "The system shall error if attempting to set a k trigger for an OpenMC mode that doesn't "
                   "have a notion of eigenvalues"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/incorrect_problem/tests
+++ b/test/tests/openmc_errors/incorrect_problem/tests
@@ -5,6 +5,6 @@
     expect_err = "TallyRelativeError can only be used with problems of type 'OpenMCCellAverageProblem'!"
     requirement = "The system shall error if an OpenMC object is used without the correct "
                   "OpenMC wrapped problem."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/incorrect_var_setup/tests
+++ b/test/tests/openmc_errors/incorrect_var_setup/tests
@@ -5,6 +5,6 @@
     expect_err = "This auxkernel can only be used with elemental variables!"
     requirement = "The system shall error if a auxkernel that queries OpenMC data structures is not used "
                   "with the correct variable type."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/input_params/tests
+++ b/test/tests/openmc_errors/input_params/tests
@@ -5,7 +5,7 @@
     expect_err = "In attempting to set the number of batches, OpenMC reported:\n\n"
                  "Number of active batches must be greater than zero."
     requirement = "The system shall error if attempting to set a negative number of active batches"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [invalid_max_batches]
     type = RunException
@@ -13,27 +13,27 @@
     expect_err = "In attempting to set the maximum number of batches, OpenMC reported:\n\n"
                  "Number of active batches must be greater than zero."
     requirement = "The system shall error if attempting to set a negative number of active batches"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_properties]
     type = RunException
     input = missing_properties.i
     expect_err = "In attempting to load temperature and density from a properties.h5 file, OpenMC reported:"
     requirement = "The system shall error if a properties file is loaded but does not exist"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [no_dag]
     type = RunException
     input = no_dag.i
     expect_err = "When the OpenMC model does not contain any DagMC universes, the 'skinner' parameter is unused!"
     requirement = "The system shall error if using a skinner without a DagMC geometry"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [duplicate_levels]
     type = RunException
     input = levels.i
     expect_err = "Either 'cell_level' or 'lowest_cell_level' must be specified. You have given either both or none."
     requirement = "The system shall error if both or none of the cell level options have been prescribed."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/openmc_errors/level/phase_too_high/tests
+++ b/test/tests/openmc_errors/level/phase_too_high/tests
@@ -6,6 +6,6 @@
     requirement = "The system shall error if the specified coordinate level for a phase is within the "
                   "maximum coordinate levels across the OpenMC domain, but invalid for the particular "
                   "region of the geometry."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/level/total_too_high/tests
+++ b/test/tests/openmc_errors/level/total_too_high/tests
@@ -5,6 +5,6 @@
     expect_err = "Coordinate level for finding cells cannot be greater than total number of coordinate levels: 1!"
     requirement = "The system shall error if the specified coordinate level for finding a cell "
                   "is greater than the maximum number of coordinate levels throughout the geometry."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/material_mappings/tests
+++ b/test/tests/openmc_errors/material_mappings/tests
@@ -5,6 +5,6 @@
     expect_err = "material 1 is present in more than one OpenMC cell with different density feedback settings!"
     requirement = "The system shall error if a fluid material exists in non-fluid parts of the domain, because "
                   "density would inadvertently be changed in other parts of the OpenMC model."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/mesh_tally/tests
+++ b/test/tests/openmc_errors/mesh_tally/tests
@@ -4,7 +4,7 @@
     input = incorrect_scaling.i
     expect_err = "The centroids of the 'mesh_template' differ from the centroids of the"
     requirement = "The system shall error if the mesh template is not provided in the same units as the [Mesh]."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [incorrect_order]
     type = RunException
@@ -12,7 +12,7 @@
     expect_err = "Centroid for element 256 in the"
     requirement = "The system shall error if the mesh template does not exactly match the [Mesh], such as when "
                   "the order of mesh translations does not match the order of inputs in a CombinerGenerator."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [incorrect_file]
     type = RunException
@@ -20,7 +20,7 @@
     expect_err = "Centroid for element 0 in the"
     requirement = "The system shall error if the mesh template does not exactly match the [Mesh], such as when "
                   "a totally different mesh is used (pincell versus pebbles)."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [invalid_estimator]
     type = RunException
@@ -29,6 +29,6 @@
     expect_err = "Tracklength estimators are currently incompatible with mesh tallies!"
     requirement = "The system shall error if a tracklength estimator is attempted with unstructured mesh tallies, "
                   "since this capability is not supported in libMesh."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/mesh_translations/tests
+++ b/test/tests/openmc_errors/mesh_translations/tests
@@ -5,6 +5,6 @@
     expect_err = "All entries in 'mesh_translations_file' must contain exactly 3 coordinates."
     requirement = "The system shall error if a particular set of coordinates in the mesh translations "
                   "does not have all requisite x, y, and z components."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/mode/particle/tests
+++ b/test/tests/openmc_errors/mode/particle/tests
@@ -4,6 +4,6 @@
     input = particle.i
     expect_err = "Running OpenMC in plotting, particle, and volume modes is not supported"
     requirement = "The system shall error if attempting to run OpenMC in particle restart mode through Cardinal."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/mode/plot/tests
+++ b/test/tests/openmc_errors/mode/plot/tests
@@ -4,6 +4,6 @@
     input = plot.i
     expect_err = "Running OpenMC in plotting, particle, and volume modes is not supported"
     requirement = "The system shall error if attempting to run OpenMC in plotting mode through Cardinal."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/mode/volume/tests
+++ b/test/tests/openmc_errors/mode/volume/tests
@@ -4,6 +4,6 @@
     input = volume.i
     expect_err = "Running OpenMC in plotting, particle, and volume modes is not supported"
     requirement = "The system shall error if attempting to run OpenMC in volume mode through Cardinal."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/no_range/tests
+++ b/test/tests/openmc_errors/no_range/tests
@@ -7,6 +7,6 @@
     requirement = "The system shall warn the user if they did not set the temperature range, protecting against "
                   "seg faults within the tracking loop when trying to access nuclear data at temperatures that "
                   "Cardinal wants to apply, but that weren't actually loaded at initialization."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/tallies/tests
+++ b/test/tests/openmc_errors/tallies/tests
@@ -4,7 +4,7 @@
     input = separate_tallies.i
     expect_err = "Cannot assume separate tallies"
     requirement = "The system shall error if attempting to use separate tallies when a global tally exists"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [invalid_length]
     type = RunException
@@ -12,7 +12,7 @@
     cli_args = 'Problem/Tallies/Cell/score="damage_energy kappa_fission" Problem/Tallies/Cell/name="heat_source"'
     expect_err = "'name' must be the same length as 'score'!"
     requirement = "The system shall error if name and score are not the same length."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_threshold]
     type = RunException
@@ -20,7 +20,7 @@
     cli_args = 'Problem/Tallies/Cell/trigger="rel_err"'
     expect_err = "You must either specify none or both of 'trigger' and 'trigger_threshold'. You have specified only one."
     requirement = "The system shall error if trigger and trigger_threshold are not simultaneously specified"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [duplicate_name]
     type = RunException
@@ -28,7 +28,7 @@
     cli_args = 'Problem/Tallies/Cell/score="damage_energy kappa_fission" Problem/Tallies/Cell/name="heat_source heat_source"'
     expect_err = "Entries cannot be repeated in 'name'!"
     requirement = "The system shall error if name has duplicate entries."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [duplicate_score]
     type = RunException
@@ -36,6 +36,6 @@
     cli_args = 'Problem/Tallies/Cell/score="damage_energy damage_energy" Problem/Tallies/Cell/name="heat1 heat2"'
     expect_err = "Entries cannot be repeated in 'score'!"
     requirement = "The system shall error if score has duplicate entries."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/xs_temperatures/tests
+++ b/test/tests/openmc_errors/xs_temperatures/tests
@@ -6,7 +6,7 @@
     expect_err = "In attempting to set cell id 1, instance 0 \(of 1\) to temperature -100 \(K\), OpenMC reported:\n\n"
     requirement = "The system shall error if we attempt to set a temperature in OpenMC below the "
                   "lower bound of available data when using the interpolation method."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [interpolation_max]
     type = RunException
@@ -14,6 +14,6 @@
     expect_err = "In attempting to set cell id 1, instance 0 \(of 1\) to temperature 100000 \(K\), OpenMC reported:\n\n"
     requirement = "The system shall error if we attempt to set a temperature in OpenMC above the "
                   "upper bound of available data when using the interpolation method."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/openmc_errors/zero_tally/tests
+++ b/test/tests/openmc_errors/zero_tally/tests
@@ -4,6 +4,6 @@
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall allow a global tally to be zero."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/postprocessors/coupled_cells/tests
+++ b/test/tests/postprocessors/coupled_cells/tests
@@ -4,6 +4,6 @@
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall output the number of coupled OpenMC cells"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/postprocessors/dimensionless_numbers/dimensional/tests
+++ b/test/tests/postprocessors/dimensionless_numbers/dimensional/tests
@@ -4,7 +4,7 @@
     input = nek.i
     csvdiff = nek_out.csv
     requirement = "The system shall correctly compute the Reynolds and Peclet numbers for a dimensional NekRS case."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [ranks]
     type = CSVDiff
@@ -12,6 +12,6 @@
     csvdiff = ranks_out.csv
     min_parallel = 3
     requirement = "The system shall correctly output the number of NekRS MPI ranks"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/dimensionless_numbers/nondimensional/tests
+++ b/test/tests/postprocessors/dimensionless_numbers/nondimensional/tests
@@ -4,13 +4,13 @@
     input = nek.i
     csvdiff = nek_out.csv
     requirement = "The system shall correctly compute the Reynolds and Peclet numbers for a nondimensional NekRS case."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [check_zero_scratch]
     type = RunApp
     input = nek.i
     cli_args = 'Problem/n_usrwrk_slots=0'
     requirement = "The system shall allow zero scratch space allocation."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/eigenvalue/tests
+++ b/test/tests/postprocessors/eigenvalue/tests
@@ -7,6 +7,6 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The k-eigenvalue and its standard deviation shall be correctly retrieved from the OpenMC solution."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/postprocessors/fission_tally_relative_error/tests
+++ b/test/tests/postprocessors/fission_tally_relative_error/tests
@@ -7,7 +7,7 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The maximum and minimum tally relative errors shall be correctly retrieved from the OpenMC solution."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [multi_score]
     type = CSVDiff
@@ -17,7 +17,7 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The maximum and minimum tally relative errors shall be correctly retrieved from the OpenMC solution when using multiple scores."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [nonexistent_score]
     type = RunException
@@ -28,7 +28,7 @@
     max_parallel = 8
     expect_err = "To extract the relative error of the 'flux' score"
     requirement = "The system shall error if trying to extract score information that does not exist"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [manual_rel_err_calc]
     type = CSVDiff
@@ -38,6 +38,6 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The system shall prove equivalence between a by-hand calculation of relative error (std_dev output divided by tally value) as compared to the tally relative error postprocessor."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/postprocessors/nek_heat_flux_integral/tests
+++ b/test/tests/postprocessors/nek_heat_flux_integral/tests
@@ -13,6 +13,6 @@
                   "and quadrature rules are different between nekRS and MOOSE's linear Lagrange "
                   "variables - we just require that they are reasonably close. A fairly fine mesh "
                   "is used in MOOSE to get closer to the higher-polynomial-order integration in nekRS."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/nek_point_value/tests
+++ b/test/tests/postprocessors/nek_point_value/tests
@@ -9,21 +9,21 @@
       input = points.i
       csvdiff = points_out.csv
       detail = 'dimensional form'
-      required_objects = 'NekRSProblem'
+      capabilities = 'nekrs'
     []
     [nondimensional]
       type = CSVDiff
       input = points_nondimensional.i
       csvdiff = points_nondimensional_out.csv
       detail = 'non-dimensional form'
-      required_objects = 'NekRSProblem'
+      capabilities = 'nekrs'
     []
     [usrwrk_units]
       type = CSVDiff
       input = usrwrk_units.i
       csvdiff = usrwrk_units_out.csv
       detail = 'non-dimensional scaling of usrwrk slots for which the units are known'
-      required_objects = 'NekRSProblem'
+      capabilities = 'nekrs'
     []
   []
 
@@ -36,7 +36,7 @@
       cli_args = 'Postprocessors/usrwrk/field=usrwrk00 --error'
       expect_err = "The units of 'usrwrk00' are unknown, so we cannot dimensionalize any objects using 'field = usrwrk00'."
       detail = 'usrwrk slot 0'
-      required_objects = 'NekRSProblem'
+      capabilities = 'nekrs'
     []
     [u01]
       type = RunException
@@ -44,7 +44,7 @@
       cli_args = 'Postprocessors/usrwrk/field=usrwrk01 --error'
       expect_err = "The units of 'usrwrk01' are unknown, so we cannot dimensionalize any objects using 'field = usrwrk01'."
       detail = 'usrwrk slot 1'
-      required_objects = 'NekRSProblem'
+      capabilities = 'nekrs'
     []
     [u02]
       type = RunException
@@ -52,7 +52,7 @@
       cli_args = '--error'
       expect_err = "The units of 'usrwrk02' are unknown, so we cannot dimensionalize any objects using 'field = usrwrk02'."
       detail = 'usrwrk slot 2'
-      required_objects = 'NekRSProblem'
+      capabilities = 'nekrs'
     []
   []
 []

--- a/test/tests/postprocessors/nek_pressure_surface_force/tests
+++ b/test/tests/postprocessors/nek_pressure_surface_force/tests
@@ -5,7 +5,7 @@
     csvdiff = nek_out.csv
     abs_zero = 1e-12
     requirement = "The system shall allow pressure drag to be computed in the x, y, and z directions in dimensional form. This test compares drag as computed via Nek with by-hand calculations using combinations of native MOOSE postprocessors acting on the NekRS pressure mapped to the mesh mirror, for dimensional form"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [pressure_nondim]
     type = CSVDiff
@@ -13,7 +13,7 @@
     csvdiff = nek_nondimensional_out.csv
     abs_zero = 1e-12
     requirement = "The system shall allow pressure drag to be computed in the x, y, and z directions in dimensional form. This test compares drag as computed via Nek with by-hand calculations using combinations of native MOOSE postprocessors acting on the NekRS pressure mapped to the mesh mirror, for nondimensional form"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [invalid_mesh]
     type = RunException
@@ -21,6 +21,6 @@
     cli_args = 'Postprocessors/pressure_x/mesh=all'
     expect_err = "The 'NekPressureSurfaceForce' postprocessor can only be applied to"
     requirement = "The system shall error if trying to compute pressure drag on non-fluid NekRS boundaries"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/nek_side_average/tests
+++ b/test/tests/postprocessors/nek_side_average/tests
@@ -13,7 +13,7 @@
                   "Perfect agreement is not to be expected, since the underlying basis functions "
                   "and quadrature rules are different between nekRS and MOOSE's linear Lagrange "
                   "variables - we just require that they are reasonably close."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     issues = '#1015' # not finished
   []
 []

--- a/test/tests/postprocessors/nek_side_extrema/tests
+++ b/test/tests/postprocessors/nek_side_extrema/tests
@@ -9,7 +9,7 @@
                   "by running the moose.i input, which computes the same max/min operations using "
                   "existing MOOSE postprocessors on the same mesh on auxvariables that match "
                   "the functional form of the solution fields initialized in the pyramid.udf. "
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [invalid_field]
     type = RunException
@@ -17,6 +17,6 @@
     cli_args = "Postprocessors/max_temp_side1/field=velocity_component Postprocessors/max_temp_side1/velocity_direction='1 0 0'"
     expect_err = "Setting 'field = velocity_component' is not yet implemented"
     requirement = "System shall error if using an unsupported field with a side extrema postprocessor."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/nek_side_integral/tests
+++ b/test/tests/postprocessors/nek_side_integral/tests
@@ -12,6 +12,6 @@
                   "Perfect agreement is not to be expected, since the underlying basis functions "
                   "and quadrature rules are different between nekRS and MOOSE's linear Lagrange "
                   "variables - we just require that they are reasonably close."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/nek_usrwrk_boundary_integral/tests
+++ b/test/tests/postprocessors/nek_usrwrk_boundary_integral/tests
@@ -4,6 +4,6 @@
     input = nek.i
     expect_err = "'usrwrk_slot' must be less than number of allocated usrwrk slots: 7"
     requirement = "The system shall error if the requested usrwrk slot to integrate exceeds the number allocated"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/nek_viscous_surface_force/tests
+++ b/test/tests/postprocessors/nek_viscous_surface_force/tests
@@ -4,7 +4,7 @@
     input = nek.i
     csvdiff = nek_out.csv
     requirement = "The system shall allow total viscous drag to be computed in dimensional form. This test compares drag as computed via Nek with by-hand calculations using combinations of native MOOSE postprocessors using the analytic expression for velocity."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [invalid_mesh]
     type = RunException
@@ -12,6 +12,6 @@
     cli_args = 'Postprocessors/viscous_1/mesh=all'
     expect_err = "The 'NekViscousSurfaceForce' postprocessor can only be applied to"
     requirement = "The system shall error if trying to compute viscous drag on non-fluid NekRS boundaries"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/nek_volume_average/tests
+++ b/test/tests/postprocessors/nek_volume_average/tests
@@ -8,13 +8,13 @@
     input = nek.i
     csvdiff = nek_out.csv
     requirement = 'dimensional form'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [nondimensional]
     type = CSVDiff
     input = nondimensional.i
     csvdiff = nondimensional_out.csv
     requirement = 'nondimensional form'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/nek_volume_extrema/tests
+++ b/test/tests/postprocessors/nek_volume_extrema/tests
@@ -8,7 +8,7 @@
                   "by running the moose.i input, which computes the same max/min operations using "
                   "existing MOOSE postprocessors on the same mesh on auxvariables that match "
                   "the functional form of the solution fields initialized in the pyramid.udf. "
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [invalid_field]
     type = RunException
@@ -16,6 +16,6 @@
     cli_args = "Postprocessors/max_temp/field=velocity_component Postprocessors/max_temp/velocity_direction='1 0 0'"
     expect_err = "Setting 'field = velocity_component' is not yet implemented"
     requirement = "System shall error if using an unsupported field with a volume extrema postprocessor."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/nek_volume_integral/tests
+++ b/test/tests/postprocessors/nek_volume_integral/tests
@@ -8,13 +8,13 @@
     input = nek.i
     csvdiff = nek_out.csv
     requirement = 'dimensional form'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [nondimensional]
     type = CSVDiff
     input = nondimensional.i
     csvdiff = nondimensional_out.csv
     requirement = 'nondimensional form'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/nek_weighted_side_average/tests
+++ b/test/tests/postprocessors/nek_weighted_side_average/tests
@@ -15,6 +15,6 @@
                   "Perfect agreement is not to be expected, since the underlying basis functions "
                   "and quadrature rules are different between nekRS and MOOSE's linear Lagrange "
                   "variables - we just require that they are reasonably close."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/nek_weighted_side_integral/tests
+++ b/test/tests/postprocessors/nek_weighted_side_integral/tests
@@ -12,7 +12,7 @@
                   "Perfect agreement is not to be expected, since the underlying basis functions "
                   "and quadrature rules are different between nekRS and MOOSE's linear Lagrange "
                   "variables - we just require that they are reasonably close."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [invalid_field]
     type = RunException
@@ -20,6 +20,6 @@
     cli_args = "Postprocessors/weighted_T_side1/field=velocity_component Postprocessors/weighted_T_side1/velocity_direction='1 0 0'"
     expect_err = "This class does not support 'field = velocity_component'"
     requirement = "System shall error if using an unsupported field with a mass flux weighted postprocessor."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/postprocessors/openmc_particles/tests
+++ b/test/tests/postprocessors/openmc_particles/tests
@@ -4,6 +4,6 @@
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall allow the number of particles run by OpenMC to be extracted as a postprocessor"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/postprocessors/reactivity/tests
+++ b/test/tests/postprocessors/reactivity/tests
@@ -9,6 +9,6 @@
     # in the fission bank on a process
     max_parallel = 8
     requirement = "The k-eigenvalue and its standard deviation shall be correctly retrieved from the OpenMC solution."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/sam_coupling/sam_master/tests
+++ b/test/tests/sam_coupling/sam_master/tests
@@ -5,6 +5,6 @@
     cli_args = '--app SamApp'
     requirement = "Cardinal shall be able to run SAM as the master application without any data transfers. "
                   "This test just ensures correct setup of SAM as a submodule with app registration."
-    required_applications = 'SamApp'
+    capabilities = 'samapp'
   []
 []

--- a/test/tests/sam_coupling/sam_sub/tests
+++ b/test/tests/sam_coupling/sam_sub/tests
@@ -4,6 +4,6 @@
     input = cardinal_master.i
     requirement = "Cardinal shall be able to run SAM as a sub-application without any data transfers. "
                   "This test just ensures correct setup of SAM as a submodule with app registration."
-    required_applications = 'SamApp'
+    capabilities = 'samapp'
   []
 []

--- a/test/tests/sockeye_coupling/sockeye_master/tests
+++ b/test/tests/sockeye_coupling/sockeye_master/tests
@@ -5,6 +5,6 @@
 
     requirement = "Cardinal shall be able to run Sockeye as a master-application without any data transfers. "
                   "This test just ensures correct setup of Sockeye as a submodule with app registration."
-    required_applications = 'SockeyeApp'
+    capabilities = 'sockeyeapp'
   []
 []

--- a/test/tests/sockeye_coupling/sockeye_sub/tests
+++ b/test/tests/sockeye_coupling/sockeye_sub/tests
@@ -4,6 +4,6 @@
     input = cardinal_master.i
     requirement = "Cardinal shall be able to run Sockeye as a sub-application without any data transfers. "
                   "This test just ensures correct setup of Sockeye as a submodule with app registration."
-    required_applications = 'SockeyeApp'
+    capabilities = 'sockeyeapp'
   []
 []

--- a/test/tests/symmetry/tests
+++ b/test/tests/symmetry/tests
@@ -4,13 +4,13 @@
     input = reflection.i
     exodiff = reflection_out.e
     requirement = "The OpenMC wrapping shall allow visualization of point reflection transformations"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [rotation]
     type = Exodiff
     input = rotation.i
     exodiff = rotation_out.e
     requirement = "The OpenMC wrapping shall allow visualization of rotation transformations"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/transfers/nek_postprocessor_value/tests
+++ b/test/tests/transfers/nek_postprocessor_value/tests
@@ -4,6 +4,6 @@
     input = nek.i
     csvdiff = nek_out.csv
     requirement = "The system shall be able to transfer postprocessors to NekRS; we check this by passing postprocessors into the usrwrk array, and then using them as boundary conditions and looking at the field solution values on those boundaries."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/transfers/nek_scalar_value/tests
+++ b/test/tests/transfers/nek_scalar_value/tests
@@ -4,6 +4,6 @@
     input = nek.i
     csvdiff = nek_out.csv
     requirement = "The NekScalarValue shall allow NekRS simulations to interface with MOOSE's Controls system"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/userobjects/gap/nondimensional/tests
+++ b/test/tests/userobjects/gap/nondimensional/tests
@@ -6,6 +6,6 @@
     requirement = "Spatially-binned volume integrals and averages shall be correctly dimensionalized for "
                   "nondimensional cases. An equivalent setup with a dimensional problem is available at "
                   "../dimensional. The user object averages/integrals computed here exactly match."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/userobjects/hexagonal_gap_layered/normals/tests
+++ b/test/tests/userobjects/hexagonal_gap_layered/normals/tests
@@ -6,7 +6,7 @@
     requirement = "A hexagonal gap and 1-D layered bin shall be combined to give a multi-dimensional "
                   "binning and demonstrate correct results for side integrals and averages in directions "
                   "normal to the gap planes."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     max_time = 400
   []
   [normal_component_aux]
@@ -14,6 +14,6 @@
     input = nek_axial.i
     exodiff = 'nek_axial_out_subchannel0.e'
     requirement = "The correct unit normals shall be formed for a layered Cartesian gap bin."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/userobjects/hexagonal_gap_layered/tests
+++ b/test/tests/userobjects/hexagonal_gap_layered/tests
@@ -4,7 +4,7 @@
     input = type_error.i
     expect_err = "This user object requires exactly one bin distribution to be a side distribution; you have specified: 0"
     requirement = "The system shall error if the userobjects aren't derived from the correct base class."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [gap_layered]
     type = Exodiff
@@ -13,7 +13,7 @@
     rel_err = 5e-5
     requirement = "A hexagonal gap and 1-D layered bin shall be combined to give a multi-dimensional "
                   "binning and demonstrate correct results for side integrals and averages."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [gap_horizontal_layered]
     type = Exodiff
@@ -21,7 +21,7 @@
     exodiff = 'nek_axial_out_subchannel0.e'
     requirement = "A layered gap and 2-D hexagonal subchannel bin shall be combined to give a multi-dimensional "
                   "binning and demonstrate correct results for side integrals and averages."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [bins_too_fine]
     type = RunException
@@ -29,7 +29,7 @@
     cli_args = "UserObjects/axial_binning/num_layers=1000"
     expect_err = "Failed to map any GLL points to bin 1!"
     requirement = "The system shall error if there are zero contributions to a gap bin."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [user_component]
     type = Exodiff
@@ -38,6 +38,6 @@
     requirement = "A hexagonal gap and 1-D layered bin shall be combined to give a multi-dimensional "
                   "binning and demonstrate correct results for side averages of velocity along a "
                   "user-specified direction."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/userobjects/interval/tests
+++ b/test/tests/userobjects/interval/tests
@@ -7,7 +7,7 @@
     requirement = "The system shall allow the Nek user objects to only evaluate on a fixed interval "
                   "of time steps. The gold files were created by setting interval = 1 to ensure that "
                   "the output files are exactly identical at the specified interval steps."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [interval_synchronization]
     type = CSVDiff
@@ -16,6 +16,6 @@
     requirement = "The system shall allow the Nek to mesh-mirror interpolation to only occur on a fixed interval "
                   "of time steps. The gold files were created by setting interval = 1 to ensure that "
                   "the output files are exactly identical at the specified interval steps."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/userobjects/layered_layered/tests
+++ b/test/tests/userobjects/layered_layered/tests
@@ -5,7 +5,7 @@
     exodiff = nek_out.e
     requirement = "Multiple 1-D layered bins shall be combined to give a multi-dimensional binning "
                   "and demonstrate correct results for volume integrals and averages."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [conflicting_bins]
     type = RunException
@@ -13,7 +13,7 @@
     expect_err = "Cannot combine multiple distributions in the same coordinate direction!\n"
                  "Bin 'x_bins2' conflicts with bin 'x_bins'"
     requirement = "System shall error if user attemps to combine multiple bins that specify the same coordinate direction."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [1d_output]
     type = CSVDiff
@@ -21,14 +21,14 @@
     csvdiff = '1d_out_from_uo_0002.csv 1d_out_from_uo_gap_0002.csv'
     requirement = "The output points shall be automatically output for a 1-D Cartesian volume distribution "
                   "and a 1-D Cartesian surface distribution."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [3d_output]
     type = CSVDiff
     input = 3d.i
     csvdiff = 3d_out_from_uo_0002.csv
     requirement = "The output points shall be automatically output for a 3-D Cartesian distribution."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [bins_too_fine]
     type = RunException
@@ -36,6 +36,6 @@
     cli_args = 'UserObjects/z_bins/num_layers=1000'
     expect_err = 'Failed to map any element centroids to bin 0!'
     requirement = 'System shall error if no points map to a spatial bin'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/userobjects/moab_skinner/errors/tests
+++ b/test/tests/userobjects/moab_skinner/errors/tests
@@ -6,7 +6,7 @@
     mesh_mode = 'replicated'
     expect_err = "'temperature_max' must be greater than 'temperature_min'"
     requirement = "The system shall error if the maximum temperature is lower than the minimum temperature for the skinner bins"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [invalid_max_density]
     type = RunException
@@ -15,7 +15,7 @@
     mesh_mode = 'replicated'
     expect_err = "'density_max' must be greater than 'density_min'"
     requirement = "The system shall error if the maximum density is lower than the minimum density for the skinner bins"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [too_low_temp]
     type = RunException
@@ -24,7 +24,7 @@
     mesh_mode = 'replicated'
     expect_err = "Variable 'temp' has value below minimum range of bins. Please decrease 'temperature_min'."
     requirement = "The system shall error if the temperature is below the minimum bin bound"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [too_high_temp]
     type = RunException
@@ -33,7 +33,7 @@
     mesh_mode = 'replicated'
     expect_err = "Variable 'temp' has value above maximum range of bins. Please increase 'temperature_max'."
     requirement = "The system shall error if the temperature is above the maximum bin bound"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [too_low_density]
     type = RunException
@@ -42,7 +42,7 @@
     mesh_mode = 'replicated'
     expect_err = "Variable 'rho' has value below minimum range of bins. Please decrease 'density_min'."
     requirement = "The system shall error if the density is below the minimum bin bound"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [too_high_density]
     type = RunException
@@ -51,7 +51,7 @@
     mesh_mode = 'replicated'
     expect_err = "Variable 'rho' has value above maximum range of bins. Please increase 'density_max'."
     requirement = "The system shall error if the density is above the maximum bin bound"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [invalid_mesh]
     type = RunException
@@ -60,7 +60,7 @@
     mesh_mode = 'replicated'
     expect_err = "The MoabSkinner can only be used with a tetrahedral \[Mesh\]!"
     requirement = "The system shall error if the skinned mesh does not contain tetrahedral elements"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [invalid_graveyard_scales]
     type = RunException
@@ -69,7 +69,7 @@
     mesh_mode = 'replicated'
     expect_err = "'graveyard_scale_outer' must be greater than 'graveyard_scale_inner'!"
     requirement = "The system shall error if the outer graveyard surface is not larger than the inner graveyard surface"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [no_aux_temp]
     type = RunException
@@ -78,7 +78,7 @@
     expect_err = "Cannot find auxiliary variable 'temperature'!"
     mesh_mode = 'replicated'
     requirement = "The system shall error if the specified temperature auxiliary variable cannot be found"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [no_aux_density]
     type = RunException
@@ -87,7 +87,7 @@
     mesh_mode = 'replicated'
     expect_err = "Cannot find auxiliary variable 'den'!"
     requirement = "The system shall error if the specified density auxiliary variable cannot be found"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [overlap_t_rho]
     type = RunException
@@ -96,7 +96,7 @@
     mesh_mode = 'replicated'
     expect_err = "The 'temperature' and 'density' variables cannot be the same!"
     requirement = "The system shall error if the specified density and temperature auxiliary variables are the same"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [distributed]
     type = RunException
@@ -104,7 +104,7 @@
     mesh_mode = 'distributed'
     expect_err = "MoabSkinner does not yet support distributed meshes!"
     requirement = "The system shall error if trying to run in distributed mesh mode"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [incorrect_material_names]
     type = RunException
@@ -113,6 +113,6 @@
     mesh_mode = 'replicated'
     expect_err = "This parameter must be the same length as the number of subdomains in the mesh \(1\)"
     requirement = "The system shall error if the material_names provided to the skinner do not match the required length"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/userobjects/moab_skinner/expanding-cube/tests
+++ b/test/tests/userobjects/moab_skinner/expanding-cube/tests
@@ -5,14 +5,14 @@
     exodiff = constant_expansion_coeff_out_sub0.e
     mesh_mode = 'replicated'
     requirement = "The system shall bin elements according to temperature and density  on an expanding mesh and be able to visualize the bins on the mesh volume."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [convert_to_gmsh_step0]
     type = RunCommand
     prereq = bins
     command = '../../../../../install/bin/mbconvert moab_skins_0.h5m skins0.msh'
     requirement = "The system shall be able to convert a .h5m file to gmsh"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
     installation_type = in_tree
     use_shell = True
   []
@@ -21,7 +21,7 @@
     prereq = bins
     command = '../../../../../install/bin/mbconvert moab_skins_1.h5m skins1.msh'
     requirement = "The system shall be able to convert a .h5m file to gmsh"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
     installation_type = in_tree
     use_shell = True
   []

--- a/test/tests/userobjects/moab_skinner/graveyard/tests
+++ b/test/tests/userobjects/moab_skinner/graveyard/tests
@@ -3,14 +3,14 @@
     type = RunApp
     input = graveyard.i
     mesh_mode = 'replicated'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [convert_to_gmsh]
     type = RunCommand
     prereq = graveyard
     command = '../../../../../install/bin/mbconvert moab_skins_0.h5m skins.msh'
     requirement = "The system shall be able to convert a .h5m file to gmsh"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
     installation_type = in_tree
     use_shell = True
   []

--- a/test/tests/userobjects/moab_skinner/output/tests
+++ b/test/tests/userobjects/moab_skinner/output/tests
@@ -5,14 +5,14 @@
     check_files = 'moab_mesh_0.h5m'
     mesh_mode = 'replicated'
     requirement = "The system shall output the MOAB mesh copied from libMesh into the .h5m format"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [convert_to_gmsh]
     type = RunCommand
     prereq = output_mesh
     command = '../../../../../install/bin/mbconvert moab_mesh_0.h5m mesh.msh'
     requirement = "The system shall be able to convert a .h5m file to gmsh"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
     installation_type = in_tree
     use_shell = True
   []

--- a/test/tests/userobjects/moab_skinner/second_order/tests
+++ b/test/tests/userobjects/moab_skinner/second_order/tests
@@ -5,14 +5,14 @@
     exodiff = all_bins_out.e
     mesh_mode = 'replicated'
     requirement = "The system shall bin elements according to temperature and density, on multiple subdomains, and be able to visualize the bins on the mesh volume for second-order tets."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [convert_to_gmsh_step0]
     type = RunCommand
     prereq = bins
     command = '../../../../../install/bin/mbconvert moab_skins_0.h5m skins0.msh'
     requirement = "The system shall be able to convert a .h5m file to gmsh"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
     installation_type = in_tree
     use_shell = True
   []
@@ -21,7 +21,7 @@
     prereq = bins
     command = '../../../../../install/bin/mbconvert moab_skins_1.h5m skins1.msh'
     requirement = "The system shall be able to convert a .h5m file to gmsh"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
     installation_type = in_tree
     use_shell = True
   []

--- a/test/tests/userobjects/moab_skinner/tests
+++ b/test/tests/userobjects/moab_skinner/tests
@@ -5,7 +5,7 @@
     exodiff = all_bins_out.e
     mesh_mode = 'replicated'
     requirement = "The system shall bin elements according to temperature and density, on multiple subdomains, and be able to visualize the bins on the mesh volume."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [bins_without_density]
     type = Exodiff
@@ -13,14 +13,14 @@
     exodiff = sub_bins_out.e
     mesh_mode = 'replicated'
     requirement = "The system shall bin elements according to temperature, on multiple subdomains, and be able to visualize the bins."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [convert_to_gmsh_step0]
     type = RunCommand
     prereq = bins
     command = '../../../../install/bin/mbconvert moab_skins_0.h5m skins0.msh'
     requirement = "The system shall be able to convert a .h5m file to gmsh"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
     installation_type = in_tree
     use_shell = True
   []
@@ -29,7 +29,7 @@
     prereq = bins
     command = '../../../../install/bin/mbconvert moab_skins_1.h5m skins1.msh'
     requirement = "The system shall be able to convert a .h5m file to gmsh"
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
     installation_type = in_tree
     use_shell = True
   []
@@ -55,6 +55,6 @@
     mesh_mode = 'replicated'
     expect_err = "Auxiliary variable 'temp' must be a CONSTANT MONOMIAL type!"
     requirement = "The system shall error if the requirements for a binning variable type are violated."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/test/tests/userobjects/openmc_nuclide_densities/tests
+++ b/test/tests/userobjects/openmc_nuclide_densities/tests
@@ -6,7 +6,7 @@
     expect_err = 'In attempting to get the material index for material with ID 3, OpenMC reported:\n\n'
                  'No material exists with ID=3.'
     requirement = 'The system shall error if trying to change nuclide densities for a non-existing material ID.'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [nonexistent_nuclide]
     type = RunException
@@ -15,7 +15,7 @@
     expect_err = "In attempting to set nuclide densities in the 'mat1' UserObject, OpenMC reported:\n\n"
                  "Nuclide 'fake' is not present in library."
     requirement = "The system shall error if trying to add a nuclide not accessible in the cross section library."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [no_change]
     type = CSVDiff
@@ -23,7 +23,7 @@
     csvdiff = no_change_out.csv
     requirement = "The system shall give identical results to a standalone OpenMC run if the nuclide compositions "
                   "are modified, but are still set to their initial values."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [no_composition_change]
     type = CSVDiff
@@ -31,21 +31,21 @@
     csvdiff = only_density_out.csv
     requirement = "The system shall give identical results to a standalone OpenMC run if the nuclide densities "
                   "are modified, but there are no nuclides added or removed."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [thermal_density]
     type = CSVDiff
     input = thermal_density.i
     csvdiff = thermal_density_out.csv
     requirement = "The system shall give identical results to a standalone OpenMC run if the nuclide densities and nuclides are modified, after which the total density is modified due to thermal effects."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [nuclide_and_density]
     type = CSVDiff
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall give identical results to a standalone OpenMC run if the nuclide densities and nuclides are modified."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [different_length]
     type = RunException
@@ -53,6 +53,6 @@
     cli_args = 'UserObjects/mat1/names="a b" UserObjects/mat1/densities="1.0"'
     expect_err = "'names' and 'densities' must be the same length!"
     requirement = "The system shall error if inconsistent lengths for names and densities are provided."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/userobjects/openmc_tally_editor/tests
+++ b/test/tests/userobjects/openmc_tally_editor/tests
@@ -10,7 +10,7 @@
       cli_args = 'UserObjects/tally_editor_uo/tally_id=3000'
       expect_err = 'Tally 3000 does not exist in the OpenMC model'
       detail = 'trying to edit a non-existant tally'
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
     [nonexistent_nuclide]
       type = RunException
@@ -18,7 +18,7 @@
       cli_args = 'UserObjects/tally_editor_uo/nuclides="fake fake2"'
       expect_err = "Nuclide 'fake' is not present in library."
       detail = "trying to add a nuclide not accessible in the cross section library"
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
     [invalid_score]
       type = RunException
@@ -26,7 +26,7 @@
       cli_args = 'UserObjects/tally_editor_uo/scores="invalid"'
       expect_err = 'Invalid tally score "invalid".'
       detail = 'trying to add an invalid score to a tally'
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
     [nonexistent_filter]
       type = RunException
@@ -34,7 +34,7 @@
       cli_args = 'UserObjects/new_filter/create_filter=false'
       expect_err = 'Filter 100 does not exist and create_filter is false'
       detail = 'the filter referenced by an OpenMCFilterEditor via ID does not exist and is not flagged for creation'
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
     [clashing_filter_types]
       type = RunException
@@ -42,28 +42,28 @@
       cli_args = 'UserObjects/new_filter/filter_type="universe" UserObjects/new_filter/filter_id=1'
       expect_err = 'An existing filter, Filter 1, is of type "cell" and cannot be changed to type "universe"'
       detail = 'an OpenMCDomainFilter editor exists with the same filter ID but a different filter type'
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
     [clashing_filter_ids]
       type = RunException
       input = clashing_filter_ids.i
       expect_err = 'Filter ID \(10\) found in multiple OpenMCDomainFilterEditors'
       detail = 'more than one OpenMCDomainFilterEditor eixsts with the same filter ID'
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
     [clashing_tally_ids]
       type = RunException
       input = clashing_tally_ids.i
       expect_err = 'Tally ID \(10\) found in multiple OpenMCTallyEditors'
       detail = 'more than one OpenMCTallyEditor eixsts with the same tally ID'
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
     [clashing_mapped_tally]
       type = RunException
       input = clash_mapped_tally.i
       expect_err = 'Tally ID 3 is a tally which Cardinal has automatically created and is controlling'
       detail = 'an OpenMCTallyEditor eixsts for a mapped tally created by Cardinal'
-      required_objects = 'OpenMCCellAverageProblem'
+      capabilities = 'openmc'
     []
   []
 
@@ -74,7 +74,7 @@
     file_expect_out ='U238'
     requirement = 'Ensure that nuclides specified by a tally editor UO are present in the tally output'
     cli_args = 'UserObjects/tally_editor_uo/nuclides="U238"'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [scatter_tally]
     type = CheckFiles
@@ -82,7 +82,7 @@
     check_files = tallies.out
     requirement = 'Ensure that the scattering score specified by a tally editor UO are present in the tally output'
     file_expect_out = 'Scattering Rate'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [absorption_u238]
     type = CheckFiles
@@ -90,7 +90,7 @@
     check_files = tallies.out
     requirement = 'Ensure that the absorption score for a specific nuclide specified by a tally editor UO are present in the tally output'
     file_expect_out = 'U238\n   Absorption Rate'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [add_cell_filter]
     type = CheckFiles
@@ -98,7 +98,7 @@
     check_files = tallies.out
     requirement = 'Ensure that a cell filter specified by a tally editor UO are present in the tally output'
     file_expect_out = 'Cell'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [add_material_filter]
     type = CheckFiles
@@ -107,7 +107,7 @@
     cli_args = 'UserObjects/new_filter/filter_type="material"'
     requirement = 'Ensure that a material filter specified by a tally editor UO are present in the tally output'
     file_expect_out = 'Material'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [add_universe_filter]
     type = CheckFiles
@@ -116,6 +116,6 @@
     cli_args = 'UserObjects/new_filter/filter_type="universe"'
     requirement = 'Ensure that a universe filters specified by a tally editor UO are present in the tally output'
     file_expect_out = 'Universe'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/userobjects/radial_layered/tests
+++ b/test/tests/userobjects/radial_layered/tests
@@ -5,7 +5,7 @@
     csvdiff = 1d_out_from_uo_0002.csv
     cli_args = 'UserObjects/vol_integral/check_zero_contributions=false'
     requirement = "The output points shall be automatically output for a single-axis radial distribution."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [2d_output]
     type = CSVDiff
@@ -13,6 +13,6 @@
     csvdiff = 2d_out_from_uo_0002.csv
     cli_args = 'UserObjects/vol_integral/check_zero_contributions=false'
     requirement = "The output points shall be automatically output for a single-axis radial distribution plus a 1-D distribution."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/userobjects/side/nondimensional/tests
+++ b/test/tests/userobjects/side/nondimensional/tests
@@ -3,7 +3,7 @@
     type = RunCommand
     command = '${NEKRS_HOME}/bin/nrspre sfr_7pin 1'
     requirement = "The system shall precompile a Nek case in preparation for a multi-input simulation."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     use_shell = True
   []
   [nondim]
@@ -14,7 +14,7 @@
                   "nondimensional cases. An equivalent setup with a dimensional problem is available at "
                   "../dimensional. The user object averages/integrals computed here exactly match."
     prereq = precompile
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     skip = 'Need to resolve precompile issues'
   []
 []

--- a/test/tests/userobjects/sideset_layered/tests
+++ b/test/tests/userobjects/sideset_layered/tests
@@ -4,7 +4,7 @@
     input = invalid_boundary.i
     expect_err = "Invalid 'boundary' entry: 5"
     requirement = "The system shall error if an invalid boundary ID is specified"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [z_bins]
     type = Exodiff
@@ -12,20 +12,20 @@
     exodiff = z_bins_out.e
     rel_err = 5e-4
     requirement = "The system shall correctly integrate over a sideset in the NekRS domain when mapping space by the quadrature point"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [z_bins_by_centroid]
     type = Exodiff
     input = z_bins_by_centroid.i
     exodiff = z_bins_by_centroid_out.e
     requirement = "The system shall correctly integrate over a sideset in the NekRS domain when mapping space by the face centroid"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [side_average]
     type = Exodiff
     input = side_average.i
     exodiff = side_average_out.e
     requirement = "The system shall correctly average over a sideset in the NekRS domain"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/userobjects/subchannel_layered/tests
+++ b/test/tests/userobjects/subchannel_layered/tests
@@ -4,14 +4,14 @@
     input = type_error.i
     expect_err = "Bin user object with name 'dummy' must inherit from SpatialBinUserObject."
     requirement = "The system shall error if the userobjects aren't derived from the correct base class."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [ordering_error]
     type = RunException
     input = order_error.i
     expect_err = "Bin user object with name 'subchannel_binning' not found in problem. The user objects in 'bins' must be listed before the 'vol_avg' user object."
     requirement = "The system shall error if the userobjects aren't listed in the correct order in the input file."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [subchannel_layered]
     type = Exodiff
@@ -19,7 +19,7 @@
     exodiff = 'nek_out.e nek_out_subchannel0.e'
     requirement = "A subchannel and 1-D layered bin shall be combined to give a multi-dimensional "
                   "binning and demonstrate correct results for volume integrals and averages."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [conflicting_bins]
     type = RunException
@@ -27,21 +27,21 @@
     expect_err = "Cannot combine multiple distributions in the same coordinate direction!\n"
                  "Bin 'x_bins' conflicts with bin 'subchannel_binning'"
     requirement = "System shall error if user attemps to combine multiple bins that specify the same coordinate direction."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [1d_output]
     type = CSVDiff
     input = 1d.i
     csvdiff = 1d_out_from_uo_0002.csv
     requirement = "The output points shall be automatically output for a single-axis subchannel binning"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [wrong_type]
     type = RunException
     input = wrong_type.i
     expect_err = "This user object requires all bins to be volume distributions"
     requirement = "System shall error if a side user object is provided to a volume binning user object."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [invalid_component]
     type = RunException
@@ -49,7 +49,7 @@
     cli_args = "UserObjects/vol_avg/field=velocity_component UserObjects/vol_avg/velocity_component=normal"
     expect_err = "Setting 'velocity_component = normal' is not supported"
     requirement = "System shall error if attempting to use a normal velocity component with a user object that does not have normals defined"
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [user_component]
     type = Exodiff
@@ -58,13 +58,13 @@
     requirement = "A subchannel and 1-D layered bin shall be combined to give a multi-dimensional "
                   "binning and demonstrate correct results for volume averages of velocity projected "
                   "along a constant direction."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [pin_1d]
     type = CSVDiff
     input = pin_1d.i
     csvdiff = pin_1d_out_from_uo_0002.csv
     requirement = "A pin-centered subchannel bin shall give correct results for side averages of temperature."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/userobjects/volume/nondimensional/tests
+++ b/test/tests/userobjects/volume/nondimensional/tests
@@ -6,6 +6,6 @@
     requirement = "Spatially-binned volume integrals and averages shall be correctly dimensionalized for "
                   "nondimensional cases. An equivalent setup with a dimensional problem is available at "
                   "../dimensional. The user object averages/integrals computed here exactly match."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/test/tests/userobjects/volume_calculation/instances/tests
+++ b/test/tests/userobjects/volume_calculation/instances/tests
@@ -5,14 +5,14 @@
     cli_args = '--error'
     expect_err = "OpenMC's stochastic volume calculation cannot individually measure volumes of cell INSTANCES."
     requirement = "The system shall warn the user if encountering volume calculations needing instance-level granularity, since this is not available yet in OpenMC itself."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [instances]
     type = CSVDiff
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall map from a stochastic volume calculation to MOOSE for repeated cell instances"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [rel_err_trigger]
     type = CSVDiff
@@ -20,6 +20,6 @@
     csvdiff = rel_err_out.csv
     cli_args = 'UserObjects/vol/trigger=rel_err UserObjects/vol/trigger_threshold=1e-2 Outputs/file_base=rel_err_out'
     requirement = "The system shall terminate the stochastic volume calculation using a relative error metric."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/test/tests/userobjects/volume_calculation/tests
+++ b/test/tests/userobjects/volume_calculation/tests
@@ -5,14 +5,14 @@
     cli_args = 'UserObjects/vol/lower_left="10.0 0.0 0.0"'
     expect_err = "The 'upper_right' \(2.5, 2.5, 10\) must be greater than the 'lower_left' \(10, 0, 0\)!"
     requirement = "The system shall error if an invalid bounding box is specified for volume calculations"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [single_level]
     type = CSVDiff
     input = openmc.i
     csvdiff = openmc_out.csv
     requirement = "The system shall map stochastic volumes for each OpenMC cell which maps to MOOSE."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [single_level_scaling]
     type = CSVDiff
@@ -20,7 +20,7 @@
     csvdiff = scaling_out.csv
     requirement = "The system shall map stochastic volumes for each OpenMC cell which maps to MOOSE when the Mesh "
                   "is not in units of centimeters"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [missing_vol]
     type = RunException
@@ -28,7 +28,7 @@
     expect_err = "To display the actual OpenMC cell volumes"
     requirement = "The system shall error if trying to view stochastic volumes without the stochastic "
                   "volume calculation having been created."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [rel_err_trigger]
     type = CSVDiff
@@ -36,13 +36,13 @@
     csvdiff = rel_err_out.csv
     cli_args = 'UserObjects/vol/trigger=rel_err UserObjects/vol/trigger_threshold=1e-2 Outputs/file_base=rel_err_out'
     requirement = "The system shall terminate the stochastic volume calculation using a relative error metric."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [user_bb]
     type = CSVDiff
     input = user_bb.i
     csvdiff = user_bb_out.csv
     requirement = "The system shall correctly compute volumes in OpenMC when using a user-provided bounding box."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/tutorials/dagmc/tests
+++ b/tutorials/dagmc/tests
@@ -10,7 +10,7 @@
     input = openmc.i
     cli_args = 'Problem/batches=100 Problem/inactive_batches=50 Executioner/num_steps=1 Problem/particles=500'
     requirement = "The system shall run DAGMC on a pincell."
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
   [coupled]
     type = CSVDiff
@@ -18,6 +18,6 @@
     csvdiff = solid_out_openmc0.csv
     prereq = mesh
     requirement = 'The system shall couple DAGMC OpenMC models to MOOSE.'
-    required_objects = 'MoabSkinner'
+    capabilities = 'dagmc'
   []
 []

--- a/tutorials/gas_compact/tests
+++ b/tutorials/gas_compact/tests
@@ -18,7 +18,7 @@
     cli_args = 'Problem/particles=100 Problem/inactive_batches=10 Problem/batches=20 Executioner/num_steps=2 Outputs/file_base=without_opt/openmc_out'
     min_parallel = 2
     requirement = 'The system shall couple OpenMC to a solid heat conduction model for a TRISO compact. This run creates an output file without the identical-cell-fills optimization, for later user in the gas_compact test.'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [gas_compact]
     type = CSVDiff
@@ -31,6 +31,6 @@
     requirement = 'The system shall couple OpenMC to a solid heat conduction model for a TRISO compact. The gold '
                   'files were created for an input that did not leverage the TRISO optimization, so here we also '
                   'prove that the identical_cell_fills option works properly.'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/tutorials/gas_compact_multiphysics/tests
+++ b/tutorials/gas_compact_multiphysics/tests
@@ -19,7 +19,7 @@
     cli_args = 'Problem/particles=200 Executioner/num_steps=2 Problem/inactive_batches=10 Problem/batches=20 Problem/Tallies/heat_source/trigger=none Problem/k_trigger=none Outputs/csv/file_base=openmc_thm_test_out Problem/identical_cell_fills="compacts compacts_trimmer_tri"'
     min_parallel = 2
     requirement = 'The system shall solve for coupled OpenMC, heat conduction, and THM fluid flow for a TRISO compact.'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [openmc_nek_moose] # can't test the nek.i, too big
     type = RunApp
@@ -29,6 +29,6 @@
     mesh_mode = 'replicated' # MultiAppGeometricInterpolationTransfer not supported
     cli_args = "Problem/particles=200 Executioner/num_steps=1 Problem/inactive_batches=10 Problem/batches=20 Problem/Tallies/heat_source/trigger=none Problem/k_trigger=none Outputs/csv/file_base=openmc_nek_test_out Problem/identical_cell_fills='compacts compacts_trimmer_tri' bison:MultiApps/active='' bison:Transfers/active='' Problem/initial_properties=xml"
     requirement = 'The system shall solve for coupled OpenMC and heat conduction for a TRISO compact.'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/tutorials/load_from_exodus/tests
+++ b/tutorials/load_from_exodus/tests
@@ -5,7 +5,7 @@
     min_parallel = 4
     requirement = "Cardinal shall be able to run NekRS and output a time history of its solution "
                   "onto a mesh mirror."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [load_nek]
     type = Exodiff
@@ -13,6 +13,6 @@
     exodiff = load_nek_out.e
     prereq = run_nek
     requirement = "Cardinal shall be able to load a time history of a NekRS solution."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/tutorials/lwr_amr/tests
+++ b/tutorials/lwr_amr/tests
@@ -15,7 +15,7 @@
     prereq = 'gen_assembly_amr'
     min_parallel = 2
     mesh_mode = 'replicated'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [gen_pin_amr]
     type = RunApp
@@ -30,6 +30,6 @@
     requirement = "The system shall be able to run AMR calculations on an LWR pincell."
     prereq = 'gen_pin_amr'
     mesh_mode = 'replicated'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/tutorials/lwr_mgxs/tests
+++ b/tutorials/lwr_mgxs/tests
@@ -15,6 +15,6 @@
     requirement = "The system shall be able to generate MGXS for an LWR assembly."
     prereq = 'gen_assembly_mgxs'
     min_parallel = 2
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/tutorials/lwr_solid/tests
+++ b/tutorials/lwr_solid/tests
@@ -10,7 +10,7 @@
     input = openmc.i
     cli_args = 'Problem/particles=500 Problem/inactive_batches=50 Problem/batches=100 Executioner/num_steps=1'
     requirement = "The system shall run OpenMC on an LWR pincell"
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [lwr_pincell]
     type = CSVDiff
@@ -20,7 +20,7 @@
     cli_args = "Executioner/num_steps=1 openmc:Problem/particles=1000 openmc:Problem/inactive_batches=5 openmc:Problem/batches=10"
     requirement = "The OpenMC wrapping shall provide heat source and temperature coupling "
                   "to MOOSE with cell tallies."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [lwr_pincell_mesh]
     type = CSVDiff
@@ -31,6 +31,6 @@
     cli_args = "Executioner/num_steps=1 openmc:Problem/particles=1000 openmc:Problem/inactive_batches=5 openmc:Problem/batches=10"
     requirement = "The OpenMC wrapping shall provide heat source and temperature coupling "
                   "to MOOSE with an unstructured mesh tally."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/tutorials/nek_stochastic/tests
+++ b/tutorials/nek_stochastic/tests
@@ -14,7 +14,7 @@
                   "MOOSE solving heat conduction in part of the domain, and NekRS solving for heat conduction "
                   "in the remaining, with coupling via flux and temperature boundary conditions at the interface. "
                   "We compare against analytic solutions for steady-state heat transfer."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [multi]
     type = CSVDiff
@@ -31,6 +31,6 @@
     requirement = "The system shall allow NekRS thermal conductivity to be perturbed by the stochastic tools "
                   "module. We compare peak temperature against an analytic solution to confirm that NekRS "
                   "is solving the correct model."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/tutorials/pebble_cht/tests
+++ b/tutorials/pebble_cht/tests
@@ -6,6 +6,6 @@
     cli_args = 'Executioner/num_steps=2 Outputs/csv=true'
     rel_err = 2e-4
     requirement = 'The system shall couple NekRS and MOOSE for conjugate heat transfer.'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/tutorials/pebbles/tests
+++ b/tutorials/pebbles/tests
@@ -5,7 +5,7 @@
     csvdiff = solid_out_openmc0.csv
     cli_args = "openmc:Problem/particles=1000 openmc:Problem/batches=10 openmc:Problem/inactive_batches=5"
     requirement = "The system shall be able to run the pebble tutorial."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [mesh]
     type = RunApp
@@ -20,6 +20,6 @@
     prereq = mesh
     cli_args = "Mesh/pebble/nr=2 openmc:Problem/particles=1000 openmc:Problem/batches=4 openmc:Problem/inactive_batches=0"
     requirement = "The system shall be able to run the pebble tutorial."
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
 []

--- a/tutorials/pincell_multiphysics/tests
+++ b/tutorials/pincell_multiphysics/tests
@@ -41,7 +41,7 @@
                   "We split up this test into separate OpenMC and NekRS components because the CIVET testing "
                   "also splits tests this way. This test runs OpenMC and heat conduction for one step."
     prereq = 'solid_mesh fluid_mesh_to_hex20'
-    required_objects = 'OpenMCCellAverageProblem'
+    capabilities = 'openmc'
   []
   [nek]
     type = RunApp
@@ -52,6 +52,6 @@
                   "We split up this test into separate OpenMC and NekRS components because the CIVET testing "
                   "also splits tests this way. This test runs heat conduction and NekRS for one step."
     prereq = 'solid_mesh'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/tutorials/restart_nek_and_moose/tests
+++ b/tutorials/restart_nek_and_moose/tests
@@ -5,7 +5,7 @@
     requirement = "The system shall be able to create checkpoint files for a coupled Nek-MOOSE simulation"
     min_parallel = 2
     max_parallel = 2
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
   [read_from_checkpoints]
     type = RunApp
@@ -14,6 +14,6 @@
     min_parallel = 2
     max_parallel = 2
     prereq = 'create_checkpoints'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/tutorials/standalone/tests
+++ b/tutorials/standalone/tests
@@ -3,7 +3,7 @@
     type = RunCommand
     command = '${NEKRS_HOME}/bin/nrsmpi turbPipe 4'
     requirement = "The system shall run nekRS as a standalone run with the NekRS executable."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
     use_shell = True
   []
   [standalone]
@@ -11,6 +11,6 @@
     input = nek.i
     min_parallel = 4
     requirement = 'Cardinal shall be able to run a NekRS standalone simulation.'
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/tutorials/subchannel/tests
+++ b/tutorials/subchannel/tests
@@ -4,6 +4,6 @@
     input = nek.i
     min_parallel = 4
     requirement = "The NekRS wrapping shall provide subchannel postprocessing features."
-    required_objects = 'NekRSProblem'
+    capabilities = 'nekrs'
   []
 []

--- a/tutorials/transfers/main.i
+++ b/tutorials/transfers/main.i
@@ -48,6 +48,10 @@
     source_variable = u
     variable = u_mesh_function
     to_multi_app = sub
+
+    # uses extrapolation to set the local value at any points which are missed due to the
+    # geometries not overlapping in some regions
+    error_on_miss = false
   []
   [nearest_node]
     type = MultiAppGeneralFieldNearestLocationTransfer


### PR DESCRIPTION
FYI @aprilnovak 

We've gotten rid of `required_objects` in test specs, and are phasing out `required_applications`. Both of these can now be achieved by capabilities.

See "Capabilities parameter in tests specs" in https://mooseframework.inl.gov/newsletter/2025/2025_04.html for more info.

I've registered three capabilities within cardinal that can be used within `capabilities` in test specs: `nekrs`, `dagmc`, and `openmc`. All registered applications are created as capabilities as well. For example, SAMApp automatically gets a capability `samapp`.

You can run cardinal with the following:

```
./cardinal-opt --show-capabilities
```

to see a full listing of capabilities that can be used in test specs.

This fixes cardinal on moose in https://civet.inl.gov/job/2922617/.