### PR TITLE
Fix the `gas_assembly` tutorial input files

### DIFF
--- a/tutorials/gas_assembly/openmc.i
+++ b/tutorials/gas_assembly/openmc.i
@@ -176,7 +176,7 @@ num_layers_for_THM = 50      # number of elements in the THM model; for the conv
   [Tallies]
     [heat_source]
       type = CellTally
-      block = '2'
+      block = 'compacts'
       name = heat_source
       check_equal_mapped_tally_volumes = true
       output = 'unrelaxed_tally_std_dev'
@@ -342,6 +342,7 @@ num_layers_for_THM = 50      # number of elements in the THM model; for the conv
     type = ElementIntegralVariablePostprocessor
     variable = heat_source
     execute_on = 'transfer initial timestep_end'
+    block = 'compacts'
   []
   [max_tally_rel_err]
     type = TallyRelativeError

--- a/tutorials/gas_assembly/solid.i
+++ b/tutorials/gas_assembly/solid.i
@@ -66,19 +66,19 @@ opyc_fraction = ${fparse (oPyC_radius^3 - SiC_radius^3) / oPyC_radius^3}
   [graphite]
     type = HeatConductionMaterial
     thermal_conductivity_temperature_function = k_graphite
-    temp = T
+    temperature = T
     block = 'graphite'
   []
   [compacts]
     type = HeatConductionMaterial
     thermal_conductivity_temperature_function = k_compacts
-    temp = T
+    temperature = T
     block = 'compacts'
   []
   [poison]
     type = HeatConductionMaterial
     thermal_conductivity_temperature_function = k_b4c
-    temp = T
+    temperature = T
     block = 'poison'
   []
 []


### PR DESCRIPTION
This PR fixes an error and a few deprecation warnings in the gas assembly tutorial. The `geometry.xml` file in Box also needs to be updated.

Ref. #1373