### PR TITLE
Removing registerMooseObject() for OpenMCCellTransformBase

### DIFF
--- a/src/transforms/OpenMCCellTransformBase.C
+++ b/src/transforms/OpenMCCellTransformBase.C
@@ -25,8 +25,6 @@
 #include "OpenMCBase.h"
 #include "UserErrorChecking.h"
 
-registerMooseObject("CardinalApp", OpenMCCellTransformBase);
-
 InputParameters
 OpenMCCellTransformBase::validParams()
 {


### PR DESCRIPTION
closes #1320 