### PR TITLE
correct typos in test object names

### DIFF
--- a/test/tests/neutronics/openmc_statepoint/tests
+++ b/test/tests/neutronics/openmc_statepoint/tests
@@ -2,7 +2,7 @@
   # This test needs to be in its own directory to prevent a false positive if another test
   # writes a statepoint.50.h5 file
   issues = '#1261'
-  design = 'OpenMCCelllAverageProblem.md'
+  design = 'OpenMCCellAverageProblem.md'
   [check_statepoint_exists]
     type = CheckFiles
     input = openmc.i

--- a/test/tests/transfers/nek_source/tests
+++ b/test/tests/transfers/nek_source/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekUsrWrkIntegral.md NekVolumetricSource.md NekBoundaryFlux.md'
+  design = 'NekUsrWrkBoundaryIntegral.md NekVolumetricSource.md NekBoundaryFlux.md'
 
   [multiple_source_transfers]
     type = CSVDiff


### PR DESCRIPTION
When building the documentation for the website, a few misspelled names are preventing builds.