### PR TITLE
WIP: Criticality search

### DIFF
--- a/include/actions/AddCriticalitySearchAction.h
+++ b/include/actions/AddCriticalitySearchAction.h
@@ -1,0 +1,31 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#pragma once
+
+#include "MooseObjectAction.h"
+
+class AddCriticalitySearchAction : public MooseObjectAction
+{
+public:
+  static InputParameters validParams();
+
+  AddCriticalitySearchAction(const InputParameters & parameters);
+
+  virtual void act() override;
+};

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -66,13 +66,6 @@ public:
   std::string subdomainName(const SubdomainID & id) const;
 
   /**
-   * Print a full error message when catching errors from OpenMC
-   * @param[in] err OpenMC error code
-   * @param[in] descriptor descriptive message for error
-   */
-  void catchOpenMCError(const int & err, const std::string descriptor) const;
-
-  /**
    * Whether the score is a reaction rate score
    * @return whether the tally from OpenMC has units of 1/src
    */

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -45,6 +45,7 @@
 class OpenMCNuclideDensities;
 class OpenMCDomainFilterEditor;
 class OpenMCTallyEditor;
+class CriticalitySearchBase;
 
 /**
  * Base class for all MOOSE wrappings of OpenMC
@@ -57,6 +58,8 @@ public:
   static InputParameters validParams();
 
   virtual ~OpenMCProblemBase() override;
+
+  virtual void initialSetup() override;
 
   /**
    * Get the subdomain name for a given ID. If not named, we return the ID
@@ -517,4 +520,8 @@ protected:
 
   /// ID used by OpenMC to indicate that a material fill is VOID
   static constexpr int MATERIAL_VOID{-1};
+
+  CriticalitySearchBase * _criticality_search;
+
+  //std::function<Real(Real)> criticalitySearch;
 };

--- a/include/base/UserErrorChecking.h
+++ b/include/base/UserErrorChecking.h
@@ -75,3 +75,10 @@ void checkRequiredParam(const InputParameters & p,
 void checkJointParams(const InputParameters & p,
                       const std::vector<std::string> & name,
                       const std::string & explanation);
+
+/**
+ * Print a full error message when catching errors from OpenMC
+ * @param[in] err OpenMC error code
+ * @param[in] descriptor descriptive message for error
+ */
+void catchOpenMCError(const int & err, const std::string descriptor);

--- a/include/criticality/CriticalitySearchBase.h
+++ b/include/criticality/CriticalitySearchBase.h
@@ -1,0 +1,43 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#pragma once
+
+#include "MooseObject.h"
+#include "OpenMCCellAverageProblem.h"
+
+class CriticalitySearchBase : public MooseObject
+{
+public:
+  static InputParameters validParams();
+
+  CriticalitySearchBase(const InputParameters & parameters);
+
+  virtual void updateOpenMCModel(const Real & input) = 0;
+
+  virtual void searchForCriticality();
+
+protected:
+  virtual std::string quantity() const = 0;
+
+  const Real & _maximum;
+  const Real & _minimum;
+  const Real & _tolerance;
+
+  OpenMCCellAverageProblem & _openmc_problem;
+};

--- a/include/criticality/OpenMCMaterialDensity.h
+++ b/include/criticality/OpenMCMaterialDensity.h
@@ -1,0 +1,37 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#pragma once
+
+#include "CriticalitySearchBase.h"
+
+class OpenMCMaterialDensity : public CriticalitySearchBase
+{
+public:
+  static InputParameters validParams();
+
+  OpenMCMaterialDensity(const InputParameters & parameters);
+
+  virtual void updateOpenMCModel(const Real & input) override;
+
+protected:
+  virtual std::string quantity() const override { return "material ID " + std::to_string(_material_id); }
+
+  const int32_t & _material_id;
+  int32_t _material_index;
+};

--- a/src/actions/AddCriticalitySearchAction.C
+++ b/src/actions/AddCriticalitySearchAction.C
@@ -1,0 +1,59 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#ifdef ENABLE_OPENMC_COUPLING
+
+#include "AddCriticalitySearchAction.h"
+#include "OpenMCCellAverageProblem.h"
+#include "CriticalitySearchBase.h"
+
+registerMooseAction("CardinalApp", AddCriticalitySearchAction, "add_criticality_search");
+
+InputParameters
+AddCriticalitySearchAction::validParams()
+{
+  auto params = MooseObjectAction::validParams();
+  params.addClassDescription("Adds a criticality search for OpenMC");
+  return params;
+}
+
+AddCriticalitySearchAction::AddCriticalitySearchAction(const InputParameters & parameters)
+  : MooseObjectAction(parameters)
+{
+}
+
+void
+AddCriticalitySearchAction::act()
+{
+  if (_current_task == "add_criticality_search")
+  {
+    auto openmc_problem = dynamic_cast<OpenMCCellAverageProblem *>(_problem.get());
+
+    if (!openmc_problem)
+      mooseError("The [CriticalitySearch] block can only be used with wrapped OpenMC cases! "
+                 "You need to change the [Problem] block to 'OpenMCCellAverageProblem'.");
+
+    if (_type == "OpenMCMaterialDensity")
+    {
+      _moose_object_pars.set<OpenMCCellAverageProblem *>("_openmc_problem") = openmc_problem;
+      auto search =
+          openmc_problem->addObject<CriticalitySearchBase>(_type, _name, _moose_object_pars, false)[0];
+    }
+  }
+}
+#endif

--- a/src/base/CardinalApp.C
+++ b/src/base/CardinalApp.C
@@ -219,6 +219,12 @@ CardinalApp::associateSyntaxInner(Syntax & syntax, ActionFactory & /* action_fac
   // Can only add external auxvars after the tallies have been added.
   addTaskDependency("add_external_aux_variables", "add_tallies");
 
+  // Add the [Problem/CriticalitySearch] block
+  registerSyntax("AddCriticalitySearchAction", "Problem/CriticalitySearch");
+  registerMooseObjectTask("add_criticality_search", CriticalitySearch, false);
+  registerTask("add_criticality_search", false /* is required */);
+  addTaskDependency("add_criticality_search", "init_mesh");
+
   // Register a modify outputs task to enable variable hiding in the MGXS action.
   registerTask("modify_outputs", true /* is required */);
   addTaskDependency("modify_outputs", "common_output");

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -27,6 +27,9 @@
 #include "OpenMCNuclideDensities.h"
 #include "OpenMCDomainFilterEditor.h"
 #include "OpenMCTallyEditor.h"
+#include "CriticalitySearchBase.h"
+
+//#include "BrentsMethod.h"
 
 #include "openmc/random_lcg.h"
 
@@ -372,9 +375,15 @@ OpenMCProblemBase::externalSolve()
     openmc_set_seed(_initial_seed);
   }
 
-  int err = openmc_run();
-  if (err)
-    mooseError(openmc_err_msg);
+  int err;
+  if (_criticality_search)
+   _criticality_search->searchForCriticality();
+  else
+  {
+    err = openmc_run();
+    if (err)
+      mooseError(openmc_err_msg);
+  }
 
   _total_n_particles += nParticles();
 
@@ -387,6 +396,23 @@ OpenMCProblemBase::externalSolve()
   // save the latest fission source for re-use in the next iteration
   if (_reuse_source)
     writeSourceBank(sourceBankFileName());
+}
+
+void
+OpenMCProblemBase::initialSetup()
+{
+  CardinalProblem::initialSetup();
+
+  // Find a criticality search object
+  TheWarehouse::Query query = theWarehouse().query().condition<AttribSystem>("CriticalitySearch");
+  std::vector<CriticalitySearchBase *> objs;
+  query.queryInto(objs);
+
+  if (objs.size() > 1)
+    mooseError("Cannot have more than one CriticalitySearch object");
+
+  if (objs.size())
+    _criticality_search = objs[0];
 }
 
 void

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -233,14 +233,6 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
 OpenMCProblemBase::~OpenMCProblemBase() { openmc_finalize(); }
 
 void
-OpenMCProblemBase::catchOpenMCError(const int & err, const std::string descriptor) const
-{
-  if (err)
-    mooseError("In attempting to ", descriptor, ", OpenMC reported:\n\n",
-      std::string(openmc_err_msg));
-}
-
-void
 OpenMCProblemBase::fillElementalAuxVariable(const unsigned int & var_num,
                                             const std::vector<unsigned int> & elem_ids,
                                             const Real & value)

--- a/src/base/UserErrorChecking.C
+++ b/src/base/UserErrorChecking.C
@@ -89,3 +89,11 @@ checkJointParams(const InputParameters & p,
                "be specified or ALL omitted; you have only provided a subset of parameters!");
   }
 }
+
+void
+catchOpenMCError(const int & err, const std::string descriptor)
+{
+  if (err)
+    mooseError("In attempting to ", descriptor, ", OpenMC reported:\n\n",
+      std::string(openmc_err_msg));
+}

--- a/src/criticality/CriticalitySearchBase.C
+++ b/src/criticality/CriticalitySearchBase.C
@@ -1,0 +1,81 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#ifdef ENABLE_OPENMC_COUPLING
+
+#include "CriticalitySearchBase.h"
+#include "BrentsMethod.h"
+#include "openmc/eigenvalue.h"
+
+InputParameters
+CriticalitySearchBase::validParams()
+{
+  auto params = MooseObject::validParams();
+  params.addRequiredParam<Real>("minimum", "Minimum for values to search over");
+  params.addRequiredParam<Real>("maximum", "Maximum for values to search over");
+  params.addRangeCheckedParam<Real>("tolerance", 1e-3, "tolerance > 0", "Absolute tolerance to converge multiplication factor");
+  params.addClassDescription("Base class for defining parameters used in a criticality search in OpenMC.");
+  params.registerBase("CriticalitySearch");
+  params.registerSystemAttributeName("CriticalitySearch");
+  params.addPrivateParam<OpenMCCellAverageProblem *>("_openmc_problem");
+  return params;
+}
+
+CriticalitySearchBase::CriticalitySearchBase(const InputParameters & parameters)
+  : MooseObject(parameters),
+    _maximum(getParam<Real>("maximum")),
+    _minimum(getParam<Real>("minimum")),
+    _tolerance(getParam<Real>("tolerance")),
+    _openmc_problem(*getParam<OpenMCCellAverageProblem *>("_openmc_problem"))
+{
+  if (_minimum >= _maximum)
+    paramError("minimum", "The 'minimum' value must be less than the 'maximum' value");
+
+  auto pp_params = _factory.getValidParams("KEigenvalue");
+  _openmc_problem.addPostprocessor("KEigenvalue", "k", pp_params);
+}
+
+void
+CriticalitySearchBase::searchForCriticality()
+{
+  _console << "Running criticality search in OpenMC for " << quantity() << " in range " << std::to_string(_minimum) << " - " << std::to_string(_maximum) << std::endl;
+
+  std::function <Real(Real)> func;
+  func = [this](Real x) {
+    updateOpenMCModel(x);
+    int err = openmc_run();
+    if (err)
+      mooseError(openmc_err_msg);
+
+    int n = openmc::simulation::n_realizations;
+    const auto & gt = openmc::simulation::global_tallies;
+
+    if (n <= 3)
+      mooseError("Cannot compute combined k-effective estimate with fewer than 4 realizations!\n"
+        "Please change the 'value_type' to either 'collision', 'tracklength', or 'absorption'.");
+
+    double k_eff[2];
+    openmc::openmc_get_keff(k_eff);
+    std::cout << k_eff[0] << std::endl;
+    return k_eff[0] - 1.0;
+  };
+
+  BrentsMethod::root(func, _minimum, _maximum, _tolerance);
+}
+
+#endif

--- a/src/criticality/OpenMCMaterialDensity.C
+++ b/src/criticality/OpenMCMaterialDensity.C
@@ -1,0 +1,54 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#ifdef ENABLE_OPENMC_COUPLING
+
+#include "OpenMCMaterialDensity.h"
+#include "UserErrorChecking.h"
+#include "openmc/capi.h"
+
+registerMooseObject("CardinalApp", OpenMCMaterialDensity);
+
+InputParameters
+OpenMCMaterialDensity::validParams()
+{
+  auto params = CriticalitySearchBase::validParams();
+  params.addRequiredParam<int32_t>("material_id", "Material ID for which to modify density");
+  params.addClassDescription("Searches for criticality using material density; units for the density range are assumed to be kg/m3");
+  return params;
+}
+
+OpenMCMaterialDensity::OpenMCMaterialDensity(const InputParameters & parameters)
+  : CriticalitySearchBase(parameters),
+    _material_id(getParam<int32_t>("material_id"))
+{
+  int err = openmc_get_material_index(_material_id, &_material_index);
+  catchOpenMCError(err, "get index for material with ID " + std::to_string(_material_id));
+}
+
+void
+OpenMCMaterialDensity::updateOpenMCModel(const Real & density)
+{
+  _console << "Running criticality search for density = " << density << " [kg/m3]" << std::endl;
+  const char * units = "g/cc";
+  int err = openmc_material_set_density(_material_index, density * _openmc_problem.densityConversionFactor(), units);
+  std::cout << density * _openmc_problem.densityConversionFactor() << std::endl;
+  catchOpenMCError(err, "set material density to " + std::to_string(density));
+}
+
+#endif

--- a/src/userobjects/OpenMCNuclideDensities.C
+++ b/src/userobjects/OpenMCNuclideDensities.C
@@ -19,6 +19,7 @@
 #ifdef ENABLE_OPENMC_COUPLING
 
 #include "OpenMCNuclideDensities.h"
+#include "UserErrorChecking.h"
 #include "openmc/material.h"
 
 registerMooseObject("CardinalApp", OpenMCNuclideDensities);
@@ -45,9 +46,9 @@ OpenMCNuclideDensities::OpenMCNuclideDensities(const InputParameters & parameter
     _names(getParam<std::vector<std::string>>("names")),
     _densities(getParam<std::vector<double>>("densities"))
 {
-  _openmc_problem->catchOpenMCError(openmc_get_material_index(_material_id, &_material_index),
-                                    "get the material index for material with ID " +
-                                        std::to_string(_material_id));
+  catchOpenMCError(openmc_get_material_index(_material_id, &_material_index),
+                   "get the material index for material with ID " +
+                   std::to_string(_material_id));
 }
 
 void


### PR DESCRIPTION
This PR adds an example of performing a criticality search using Cardinal, starting by the easier form of criticality maneuver (changing a material density).