### PR TITLE
Add currently optional hexagonal lattice parameter for the rotation around lattice axis

### DIFF
--- a/src/mesh/HexagonalSubchannelMeshBase.C
+++ b/src/mesh/HexagonalSubchannelMeshBase.C
@@ -56,7 +56,8 @@ HexagonalSubchannelMeshBase::HexagonalSubchannelMeshBase(const InputParameters &
         0.0 /* wire diameter not needed for subchannel mesh, use dummy value */,
         1.0 /* wire pitch not needed for subchannel mesh, use dummy value */,
         _n_rings,
-        _axis)),
+        _axis,
+        0. /*rotation_around_axis*/)),
     _pin_centers(_hex_lattice.pinCenters())
 {
 }

--- a/src/userobjects/HexagonalSubchannelBin.C
+++ b/src/userobjects/HexagonalSubchannelBin.C
@@ -60,7 +60,8 @@ HexagonalSubchannelBin::HexagonalSubchannelBin(const InputParameters & parameter
                                                0.0 /* wire diameter, unused */,
                                                1.0 /* wire pitch, unused */,
                                                _n_rings,
-                                               _axis));
+                                               _axis,
+                                               0. /*rotation_around_axis*/));
 
   if (_axis == 0) // x vertical axis
     _directions = {1, 2};

--- a/src/userobjects/HexagonalSubchannelGapBin.C
+++ b/src/userobjects/HexagonalSubchannelGapBin.C
@@ -55,7 +55,8 @@ HexagonalSubchannelGapBin::HexagonalSubchannelGapBin(const InputParameters & par
                                                0.0 /* wire diameter, unused */,
                                                1.0 /* wire pitch, unused */,
                                                _n_rings,
-                                               _axis));
+                                               _axis,
+                                               0. /*rotation_around_axis*/));
 
   if (_axis == 0) // x vertical axis
     _directions = {1, 2};


### PR DESCRIPTION

So we can make this parameter required in moose.
Note that this will require a moose submodule update to pass

see idaholab/moose#31215