### PR TITLE
remove complicated reinit coupling

### DIFF
--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -2581,18 +2581,7 @@ OpenMCCellAverageProblem::syncSolutions(ExternalProblem::Direction direction)
         reloadDAGMC();
       }
 #endif
-      /*
-       * We run the skinner on the first transfer as OpenMC may be a sub-application
-       * of a solid or fluids multiapp. If this is the case, then those other applications
-       * may execute ahead of OpenMC and provide updated temperatures/densities on the first
-       * transfer which the skinner can use to update the OpenMC geometry. This also holds for
-       * initial conditions provided by the user.
-       *
-       * If the problem doesn't use a skinner, then we can avoid reinitializing it on the first
-       * timestep as nothing will have changed from when the problem was initialized in
-       * initialSetup().
-       */
-      if ((!_first_transfer || _using_skinner) && _need_to_reinit_coupling)
+      if (_need_to_reinit_coupling)
       {
         if (_volume_calc)
           _volume_calc->resetVolumeCalculation();


### PR DESCRIPTION
If the problem needs to reinitialize coupling, do so on every opportunity. This was initially motivated by the idea that OpenMC would always be the first app to run, but in general that might not be the case so this will be more straightforward behavior and also support more flexible usage.