### PR TITLE
Add `--progress` to `get-dependencies.sh`

### DIFF
--- a/scripts/get-dependencies.sh
+++ b/scripts/get-dependencies.sh
@@ -3,14 +3,14 @@ SCRIPT_DIR=$( dirname $(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null
 
 set -ex
 
-git submodule update --init contrib/moose
-git submodule update --init contrib/nekRS
-git submodule update --init --recursive contrib/openmc
-git submodule update --init contrib/DAGMC
-git submodule update --init contrib/moab
-git submodule update --init test/tests/nek_ci
-git submodule update --init contrib/double-down
-git submodule update --init contrib/embree
+git submodule update --init --progress contrib/moose
+git submodule update --init --progress contrib/nekRS
+git submodule update --init --recursive --progress contrib/openmc
+git submodule update --init --progress contrib/DAGMC
+git submodule update --init --progress contrib/moab
+git submodule update --init --progress test/tests/nek_ci
+git submodule update --init --progress contrib/double-down
+git submodule update --init --progress contrib/embree
 
 set +ex
 


### PR DESCRIPTION
As of late I've been working on rather sluggish internet connections, and found that running `get-dependencies.sh` would take several minutes. This PR adds the `--progress` flag to the git calls in `get-dependencies.sh` so people in a similar situation would have an estimate of how long initializing submodules will take.

@nglaser3 finally got around to this...