### PR TITLE
Override `threadJoin(...)` in `SymmetryPointGenerator`.

### DIFF
--- a/include/userobjects/SymmetryPointGenerator.h
+++ b/include/userobjects/SymmetryPointGenerator.h
@@ -35,6 +35,7 @@ public:
   virtual void initialize() {}
   virtual void finalize() {}
   virtual void execute() {}
+  virtual void threadJoin(const UserObject & /* uo */) override {}
 
   /**
    * Whether point is on the positive side of a plane; points exactly on plane return false


### PR DESCRIPTION
Fixes the following error when using the `SymmetryPointGenerator` with threading:
```
The following error occurred in the UserObject 'sym' of type SymmetryPointGenerator.

ThreadedGeneralUserObject failed to override threadJoin
```