### PR TITLE
OpenMC initialization action

### DIFF
--- a/include/actions/OpenMCInitAction.h
+++ b/include/actions/OpenMCInitAction.h
@@ -33,8 +33,6 @@ public:
   virtual void act() override;
 
 protected:
-
   /// Directory in which OpenMC settings xml files are located
   const std::string & _xml_directory;
-
 };

--- a/include/actions/OpenMCInitAction.h
+++ b/include/actions/OpenMCInitAction.h
@@ -1,0 +1,40 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#pragma once
+
+#include "MooseObjectAction.h"
+
+/**
+ * Initialize OpenMC.
+ */
+class OpenMCInitAction : public MooseObjectAction
+{
+public:
+  static InputParameters validParams();
+
+  OpenMCInitAction(const InputParameters & parameters);
+
+  virtual void act() override;
+
+protected:
+
+  /// Directory in which OpenMC settings xml files are located
+  const std::string & _xml_directory;
+
+};

--- a/include/actions/OpenMCInitAction.h
+++ b/include/actions/OpenMCInitAction.h
@@ -18,17 +18,17 @@
 
 #pragma once
 
-#include "MooseObjectAction.h"
+#include "Action.h"
 
 /**
  * Initialize OpenMC.
  */
-class OpenMCInitAction : public MooseObjectAction
+class OpenMCInitAction : public Action
 {
 public:
-  static InputParameters validParams();
-
   OpenMCInitAction(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   virtual void act() override;
 

--- a/include/actions/OpenMCInitAction.h
+++ b/include/actions/OpenMCInitAction.h
@@ -33,6 +33,9 @@ public:
   virtual void act() override;
 
 protected:
-  /// Directory in which OpenMC settings xml files are located
-  const std::string & _xml_directory;
+  /// Check if OpenMCCellAverageProblem is present and return xml_directory if it is the case
+  bool get_openmc_problem_type_xml_directory(std::string & xml_directory) const;
+
+  /// Call the OpenMC initialization handle
+  void init_openmc(const std::string & xml_directory);
 };

--- a/include/actions/OpenMCInitAction.h
+++ b/include/actions/OpenMCInitAction.h
@@ -37,5 +37,5 @@ protected:
   bool get_openmc_problem_type_xml_directory(std::string & xml_directory) const;
 
   /// Call the OpenMC initialization handle
-  void init_openmc(const std::string & xml_directory);
+  void initOpenMC(const std::string & xml_directory);
 };

--- a/include/actions/OpenMCInitAction.h
+++ b/include/actions/OpenMCInitAction.h
@@ -33,8 +33,14 @@ public:
   virtual void act() override;
 
 protected:
-  /// Check if OpenMCCellAverageProblem is present and return xml_directory if it is the case
-  bool get_openmc_problem_type_xml_directory(std::string & xml_directory) const;
+  /**
+   * Check whether an OpenMCCellAverageProblem have been requested in the input file and returns the
+   * associated path to the XML directory if an OpenMCCellAverageProblem is present in the input
+   * file.
+   * @param[out] xml_directory directory in which OpenMC settings xml files are located
+   * @return whether an OpenMCCellAverageProblem have been requested in the input file
+   */
+  bool isOpenMCCellAverageProblemRequested(std::string & xml_directory) const;
 
   /// Call the OpenMC initialization handle
   void initOpenMC(const std::string & xml_directory);

--- a/include/actions/OpenMCInitAction.h
+++ b/include/actions/OpenMCInitAction.h
@@ -42,6 +42,9 @@ protected:
    */
   bool isOpenMCCellAverageProblemRequested(std::string & xml_directory) const;
 
-  /// Call the OpenMC initialization handle
+  /**
+   * Call the OpenMC initialization handle
+   * @param[in] xml_directory directory in which OpenMC settings xml files are located
+   */
   void initOpenMC(const std::string & xml_directory);
 };

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -564,9 +564,6 @@ protected:
   /// The global tally used to accumulate the score required for \beta_eff.
   openmc::Tally * _ifp_mg_beta_tally = nullptr;
 
-  /// Directory in which OpenMC settings xml files are located
-  const std::string & _xml_directory;
-
   /// Conversion unit to transfer between kg/m3 and g/cm3
   static constexpr Real _density_conversion_factor{0.001};
 

--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -564,6 +564,9 @@ protected:
   /// The global tally used to accumulate the score required for \beta_eff.
   openmc::Tally * _ifp_mg_beta_tally = nullptr;
 
+  /// Directory in which OpenMC settings xml files are located
+  const std::string & _xml_directory;
+
   /// Conversion unit to transfer between kg/m3 and g/cm3
   static constexpr Real _density_conversion_factor{0.001};
 

--- a/include/parser/OpenMCSyntax.h
+++ b/include/parser/OpenMCSyntax.h
@@ -1,0 +1,29 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#pragma once
+
+class Syntax;
+class ActionFactory;
+
+namespace OpenMC
+{
+
+void associateSyntax(Syntax & syntax, ActionFactory & action_factory);
+
+}

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -45,7 +45,7 @@ OpenMCInitAction::OpenMCInitAction(const InputParameters & parameters)
 void
 OpenMCInitAction::act()
 {
-  if (_type != "OpenMCCellAverageProblem") // TODO: add more types?
+  if (_type != "OpenMCCellAverageProblem")
     return;
 
   const auto timeStart = std::chrono::high_resolution_clock::now();
@@ -73,7 +73,7 @@ OpenMCInitAction::act()
   // Initialize OpenMC
   openmc_init(argv.size() - 1, argv.data(), &_communicator.get());
 
-  // Timer - TODO - maybe not needed
+  // Timer
   double elapsedTime = 0;
   const auto timeStop = std::chrono::high_resolution_clock::now();
   elapsedTime += std::chrono::duration<double, std::milli>(timeStop - timeStart).count() / 1e3;

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -1,0 +1,85 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#ifdef ENABLE_OPENMC_COUPLING
+
+#include "OpenMCInitAction.h"
+
+#include "MooseApp.h"
+#include <chrono>
+
+registerMooseAction("CardinalApp", OpenMCInitAction, "openmc_init");
+
+InputParameters
+OpenMCInitAction::validParams()
+{
+  InputParameters params = MooseObjectAction::validParams();
+  params.addParam<std::string>("type", "Problem type");
+  params.addParam<FileName>(
+      "xml_directory", "./", "The directory in which to look for OpenMC XML files.");
+
+  return params;
+}
+
+OpenMCInitAction::OpenMCInitAction(const InputParameters & parameters)
+  : MooseObjectAction(parameters),
+    _xml_directory(getParam<FileName>("xml_directory"))
+{
+}
+
+void
+OpenMCInitAction::act()
+{
+  if (_type != "OpenMCCellAverageProblem") // TODO: add more types?
+    return;
+
+  const auto timeStart = std::chrono::high_resolution_clock::now();
+
+  // Suppress OpenMC output when the language server is active by
+  // decreasing the verbosity to level 1 (the lowest).
+  std::vector<std::string> argv_vec = {"openmc"};
+  if (_app.isParamValid("language_server") && _app.getParam<bool>("language_server"))
+  {
+    argv_vec.push_back("-q");
+    argv_vec.push_back("1");
+  }
+  // Add the parameter for the XML directory at the end.
+  argv_vec.push_back(_xml_directory);
+
+  std::vector<char *> argv;
+
+  for (const auto & arg : argv_vec)
+  {
+    argv.push_back(const_cast<char *>(arg.data()));
+  }
+  // Add terminating nullptr
+  argv.push_back(nullptr);
+
+  // Initialize OpenMC
+  openmc_init(argv.size() - 1, argv.data(), &_communicator.get());
+
+  // Timer - TODO - maybe not needed
+  double elapsedTime = 0;
+  const auto timeStop = std::chrono::high_resolution_clock::now();
+  elapsedTime += std::chrono::duration<double, std::milli>(timeStop - timeStart).count() / 1e3;
+
+  _console << "OpenMC initialization took " << elapsedTime << " s" << std::endl;
+
+}
+
+#endif

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -37,8 +37,7 @@ OpenMCInitAction::validParams()
 }
 
 OpenMCInitAction::OpenMCInitAction(const InputParameters & parameters)
-  : MooseObjectAction(parameters),
-    _xml_directory(getParam<FileName>("xml_directory"))
+  : MooseObjectAction(parameters), _xml_directory(getParam<FileName>("xml_directory"))
 {
 }
 
@@ -79,7 +78,6 @@ OpenMCInitAction::act()
   elapsedTime += std::chrono::duration<double, std::milli>(timeStop - timeStart).count() / 1e3;
 
   _console << "OpenMC initialization took " << elapsedTime << " s" << std::endl;
-
 }
 
 #endif

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -39,7 +39,9 @@ OpenMCInitAction::act()
 {
   // Check if OpenMCCellAverageProblem is present and return xml_directory if it is the case
   std::string xml_directory;
-  if (!get_openmc_problem_type_xml_directory(xml_directory))
+
+  // Leave if no OpenMCCellAverageProblem requested in the input file
+  if (!isOpenMCCellAverageProblemRequested(xml_directory))
     return;
 
   // Initialize OpenMC
@@ -47,7 +49,7 @@ OpenMCInitAction::act()
 }
 
 bool
-OpenMCInitAction::get_openmc_problem_type_xml_directory(std::string & xml_directory) const
+OpenMCInitAction::isOpenMCCellAverageProblemRequested(std::string & xml_directory) const
 {
   // Retrieve all create problem actions
   const auto & problem_actions = _awh.getActions<CreateProblemAction>();

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -20,7 +20,6 @@
 
 #include "OpenMCInitAction.h"
 
-#include "MooseApp.h"
 #include <chrono>
 
 registerMooseAction("CardinalApp", OpenMCInitAction, "openmc_init");
@@ -28,7 +27,7 @@ registerMooseAction("CardinalApp", OpenMCInitAction, "openmc_init");
 InputParameters
 OpenMCInitAction::validParams()
 {
-  InputParameters params = MooseObjectAction::validParams();
+  InputParameters params = Action::validParams();
   params.addClassDescription("Initializes OpenMC.");
   params.addParam<std::string>("type", "Problem type");
   params.addParam<FileName>(
@@ -38,7 +37,7 @@ OpenMCInitAction::validParams()
 }
 
 OpenMCInitAction::OpenMCInitAction(const InputParameters & parameters)
-  : MooseObjectAction(parameters), _xml_directory(getParam<FileName>("xml_directory"))
+  : Action(parameters), _xml_directory(getParam<FileName>("xml_directory"))
 {
 }
 

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -37,7 +37,7 @@ OpenMCInitAction::OpenMCInitAction(const InputParameters & parameters) : Action(
 void
 OpenMCInitAction::act()
 {
-  // Check if OpenMCCellAverageProblem is present and return xml_directory if it is the case
+  // Directory containing XML files for OpenMC initialization
   std::string xml_directory;
 
   // Leave if no OpenMCCellAverageProblem requested in the input file
@@ -51,12 +51,12 @@ OpenMCInitAction::act()
 bool
 OpenMCInitAction::isOpenMCCellAverageProblemRequested(std::string & xml_directory) const
 {
-  // Retrieve all create problem actions
+  // Retrieve all CreateProblemAction actions
   const auto & problem_actions = _awh.getActions<CreateProblemAction>();
 
+  // Search for an OpenMCCellAverageProblem
   for (const auto * action : problem_actions)
   {
-    // If an action has the OpenMCCellAverageProblem type
     if (action->getParam<std::string>("type") == "OpenMCCellAverageProblem")
     {
       xml_directory = action->getObjectParams().get<FileName>("xml_directory");

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -64,11 +64,6 @@ OpenMCInitAction::get_openmc_problem_type_xml_directory(std::string & xml_direct
         xml_directory = obj_params.get<FileName>("xml_directory");
         return true;
       }
-      else
-      {
-        mooseError(
-            "OpenMCCellAverageProblem was found but does not have an 'xml_directory' parameter.");
-      }
     }
   }
   return false;

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -19,6 +19,7 @@
 #ifdef ENABLE_OPENMC_COUPLING
 
 #include "OpenMCInitAction.h"
+#include "CreateProblemAction.h"
 
 registerMooseAction("CardinalApp", OpenMCInitAction, "openmc_init");
 
@@ -26,26 +27,56 @@ InputParameters
 OpenMCInitAction::validParams()
 {
   InputParameters params = Action::validParams();
-  params.addClassDescription("Initializes OpenMC.");
-  params.addParam<std::string>("type", "Problem type");
-  params.addParam<FileName>(
-      "xml_directory", "./", "The directory in which to look for OpenMC XML files.");
-
+  params.addClassDescription(
+      "Initializes OpenMC when an OpenMCCellAverageProblem is present in the input.");
   return params;
 }
 
-OpenMCInitAction::OpenMCInitAction(const InputParameters & parameters)
-  : Action(parameters), _xml_directory(getParam<FileName>("xml_directory"))
-{
-}
+OpenMCInitAction::OpenMCInitAction(const InputParameters & parameters) : Action(parameters) {}
 
 void
 OpenMCInitAction::act()
 {
-  if (_type != "OpenMCCellAverageProblem")
+  // Check if OpenMCCellAverageProblem is present and return xml_directory if it is the case
+  std::string xml_directory;
+  if (!get_openmc_problem_type_xml_directory(xml_directory))
     return;
 
+  init_openmc(xml_directory);
+}
 
+bool
+OpenMCInitAction::get_openmc_problem_type_xml_directory(std::string & xml_directory) const
+{
+  // Retrieve all create problem actions
+  const auto & problem_actions = _awh.getActions<CreateProblemAction>();
+
+  for (const auto * action : problem_actions)
+  {
+    // If an action has the OpenMCCellAverageProblem type
+    if (action->getParam<std::string>("type") == "OpenMCCellAverageProblem")
+    {
+      // Retrieve the associated xml_directory_parameter
+      const InputParameters & obj_params = action->getObjectParams();
+
+      if (obj_params.have_parameter<FileName>("xml_directory"))
+      {
+        xml_directory = obj_params.get<FileName>("xml_directory");
+        return true;
+      }
+      else
+      {
+        mooseError(
+            "OpenMCCellAverageProblem was found but does not have an 'xml_directory' parameter.");
+      }
+    }
+  }
+  return false;
+}
+
+void
+OpenMCInitAction::init_openmc(const std::string & xml_directory)
+{
   // Suppress OpenMC output when the language server is active by
   // decreasing the verbosity to level 1 (the lowest).
   std::vector<std::string> argv_vec = {"openmc"};
@@ -54,15 +85,16 @@ OpenMCInitAction::act()
     argv_vec.push_back("-q");
     argv_vec.push_back("1");
   }
-  // Add the parameter for the XML directory at the end.
-  argv_vec.push_back(_xml_directory);
+
+  // Add xml_directory
+  argv_vec.push_back(xml_directory);
 
   std::vector<char *> argv;
-
   for (const auto & arg : argv_vec)
   {
     argv.push_back(const_cast<char *>(arg.data()));
   }
+
   // Add terminating nullptr
   argv.push_back(nullptr);
 

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -42,7 +42,8 @@ OpenMCInitAction::act()
   if (!get_openmc_problem_type_xml_directory(xml_directory))
     return;
 
-  init_openmc(xml_directory);
+  // Initialize OpenMC
+  initOpenMC(xml_directory);
 }
 
 bool
@@ -70,7 +71,7 @@ OpenMCInitAction::get_openmc_problem_type_xml_directory(std::string & xml_direct
 }
 
 void
-OpenMCInitAction::init_openmc(const std::string & xml_directory)
+OpenMCInitAction::initOpenMC(const std::string & xml_directory)
 {
   // Suppress OpenMC output when the language server is active by
   // decreasing the verbosity to level 1 (the lowest).

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -57,14 +57,8 @@ OpenMCInitAction::get_openmc_problem_type_xml_directory(std::string & xml_direct
     // If an action has the OpenMCCellAverageProblem type
     if (action->getParam<std::string>("type") == "OpenMCCellAverageProblem")
     {
-      // Retrieve the associated xml_directory_parameter
-      const InputParameters & obj_params = action->getObjectParams();
-
-      if (obj_params.have_parameter<FileName>("xml_directory"))
-      {
-        xml_directory = obj_params.get<FileName>("xml_directory");
-        return true;
-      }
+      xml_directory = action->getObjectParams().get<FileName>("xml_directory");
+      return true;
     }
   }
   return false;

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -29,6 +29,7 @@ InputParameters
 OpenMCInitAction::validParams()
 {
   InputParameters params = MooseObjectAction::validParams();
+  params.addClassDescription("Initializes OpenMC.");
   params.addParam<std::string>("type", "Problem type");
   params.addParam<FileName>(
       "xml_directory", "./", "The directory in which to look for OpenMC XML files.");

--- a/src/actions/OpenMCInitAction.C
+++ b/src/actions/OpenMCInitAction.C
@@ -20,8 +20,6 @@
 
 #include "OpenMCInitAction.h"
 
-#include <chrono>
-
 registerMooseAction("CardinalApp", OpenMCInitAction, "openmc_init");
 
 InputParameters
@@ -47,7 +45,6 @@ OpenMCInitAction::act()
   if (_type != "OpenMCCellAverageProblem")
     return;
 
-  const auto timeStart = std::chrono::high_resolution_clock::now();
 
   // Suppress OpenMC output when the language server is active by
   // decreasing the verbosity to level 1 (the lowest).
@@ -71,13 +68,6 @@ OpenMCInitAction::act()
 
   // Initialize OpenMC
   openmc_init(argv.size() - 1, argv.data(), &_communicator.get());
-
-  // Timer
-  double elapsedTime = 0;
-  const auto timeStop = std::chrono::high_resolution_clock::now();
-  elapsedTime += std::chrono::duration<double, std::milli>(timeStop - timeStart).count() / 1e3;
-
-  _console << "OpenMC initialization took " << elapsedTime << " s" << std::endl;
 }
 
 #endif

--- a/src/base/CardinalApp.C
+++ b/src/base/CardinalApp.C
@@ -24,6 +24,10 @@
 #include "CardinalAppTypes.h"
 #include "CardinalRevision.h"
 
+#ifdef ENABLE_OPENMC_COUPLING
+#include "OpenMCSyntax.h"
+#endif
+
 #ifdef ENABLE_NEK_COUPLING
 #include "NekSyntax.h"
 #endif
@@ -130,6 +134,10 @@ CardinalApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
   /* register custom execute flags, action syntax, etc. here */
 #ifdef ENABLE_NEK_COUPLING
   Nek::associateSyntax(s, af);
+#endif
+
+#ifdef ENABLE_OPENMC_COUPLING
+  OpenMC::associateSyntax(s, af);
 #endif
 
   associateSyntaxInner(s, af);

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -115,34 +115,11 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
     _run_on_adaptivity_cycle(true),
     _calc_kinetics_params(getParam<bool>("calc_kinetics_params")),
     _reset_seed(getParam<bool>("reset_seed")),
-    _initial_seed(openmc::openmc_get_seed()),
-    _xml_directory(getParam<FileName>("xml_directory"))
+    _initial_seed(openmc::openmc_get_seed())
 {
   if (isParamValid("tally_type"))
     mooseError("The tally system used by OpenMCProblemBase derived classes has been deprecated. "
                "Please add tallies with the [Tallies] block instead.");
-
-  // Suppress OpenMC output when the language server is active by
-  // decreasing the verbosity to level 1 (the lowest).
-  std::vector<std::string> argv_vec = {"openmc"};
-  if (_app.isParamValid("language_server") && _app.getParam<bool>("language_server"))
-  {
-    argv_vec.push_back("-q");
-    argv_vec.push_back("1");
-  }
-  // Add the parameter for the XML directory at the end.
-  argv_vec.push_back(_xml_directory);
-
-  std::vector<char *> argv;
-
-  for (const auto & arg : argv_vec)
-  {
-    argv.push_back(const_cast<char *>(arg.data()));
-  }
-  // Add terminating nullptr
-  argv.push_back(nullptr);
-
-  openmc_init(argv.size() - 1, argv.data(), &_communicator.get());
 
   // ensure that any mapped cells have their distribcell indices generated in OpenMC
   if (!openmc::settings::material_cell_offsets)

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -86,6 +86,8 @@ OpenMCProblemBase::validParams()
       "reset_seed",
       false,
       "Whether to reset OpenMC's seed to the initial starting seed before each OpenMC solve");
+  params.addParam<FileName>(
+      "xml_directory", "./", "The directory in which to look for OpenMC XML files.");
 
   // Kinetics parameters.
   params.addParam<bool>("calc_kinetics_params",
@@ -113,7 +115,8 @@ OpenMCProblemBase::OpenMCProblemBase(const InputParameters & params)
     _run_on_adaptivity_cycle(true),
     _calc_kinetics_params(getParam<bool>("calc_kinetics_params")),
     _reset_seed(getParam<bool>("reset_seed")),
-    _initial_seed(openmc::openmc_get_seed())
+    _initial_seed(openmc::openmc_get_seed()),
+    _xml_directory(getParam<FileName>("xml_directory"))
 {
   if (isParamValid("tally_type"))
     mooseError("The tally system used by OpenMCProblemBase derived classes has been deprecated. "

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -96,8 +96,6 @@ OpenMCProblemBase::validParams()
       "ifp_generations",
       openmc::DEFAULT_IFP_N_GENERATION,
       "The number of generations to use with the method of iterated fission probabilities.");
-  params.addParam<FileName>(
-      "xml_directory", "./", "The directory in which to look for OpenMC XML files.");
   return params;
 }
 

--- a/src/parser/OpenMCSyntax.C
+++ b/src/parser/OpenMCSyntax.C
@@ -1,0 +1,38 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#ifdef ENABLE_OPENMC_COUPLING
+
+#include "OpenMCSyntax.h"
+#include "ActionFactory.h"
+#include "Syntax.h"
+
+namespace OpenMC
+{
+
+void
+associateSyntax(Syntax & syntax, ActionFactory & /*action_factory*/)
+{
+  registerMooseObjectTask("openmc_init", Problem, true);
+  registerSyntax("OpenMCInitAction", "Problem");
+  addTaskDependency("meta_action", "openmc_init");
+}
+
+} // namespace OpenMC
+
+#endif

--- a/src/parser/OpenMCSyntax.C
+++ b/src/parser/OpenMCSyntax.C
@@ -26,11 +26,10 @@ namespace OpenMC
 {
 
 void
-associateSyntax(Syntax & syntax, ActionFactory & /*action_factory*/)
+associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 {
-  registerMooseObjectTask("openmc_init", Problem, true);
-  registerSyntax("OpenMCInitAction", "Problem");
-  addTaskDependency("meta_action", "openmc_init");
+  registerTask("openmc_init", true);
+  addTaskDependency("create_problem", "openmc_init");
 }
 
 } // namespace OpenMC


### PR DESCRIPTION
This PR adds a new action to initialize OpenMC.

### Context

I am using Cardinal to transfer temperatures to OpenMC not to OpenMC cells, but to a custom temperature field using a regular mesh on the OpenMC side. The multiphysics coupling seems to work well with my local prototype so I am working on cleaning the different features I have to submit them as PRs here.

### Description

I moved the initialization of OpenMC from the constructor of OpenMCProblemBase to its own action. The objective is to be able to initialize OpenMC once and potentially before the [Mesh] keyword is interpreted as I have a custom mesh generator (coming in a next PR) that requires having access to information from the XML file of OpenMC.

### Open question

I mainly copied the NekInitAction mechanism. However, I am not sure if we need to protect this action against multiple calls as I do not know if Cardinal is able to call this action more than once. Please let me know if you think that I should add a protection against that.