### PR TITLE
Only print temperature warning if temperature is going to be changed

### DIFF
--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -214,6 +214,9 @@ OpenMCCellAverageProblem::OpenMCCellAverageProblem(const InputParameters & param
     _symmetry(nullptr),
     _initial_num_openmc_surfaces(openmc::model::surfaces.size())
 {
+  if (_specified_temperature_feedback && openmc::settings::temperature_range[1] == 0.0)
+    mooseWarning("For multiphysics simulations, we recommend setting the 'temperature_range' in OpenMC's settings.xml file. This will pre-load nuclear data over a range of temperatures, instead of only the temperatures defined in the XML file.\n\nFor efficiency purposes, OpenMC only checks that cell temperatures are within the global min/max of loaded data, which can be different from data loaded for each nuclide. Run may abort suddenly if requested nuclear data is not available.");
+
   // Check to see if a displaced problem is being initialized
   const auto & dis_actions =
       getMooseApp().actionWarehouse().getActions<CreateDisplacedProblemAction>();

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -177,15 +177,6 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
 
   openmc::settings::libmesh_comm = &_mesh.comm();
 
-  if (openmc::settings::temperature_range[1] == 0.0)
-    mooseWarning(
-        "For multiphysics simulations, we recommend setting the 'temperature_range' in OpenMC's "
-        "settings.xml file. This will pre-load nuclear data over a range of temperatures, instead "
-        "of only the temperatures defined in the XML file.\n\n"
-        "For efficiency purposes, OpenMC only checks that cell temperatures are within the global "
-        "min/max of loaded data, which can be different from data loaded for each nuclide. Run may "
-        "abort suddenly if requested nuclear data is not available.");
-
   if (isParamValid("openmc_verbosity"))
     openmc::settings::verbosity = getParam<unsigned int>("openmc_verbosity");
 


### PR DESCRIPTION
If no temperature feedback is applied in OpenMC, we do not need to print the warning about the temperature data being pre-loaded. 