### PR TITLE
Disable Double-Down and Embree by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ENABLE_DAGMC        ?= no
 
 # Whether we want to use the double-precision interface to Embree for DAGMC
 # ray tracing instead of MOAB.
-ENABLE_DOUBLE_DOWN  ?= yes
+ENABLE_DOUBLE_DOWN  ?= off
 
 # What GPU backends to enable for Nek (if any)
 OCCA_CUDA_ENABLED=0

--- a/doc/content/options.md
+++ b/doc/content/options.md
@@ -23,10 +23,9 @@ export ENABLE_DAGMC=yes
 ```
 
 If you chose to enable DAGMC, we also provide support for [Double-Down](https://double-down.readthedocs.io/en/latest/) -
-a mixed-precision interface to the ray-tracing library [Embree](https://www.embree.org/). Embree support is enabled by
-default in Cardinal due to the large improvements to threaded scalability and per-thread performance it provides over
-MOAB's native raytracing. If you do *not* want to use DAGMC with Embree, set:
+a mixed-precision interface to the ray-tracing library [Embree](https://www.embree.org/). Embree support is disabled by
+default, if you do want to use DAGMC with Embree, set:
 
 ```
-export ENABLE_DOUBLE_DOWN=no
+export ENABLE_DOUBLE_DOWN=yes
 ```

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -46,7 +46,7 @@ ENABLE_DAGMC        ?= no
 
 # Whether we want to use the double-precision interface to Embree for DAGMC
 # ray tracing instead of MOAB.
-ENABLE_DOUBLE_DOWN  ?= yes
+ENABLE_DOUBLE_DOWN  ?= no
 
 # What GPU backends to enable for Nek (if any)
 OCCA_CUDA_ENABLED=0


### PR DESCRIPTION
Disabling Embree and Double-Down by default due to some build errors. Currently working on resolving these.

Ref. #1129