### PR TITLE
simplify gradient code

### DIFF
--- a/include/base/NekInterface.h
+++ b/include/base/NekInterface.h
@@ -552,7 +552,10 @@ void limitTemperature(const double * min_T, const double * max_T);
  * @param[in] pp_mesh which NekRS mesh to operate on
  * @param[out] grad_f gradient of field
  */
-void gradient(const int offset, const int e, const double * f, double * grad_f,
+void gradient(const int offset,
+              const int e,
+              const double * f,
+              double * grad_f,
               const nek_mesh::NekMeshEnum pp_mesh);
 
 /**

--- a/include/base/NekInterface.h
+++ b/include/base/NekInterface.h
@@ -547,11 +547,12 @@ void limitTemperature(const double * min_T, const double * max_T);
 /**
  * Compute the gradient of a volume field
  * @param[in] offset in the gradient field for each component (grad_x, grad_y, or grad_z)
+ * @param[in] e element ID to compute gradient
  * @param[in] f field to compute the gradient of
  * @param[in] pp_mesh which NekRS mesh to operate on
  * @param[out] grad_f gradient of field
  */
-void gradient(const int offset, const double * f, double * grad_f,
+void gradient(const int offset, const int e, const double * f, double * grad_f,
               const nek_mesh::NekMeshEnum pp_mesh);
 
 /**

--- a/src/base/NekInterface.C
+++ b/src/base/NekInterface.C
@@ -1107,10 +1107,9 @@ heatFluxIntegral(const std::vector<int> & boundary_id, const nek_mesh::NekMeshEn
           int vol_id = mesh->vmapM[offset + v] - i * mesh->Np;
           int surf_offset = mesh->Nsgeo * (offset + v);
 
-          double normal_grad_T =
-              grad_T[vol_id + 0 * mesh->Np] * sgeo[surf_offset + NXID] +
-              grad_T[vol_id + 1 * mesh->Np] * sgeo[surf_offset + NYID] +
-              grad_T[vol_id + 2 * mesh->Np] * sgeo[surf_offset + NZID];
+          double normal_grad_T = grad_T[vol_id + 0 * mesh->Np] * sgeo[surf_offset + NXID] +
+                                 grad_T[vol_id + 1 * mesh->Np] * sgeo[surf_offset + NYID] +
+                                 grad_T[vol_id + 2 * mesh->Np] * sgeo[surf_offset + NZID];
 
           integral += -k * normal_grad_T * sgeo[surf_offset + WSJID];
         }
@@ -1131,7 +1130,11 @@ heatFluxIntegral(const std::vector<int> & boundary_id, const nek_mesh::NekMeshEn
 }
 
 void
-gradient(const int offset, const int e, const double * f, double * grad_f, const nek_mesh::NekMeshEnum pp_mesh)
+gradient(const int offset,
+         const int e,
+         const double * f,
+         double * grad_f,
+         const nek_mesh::NekMeshEnum pp_mesh)
 {
   mesh_t * mesh = getMesh(pp_mesh);
 


### PR DESCRIPTION
We usually only need heat fluxes computed on boundaries; this PR adjusts the `gradient` routine to allow calling it on a per-element basis to save on computation. This will support efficiency improvements in #1168 