### PR TITLE
Add missing design documents to tests

### DIFF
--- a/test/tests/auxkernels/cartesian_grid/tests
+++ b/test/tests/auxkernels/cartesian_grid/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'CartesianGrid.md'
   [grid]
     type = Exodiff
     input = grid.i

--- a/test/tests/auxkernels/nek_spatial_bin_component_aux/tests
+++ b/test/tests/auxkernels/nek_spatial_bin_component_aux/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekSpatialBinComponentAux.md'
   [invalid_uo]
     type = RunException
     input = nek_bin_aux.i

--- a/test/tests/cht/multi_cht/tests
+++ b/test/tests/cht/multi_cht/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekFieldVariable.md NekVolumeIntegral.md NekVolumeAverage.md'
   [volume_pp]
     type = CSVDiff
     input = nek.i

--- a/test/tests/cht/nondimensional/tests
+++ b/test/tests/cht/nondimensional/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekBoundaryFlux.md NekFieldVariable.md DimensionalizeAction.md'
   [sfr_pincell]
     type = Exodiff
     input = nek_master.i

--- a/test/tests/cht/pebble/shift/tests
+++ b/test/tests/cht/pebble/shift/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekBoundaryFlux.md NekFieldVariable.md'
   [pebble]
     type = CSVDiff
     input = nek_master.i

--- a/test/tests/cht/pebble/tests
+++ b/test/tests/cht/pebble/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekBoundaryFlux.md NekFieldVariable.md'
   [pebble]
     type = Exodiff
     input = nek_master.i

--- a/test/tests/cht/pincell_p_v/tests
+++ b/test/tests/cht/pincell_p_v/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekFieldVariable.md NekBoundaryFlux.md'
   [output_cht]
     type = RunApp
     input = nek_master.i

--- a/test/tests/cht/pincell_p_v/tests
+++ b/test/tests/cht/pincell_p_v/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekRSProblem.md NekFieldVariable.md NekBoundaryFlux.md'
+  design = 'NekFieldVariable.md'
   [output_cht]
     type = RunApp
     input = nek_master.i

--- a/test/tests/conduction/boundary_and_volume/prism/tests
+++ b/test/tests/conduction/boundary_and_volume/prism/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekBoundaryFlux.md NekVolumetricSource.md NekFieldVariable.md'
   [pyramid]
     type = Exodiff
     input = openmc.i

--- a/test/tests/conduction/boundary_and_volume/prism/tests
+++ b/test/tests/conduction/boundary_and_volume/prism/tests
@@ -1,5 +1,4 @@
 [Tests]
-  design = 'NekRSProblem.md NekBoundaryFlux.md NekVolumetricSource.md NekFieldVariable.md'
   [pyramid]
     type = Exodiff
     input = openmc.i
@@ -13,6 +12,7 @@
                   "can be made better by using finer meshes in the coupled Cardinal case."
     min_slots = 12 # memory heavy
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md NekBoundaryFlux.md NekVolumetricSource.md NekFieldVariable.md'
   []
   [pyramid_exact]
     type = CSVDiff
@@ -27,6 +27,7 @@
                   "to the pyramid test and the usrwrk output for flux and volumetric heating match the "
                   "auxiliary variables in the Nek-wrapped input."
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md NekBoundaryFlux.md NekVolumetricSource.md NekFieldVariable.md'
   []
   [duplicate_temp]
     type = RunException
@@ -36,5 +37,6 @@
     requirement = "The system shall error if the user specifies a duplicate variable with a name overlapping with special names reserved for Cardinal data transfers."
     min_slots = 6 # memory heavy
     capabilities = 'nekrs'
+    design = 'NekVolumetricSource.md'
   []
 []

--- a/test/tests/conduction/identical_interface/cube/tests
+++ b/test/tests/conduction/identical_interface/cube/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekBoundaryFlux.md NekFieldVariable.md'
   [slab_conduction]
     type = Exodiff
     input = nek_master.i

--- a/test/tests/conduction/identical_interface/pyramid/tests
+++ b/test/tests/conduction/identical_interface/pyramid/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekBoundaryFlux.md NekFieldVariable.md'
   [pyramid_conduction]
     type = Exodiff
     input = nek_master.i

--- a/test/tests/conduction/identical_volume/cube/tests
+++ b/test/tests/conduction/identical_volume/cube/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekVolumetricSource.md NekFieldVariable.md'
   [slab_heat_source]
     type = Exodiff
     input = nek_master.i

--- a/test/tests/conduction/nonidentical_interface/cylinders/tests
+++ b/test/tests/conduction/nonidentical_interface/cylinders/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekBoundaryFlux.md NekFieldVariable.md'
   [cylinder_conduction]
     type = Exodiff
     input = nek_master.i

--- a/test/tests/conduction/nonidentical_volume/cylinder/tests
+++ b/test/tests/conduction/nonidentical_volume/cylinder/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekVolumetricSource.md NekFieldVariable.md'
   [cylinder_heat_source]
     type = Exodiff
     input = nek_master.i

--- a/test/tests/conduction/nonidentical_volume/nondimensional/tests
+++ b/test/tests/conduction/nonidentical_volume/nondimensional/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekVolumetricSource.md NekFieldVariable.md DimensionalizeAction.md'
   [cylinder_heat_source]
     type = Exodiff
     input = nek_master.i

--- a/test/tests/conduction/reverse_cht/tests
+++ b/test/tests/conduction/reverse_cht/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekBoundaryFlux.md NekFieldVariable.md'
   [reverse_cht]
     type = CSVDiff
     input = main.i

--- a/test/tests/conduction/zero_flux/tests
+++ b/test/tests/conduction/zero_flux/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekBoundaryFlux.md'
   [zero_flux_total]
     type = RunApp
     input = main.i

--- a/test/tests/conduction/zero_flux/tests
+++ b/test/tests/conduction/zero_flux/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekRSProblem.md NekBoundaryFlux.md'
+  design = 'NekBoundaryFlux.md'
   [zero_flux_total]
     type = RunApp
     input = main.i

--- a/test/tests/controls/openmc_nuclide_densities/tests
+++ b/test/tests/controls/openmc_nuclide_densities/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCNuclideDensitiesControl.md OpenMCNuclideDensities.md'
   [wrong_uo]
     type = RunException
     input = error.i

--- a/test/tests/deformation/nek_standalone/tests
+++ b/test/tests/deformation/nek_standalone/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [volume]
     type = CSVDiff
     input = nek.i

--- a/test/tests/deformation/nek_standalone/tests
+++ b/test/tests/deformation/nek_standalone/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekRSProblem.md'
+  design = 'NekRSProblem.md NekVolumeIntegral.md NekSideIntegral.md'
   [volume]
     type = CSVDiff
     input = nek.i

--- a/test/tests/ics/bulk_energy_conservation_ic/tests
+++ b/test/tests/ics/bulk_energy_conservation_ic/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'BulkEnergyConservationIC.md VolumetricHeatSourceICAction.md'
   [missing_initial]
     type = RunException
     input = sinusoidal_z.i

--- a/test/tests/ics/volumetric_heat_source_ic/tests
+++ b/test/tests/ics/volumetric_heat_source_ic/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'VolumetricHeatSourceICAction.md'
   [sinusoidal]
     type = Exodiff
     input = 'sinusoidal_z.i'

--- a/test/tests/mesh/hexagonal_gap_mesh/tests
+++ b/test/tests/mesh/hexagonal_gap_mesh/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'HexagonalSubchannelGapMesh.md'
   [three_rings]
     type = Exodiff
     input = three_rings.i

--- a/test/tests/mesh/hexagonal_subchannel_mesh/tests
+++ b/test/tests/mesh/hexagonal_subchannel_mesh/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'HexagonalSubchannelMesh.md'
   [three_rings]
     type = Exodiff
     input = three_rings.i

--- a/test/tests/meshgenerators/polygon_corners/tests
+++ b/test/tests/meshgenerators/polygon_corners/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekMeshGenerator.md'
   [invalid_id]
     type = RunException
     input = six.i

--- a/test/tests/meshgenerators/quad8_generator/tests
+++ b/test/tests/meshgenerators/quad8_generator/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekMeshGenerator.md'
   [invalid_elem]
     type = RunException
     input = invalid_elem.i

--- a/test/tests/meshgenerators/second_order_hex_generator/tests
+++ b/test/tests/meshgenerators/second_order_hex_generator/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekMeshGenerator.md'
   [invalid_elem]
     type = RunException
     input = invalid_elem.i

--- a/test/tests/meshgenerators/sphere/tests
+++ b/test/tests/meshgenerators/sphere/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekMeshGenerator.md'
   [sphere]
     type = RunApp
     input = sphere.i

--- a/test/tests/meshgenerators/sphere/tests
+++ b/test/tests/meshgenerators/sphere/tests
@@ -1,5 +1,4 @@
 [Tests]
-  design = 'NekMeshGenerator.md'
   [sphere]
     type = RunApp
     input = sphere.i
@@ -13,6 +12,7 @@
     prereq = sphere
     cli_args = '--mesh-only'
     requirement = 'The system shall move the nodes on a sphere boundary to the curved surface'
+    design = 'NekMeshGenerator.md'
   []
   [shift_convert]
     type = Exodiff
@@ -21,5 +21,6 @@
     prereq = sphere
     cli_args = '--mesh-only'
     requirement = 'The system shall move the nodes on a sphere boundary to the curved surface when the sphere is offset from the origin'
+    design = 'NekMeshGenerator.md'
   []
 []

--- a/test/tests/multiple_nek_apps/subdirectory/tests
+++ b/test/tests/multiple_nek_apps/subdirectory/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [sub]
     type = CheckFiles
     input = nek.i

--- a/test/tests/multiple_nek_apps/two_channels/tests
+++ b/test/tests/multiple_nek_apps/two_channels/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [invalid_write_fld]
     type = RunException
     input = nek.i

--- a/test/tests/nek_errors/invalid_bid_postprocessor/tests
+++ b/test/tests/nek_errors/invalid_bid_postprocessor/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekSideIntegral.md'
   [invalid_boundary_id]
     type = RunException
     input = nek.i

--- a/test/tests/nek_errors/invalid_bid_postprocessor/tests
+++ b/test/tests/nek_errors/invalid_bid_postprocessor/tests
@@ -11,8 +11,7 @@
                  "nekRS assumes the boundary IDs are ordered "
                  "contiguously beginning at 1. For this problem, nekRS has 6 boundaries. "
                  "Did you enter a valid 'boundary' in 'nek.i'?"
-    requirement = "MOOSE shall throw an error if an invalid boundary is specified for the construction "
-                  "of nekRS's mesh as a MooseMesh."
+    requirement = "MOOSE shall throw an error if an invalid boundary is specified for a side postprocessor."
     capabilities = 'nekrs'
   []
 []

--- a/test/tests/nek_errors/invalid_field/tests
+++ b/test/tests/nek_errors/invalid_field/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekFieldVariable.md NekVolumeExtremeValue.md NekRSProblem.md'
   [temperature]
     type = RunException
     input = nek.i

--- a/test/tests/nek_errors/invalid_field/tests
+++ b/test/tests/nek_errors/invalid_field/tests
@@ -1,11 +1,11 @@
 [Tests]
-  design = 'NekFieldVariable.md NekVolumeExtremeValue.md NekRSProblem.md'
   [temperature]
     type = RunException
     input = nek.i
     expect_err = "Cannot find 'temperature' because your Nek case files do not have a temperature variable!"
     requirement = "The system shall throw an error if trying to use temperature as a field for cases that do not have a temperature variable"
     capabilities = 'nekrs'
+    design = 'NekVolumeExtremeValue.md'
   []
   [scalar01]
     type = RunException
@@ -14,6 +14,7 @@
     expect_err = "Cannot find 'scalar01' because your Nek case files do not have a scalar01 variable!"
     requirement = "The system shall throw an error if trying to use scalar01 as a field for problems that don't have a scalar01 variable."
     capabilities = 'nekrs'
+    design = 'NekVolumeExtremeValue.md'
   []
   [scalar02]
     type = RunException
@@ -22,6 +23,7 @@
     expect_err = "Cannot find 'scalar02' because your Nek case files do not have a scalar02 variable!"
     requirement = "The system shall throw an error if trying to use scalar02 as a field for problems that don't have a scalar02 variable."
     capabilities = 'nekrs'
+    design = 'NekVolumeExtremeValue.md'
   []
   [scalar03]
     type = RunException
@@ -30,6 +32,7 @@
     expect_err = "Cannot find 'scalar03' because your Nek case files do not have a scalar03 variable!"
     requirement = "The system shall throw an error if trying to use scalar03 as a field for problems that don't have a scalar03 variable."
     capabilities = 'nekrs'
+    design = 'NekVolumeExtremeValue.md'
   []
   [usrwrk00]
     type = RunException
@@ -38,6 +41,7 @@
     expect_err = "Cannot find 'usrwrk00' because you have only allocated 'n_usrwrk_slots = 0'"
     requirement = "The system shall throw an error if trying to use usrwrk00 as a field for problems that don't have sufficient usrwrk slots."
     capabilities = 'nekrs'
+    design = 'NekVolumeExtremeValue.md'
   []
   [usrwrk01]
     type = RunException
@@ -46,6 +50,7 @@
     expect_err = "Cannot find 'usrwrk01' because you have only allocated 'n_usrwrk_slots = 1'"
     requirement = "The system shall throw an error if trying to use usrwrk01 as a field for problems that don't have sufficient usrwrk slots."
     capabilities = 'nekrs'
+    design = 'NekVolumeExtremeValue.md'
   []
   [usrwrk02]
     type = RunException
@@ -54,6 +59,7 @@
     expect_err = "Cannot find 'usrwrk02' because you have only allocated 'n_usrwrk_slots = 2'"
     requirement = "The system shall throw an error if trying to use usrwrk02 as a field for problems that don't have sufficient usrwrk slots."
     capabilities = 'nekrs'
+    design = 'NekVolumeExtremeValue.md'
   []
   [allocate_scratch_no_T]
     type = RunApp
@@ -61,6 +67,7 @@
     cli_args = "Postprocessors/active='' Problem/n_usrwrk_slots=2"
     requirement = "The system shall correctly allocate scratch by accessing only quantities on the flow mesh if there is no temperature variable"
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
   [duplicate_auxvar]
     type = RunException
@@ -68,6 +75,7 @@
     expect_err = "Cardinal is trying to add an auxiliary variable named 'temp' through the FieldTransfer system"
     requirement = "The system shall error if the user manually specifies a duplicate name for an output field."
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
   [duplicate_var]
     type = RunException
@@ -75,5 +83,6 @@
     expect_err = "Cardinal is trying to add a nonlinear variable named 'temp', but you already have a variable by this name."
     requirement = "The system shall error if the user manually specifies a duplicate name for an output field."
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
 []

--- a/test/tests/nek_errors/invalid_settings/tests
+++ b/test/tests/nek_errors/invalid_settings/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekRSMesh.md'
 
   # can't use more processors than elements, so all tests are limited to 12 ranks
 

--- a/test/tests/nek_errors/invalid_settings/tests
+++ b/test/tests/nek_errors/invalid_settings/tests
@@ -1,6 +1,4 @@
 [Tests]
-  design = 'NekRSProblem.md NekRSMesh.md'
-
   # can't use more processors than elements, so all tests are limited to 12 ranks
 
   [executioner]
@@ -10,6 +8,7 @@
     requirement = "The system shall error if NekRSProblem is not paired with the correct executioner."
     max_parallel = 12
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
   [dimensionalize]
     type = RunException
@@ -18,6 +17,7 @@
     requirement = "The system shall error if the Dimensionalize action is not paired with the correct problem."
     max_parallel = 12
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
   [mesh]
     type = RunException
@@ -26,6 +26,7 @@
     requirement = "The system shall error if NekRSProblem is not paired with the correct mesh type."
     max_parallel = 12
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
   [problem_base]
     type = RunException
@@ -34,6 +35,7 @@
     requirement = "The system shall error if a Nek object is not paired with the correct problem."
     max_parallel = 12
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
   [problem_mesh]
     type = RunException
@@ -43,6 +45,7 @@
                   "problem."
     max_parallel = 12
     capabilities = 'nekrs'
+    design = 'NekRSMesh.md'
   []
   [timestepper]
     type = RunException
@@ -52,6 +55,7 @@
     requirement = "The system shall error if NekRSProblem is not paired with the correct time stepper."
     max_parallel = 12
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
   [missing_flux_bc]
     type = RunException
@@ -61,6 +65,7 @@
                   "on the nekRS boundaries that are coupled to MOOSE."
     max_parallel = 12
     capabilities = 'nekrs'
+    design = 'NekRSMesh.md'
   []
   [boundary_id]
     type = RunException
@@ -72,6 +77,7 @@
                   "of nekRS's mesh as a MooseMesh."
     max_parallel = 12
     capabilities = 'nekrs'
+    design = 'NekRSMesh.md'
   []
   [scaling_mismatch]
     type = RunException
@@ -80,5 +86,6 @@
     requirement = "The system shall error if there is a mismatch between the scaling of the mesh and NekRS problem."
     max_parallel = 12
     capabilities = 'nekrs'
+    design = 'NekRSMesh.md NekRSProblem.md'
   []
 []

--- a/test/tests/nek_errors/invalid_transfer_pp/tests
+++ b/test/tests/nek_errors/invalid_transfer_pp/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [invalid_transfer_pp]
     type = RunException
     input = nek_master.i

--- a/test/tests/nek_errors/mpi_setup_multiple_inputs/tests
+++ b/test/tests/nek_errors/mpi_setup_multiple_inputs/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [too_few_mpi_ranks]
     type = RunException
     input = nek_master.i

--- a/test/tests/nek_errors/no_occa_source_kernel/tests
+++ b/test/tests/nek_errors/no_occa_source_kernel/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekVolumetricSource.md'
   [no_occa_source_kernel]
     type = RunException
     input = nek.i

--- a/test/tests/nek_errors/no_temp_solve/tests
+++ b/test/tests/nek_errors/no_temp_solve/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekBoundaryFlux.md NekVolumetricSource.md'
   [flux]
     type = RunException
     input = nek.i

--- a/test/tests/nek_errors/no_temp_solve/tests
+++ b/test/tests/nek_errors/no_temp_solve/tests
@@ -1,5 +1,4 @@
 [Tests]
-  design = 'NekBoundaryFlux.md NekVolumetricSource.md'
   [flux]
     type = RunException
     input = nek.i
@@ -11,6 +10,7 @@
     cli_args = '--error'
     requirement = "MOOSE shall throw a warning if there is no temperature passive scalar solve in NekRS when passing heat flux"
     capabilities = 'nekrs'
+    design = 'NekBoundaryFlux.md'
   []
   [source]
     type = RunException
@@ -23,5 +23,6 @@
     cli_args = '--error'
     requirement = "MOOSE shall throw a warning if there is no temperature passive scalar solve in NekRS when passing heat flux"
     capabilities = 'nekrs'
+    design = 'NekVolumetricSource.md'
   []
 []

--- a/test/tests/nek_errors/no_temp_var/tests
+++ b/test/tests/nek_errors/no_temp_var/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekBoundaryFlux.md NekVolumetricSource.md'
   [flux]
     type = RunException
     input = nek.i

--- a/test/tests/nek_errors/no_temp_var/tests
+++ b/test/tests/nek_errors/no_temp_var/tests
@@ -1,5 +1,4 @@
 [Tests]
-  design = 'NekBoundaryFlux.md NekVolumetricSource.md'
   [flux]
     type = RunException
     input = nek.i
@@ -7,6 +6,7 @@
     requirement = "MOOSE shall throw an error if there is no temperature passive scalar "
                   "variable initialized in nekRS for flux coupling."
     capabilities = 'nekrs'
+    design = 'NekBoundaryFlux.md'
   []
   [source]
     type = RunException
@@ -15,5 +15,6 @@
     requirement = "MOOSE shall throw an error if there is no temperature passive scalar "
                   "variable initialized in nekRS for source coupling."
     capabilities = 'nekrs'
+    design = 'NekVolumetricSource.md'
   []
 []

--- a/test/tests/nek_errors/used_scratch/tests
+++ b/test/tests/nek_errors/used_scratch/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [occupied_scratch_space]
     type = RunException
     input = nek.i

--- a/test/tests/nek_errors/usrwrk_transfers/tests
+++ b/test/tests/nek_errors/usrwrk_transfers/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekBoundaryFlux.md NekVolumetricSource.md NekScalarValue.md'
   [duplicate_scratch]
     type = RunException
     input = nek.i

--- a/test/tests/nek_errors/usrwrk_transfers/tests
+++ b/test/tests/nek_errors/usrwrk_transfers/tests
@@ -1,5 +1,4 @@
 [Tests]
-  design = 'NekBoundaryFlux.md NekVolumetricSource.md NekScalarValue.md'
   [duplicate_scratch]
     type = RunException
     input = nek.i
@@ -7,6 +6,7 @@
     expect_err = "There are duplicate entries in 'usrwrk_slot': 1 1 ; duplicate entries are not allowed because the field transfer will overwrite itself."
     requirement = "MOOSE shall throw an error if a single transfer tries to occupy the same slot more than once"
     capabilities = 'nekrs'
+    design = 'NekBoundaryFlux.md'
   []
   [exceed_allocated_field]
     type = RunException
@@ -15,6 +15,7 @@
     expect_err = "Cannot write into usrwrk slot 7 because only 7 have been allocated with 'n_usrwrk_slots'. Slots are zero-indexed, so the maximum acceptable value in 'usrwrk_slot' is 6."
     requirement = "MOOSE shall throw an error if a attempting to write a field into a usrwrk slot which has not been allocated"
     capabilities = 'nekrs'
+    design = 'NekBoundaryFlux.md'
   []
   [exceed_allocated_scalar]
     type = RunException
@@ -23,6 +24,7 @@
     expect_err = "Cannot write into usrwrk slot 7 because only 7 have been allocated with 'n_usrwrk_slots'. Slots are zero-indexed, so the maximum acceptable value in 'usrwrk_slot' is 6."
     requirement = "MOOSE shall throw an error if a attempting to write a scalar into a usrwrk slot which has not been allocated"
     capabilities = 'nekrs'
+    design = 'NekScalarValue.md'
   []
   [field_duplicated_by_field]
     type = RunException
@@ -31,6 +33,7 @@
     expect_err = "A duplicate slot, 2, is being used by another FieldTransfer."
     requirement = "MOOSE shall throw an error if a attempting to write a field into a usrwrk slot already claimed by another field transfer"
     capabilities = 'nekrs'
+    design = 'NekBoundaryFlux.md'
   []
   [scalar_duplicated_by_field]
     type = RunException
@@ -38,6 +41,7 @@
     expect_err = "The usrwrk slot 3 is already used by the FieldTransfers for writing field data into NekRS. You cannot set 'usrwrk_slot' to any of: 3 4"
     requirement = "MOOSE shall throw an error if a attempting to write a scalar into a usrwrk slot already claimed by a field transfer"
     capabilities = 'nekrs'
+    design = 'NekScalarValue.md'
   []
   [flux_no_boundary]
     type = RunException
@@ -45,6 +49,7 @@
     expect_err = "NekBoundaryFlux can only be used when there is boundary coupling of NekRS with MOOSE, i.e. when 'boundary' is provided in NekRSMesh."
     requirement = "The system shall error when a boundary flux transfer is applied when there is not boundary coupling"
     capabilities = 'nekrs'
+    design = 'NekBoundaryFlux.md'
   []
   [source_no_volume]
     type = RunException
@@ -53,6 +58,7 @@
     expect_err = "The NekVolumetricSource object can only be used when there is volumetric coupling of NekRS with MOOSE, i.e. when 'volume = true' in NekRSMesh."
     requirement = "The system shall error when a volumetric source transfer is applied when there is not volume coupling"
     capabilities = 'nekrs'
+    design = 'NekVolumetricSource.md'
   []
   [flux_slots]
     type = RunException
@@ -61,6 +67,7 @@
     expect_err = "'usrwrk_slot' must be of length 1 for boundary flux transfers; you have entered a vector of length 2"
     requirement = "The system shall error when the usrwrk slot request does not match the needed number of slots for a flux transfer"
     capabilities = 'nekrs'
+    design = 'NekBoundaryFlux.md'
   []
   [source_slots]
     type = RunException
@@ -68,6 +75,7 @@
     expect_err = "'usrwrk_slot' must be of length 1 for volumetric source transfers; you have entered a vector of length 2"
     requirement = "The system shall error when the usrwrk slot request does not match the needed number of slots for a source transfer"
     capabilities = 'nekrs'
+    design = 'NekVolumetricSource.md'
   []
   [problem_field]
     type = RunException
@@ -75,6 +83,7 @@
     expect_err = "The \[FieldTransfers\] block can only be used with wrapped Nek cases! You need to change the \[Problem\] block to 'NekRSProblem'."
     requirement = "The system shall error if trying to use field transfer syntax only relevant for NekRS wrapped cases with a non-Nek case."
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
   [problem_scalar]
     type = RunException
@@ -82,5 +91,6 @@
     expect_err = "The \[ScalarTransfers\] block can only be used with wrapped Nek cases! You need to change the \[Problem\] block to 'NekRSProblem'."
     requirement = "The system shall error if trying to use scalar transfer syntax only relevant for NekRS wrapped cases with a non-Nek case."
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
 []

--- a/test/tests/nek_file_output/nek_as_master/tests
+++ b/test/tests/nek_file_output/nek_as_master/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [nek_as_master_output]
     type = CheckFiles
     input = nek.i

--- a/test/tests/nek_file_output/nek_as_master_even/tests
+++ b/test/tests/nek_file_output/nek_as_master_even/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [nek_as_master_even_output]
     type = CheckFiles
     input = nek.i

--- a/test/tests/nek_file_output/nek_as_sub/tests
+++ b/test/tests/nek_file_output/nek_as_sub/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [nek_as_sub_output]
     type = CheckFiles
     input = nek_master.i

--- a/test/tests/nek_file_output/nek_as_sub_even/tests
+++ b/test/tests/nek_file_output/nek_as_sub_even/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [nek_as_sub_even_output]
     type = CheckFiles
     input = nek_master.i

--- a/test/tests/nek_file_output/usrwrk/tests
+++ b/test/tests/nek_file_output/usrwrk/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [check_scratch]
     type = CheckFiles
     input = nek.i

--- a/test/tests/nek_mesh/exact/tests
+++ b/test/tests/nek_mesh/exact/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSMesh.md'
   [boundary_exact]
     type = Exodiff
     input = exact.i

--- a/test/tests/nek_mesh/first_order/tests
+++ b/test/tests/nek_mesh/first_order/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSMesh.md'
   [first_order_mesh]
     type = Exodiff
     input = nek.i

--- a/test/tests/nek_mesh/second_order/tests
+++ b/test/tests/nek_mesh/second_order/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSMesh.md'
   [second_order_mesh]
     type = 'Exodiff'
     input = 'nek.i'

--- a/test/tests/nek_mesh/sidesets/cube/tests
+++ b/test/tests/nek_mesh/sidesets/cube/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSMesh.md'
   [cube_sidesets]
     type = CSVDiff
     input = nek_volume.i

--- a/test/tests/nek_mesh/sidesets/pyramid/tests
+++ b/test/tests/nek_mesh/sidesets/pyramid/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSMesh.md'
   [pyramid_sidesets]
     type = CSVDiff
     input = nek_volume.i

--- a/test/tests/nek_output/tests
+++ b/test/tests/nek_output/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekFieldVariable.md NekRSProblem.md'
   [scalar_output]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_output/tests
+++ b/test/tests/nek_output/tests
@@ -1,5 +1,4 @@
 [Tests]
-  design = 'NekFieldVariable.md NekRSProblem.md'
   [scalar_output]
     type = CSVDiff
     input = nek.i
@@ -8,6 +7,7 @@
     requirement = "Nek-wrapped MOOSE cases shall be able to output the "
                   "passive scalars from the Nek solution onto the mesh mirror."
     capabilities = 'nekrs'
+    design = 'NekFieldVariable.md'
   []
   [other_output]
     type = CSVDiff
@@ -16,6 +16,7 @@
     abs_zero = 1e-8
     requirement = "Nek-wrapped MOOSE cases shall be able to output any quantity in the field enumeration from NekRS onto the mesh mirror."
     capabilities = 'nekrs'
+    design = 'NekFieldVariable.md'
   []
   [too_high_slot]
     type = RunException
@@ -23,6 +24,7 @@
     expect_err = "Cannot write field file for usrwrk slot greater than the total number of allocated slots: 2!"
     requirement = "The system shall error if trying to write a usrwrk slot greater than the total number of allocated slots"
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
   [mismatch_length]
     type = RunException
@@ -31,6 +33,7 @@
     expect_err = "The length of 'usrwrk_output' must match the length of 'usrwrk_output_prefix'!"
     requirement = "The system shall error if there is a mismatch between parameter lengths for writing usrwrk field files"
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
   [bad_name]
     type = RunException
@@ -38,5 +41,6 @@
     expect_err = "We tried to choose a default 'field' as 'temp', but this value is not an option in the 'field' enumeration. Please provide the 'field' parameter."
     requirement = "The system shall error if the default choice for the field cannot be matched from the object name."
     capabilities = 'nekrs'
+    design = 'NekFieldVariable.md'
   []
 []

--- a/test/tests/nek_standalone/adaptive_dt/tests
+++ b/test/tests/nek_standalone/adaptive_dt/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekTimeStepper.md NekRSProblem.md'
   [variable_dt]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_standalone/adaptive_dt/tests
+++ b/test/tests/nek_standalone/adaptive_dt/tests
@@ -1,11 +1,11 @@
 [Tests]
-  design = 'NekTimeStepper.md NekRSProblem.md'
   [variable_dt]
     type = CSVDiff
     input = nek.i
     csvdiff = nek_out.csv
     requirement = "The system shall support adaptive time stepping in NekRS when running as the main application."
     capabilities = 'nekrs'
+    design = 'NekTimeStepper.md'
   []
   [variable_dt_nondim]
     type = CSVDiff
@@ -14,5 +14,6 @@
     requirement = "The system shall support adaptive time stepping in NekRS when running as the main application "
                   "and with a non-dimensional formulation."
     capabilities = 'nekrs'
+    design = 'NekTimeStepper.md DimensionalizeAction.md'
   []
 []

--- a/test/tests/nek_standalone/channel/tests
+++ b/test/tests/nek_standalone/channel/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekRSMesh.md'
   [test]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_standalone/channel/tests
+++ b/test/tests/nek_standalone/channel/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekRSProblem.md NekRSMesh.md'
+  design = 'NekRSProblem.md NekRSMesh.mdi NekFieldVariable.md NekTimeStepper.md NekVolumeExtremeValue.md NekSideExtremeValue.md NekVolumeAverage.md NekSideAverage.md'
   [test]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_standalone/channel/tests
+++ b/test/tests/nek_standalone/channel/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekRSProblem.md NekRSMesh.mdi NekFieldVariable.md NekTimeStepper.md NekVolumeExtremeValue.md NekSideExtremeValue.md NekVolumeAverage.md NekSideAverage.md'
+  design = 'NekRSProblem.md NekRSMesh.md NekFieldVariable.md NekTimeStepper.md NekVolumeExtremeValue.md NekSideExtremeValue.md NekVolumeAverage.md NekSideAverage.md'
   [test]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_standalone/conj_ht/tests
+++ b/test/tests/nek_standalone/conj_ht/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekRSMesh.md'
   [nek_example]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_standalone/conj_ht/tests
+++ b/test/tests/nek_standalone/conj_ht/tests
@@ -1,5 +1,4 @@
 [Tests]
-  design = 'NekRSProblem.md NekRSMesh.md'
   [nek_example]
     type = CSVDiff
     input = nek.i
@@ -8,6 +7,7 @@
     requirement = "Cardinal shall be able to run the conj_ht NekRS example with a thin wrapper while "
                   "using postprocessors acting on either the fluid mesh or fluid+solid mesh."
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md NekRSMesh.md NekTimeStepper.md NekSideIntegral.md NekHeatFluxIntegral.md NekMassFluxWeightedSideIntegral.md NekMassFluxWeightedSideAverage.md ReynoldsNumber.md PecletNumber.md NekVolumeIntegral.md NekVolumeExtremeValue.md NekVolumeAverage.md'
   []
   [invalid_mesh_solid]
     type = RunException
@@ -16,5 +16,6 @@
     expect_err = "This object does not support operations on the solid part of the NekRS mesh!"
     requirement = "The system shall throw an error if trying to act on only the NekRS solid mesh for side postprocessors."
     capabilities = 'nekrs'
+    design = 'NekSideIntegral.md'
   []
 []

--- a/test/tests/nek_standalone/ethier/tests
+++ b/test/tests/nek_standalone/ethier/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [test]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_standalone/ethier/tests
+++ b/test/tests/nek_standalone/ethier/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekRSProblem.md'
+  design = 'NekRSProblem.md NekRSMesh.md NekFieldVariable.md NekTimeStepper.md NekHeatFluxIntegral.md'
   [test]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_standalone/from_restart/tests
+++ b/test/tests/nek_standalone/from_restart/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md'
   [postprocess_from_restart]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_standalone/from_restart/tests
+++ b/test/tests/nek_standalone/from_restart/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekRSProblem.md'
+  design = 'NekRSProblem.md NekRSMesh.md NekTimeStepper.md NekVolumeAverage.md'
   [postprocess_from_restart]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_standalone/ktauChannel/tests
+++ b/test/tests/nek_standalone/ktauChannel/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md ktau.md'
   [volume]
     type = RunApp
     input = nek.i

--- a/test/tests/nek_standalone/ktauChannel/tests
+++ b/test/tests/nek_standalone/ktauChannel/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekRSProblem.md ktau.md'
+  design = 'NekRSProblem.md NekRSMesh.md NekTimeStepper.md NekFieldVariable.md NekVolumeExtremeValue.md'
   [volume]
     type = RunApp
     input = nek.i

--- a/test/tests/nek_standalone/lowMach/tests
+++ b/test/tests/nek_standalone/lowMach/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSProblem.md NekRSMesh.md'
   [volume]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_standalone/lowMach/tests
+++ b/test/tests/nek_standalone/lowMach/tests
@@ -1,5 +1,4 @@
 [Tests]
-  design = 'NekRSProblem.md NekRSMesh.md'
   [volume]
     type = CSVDiff
     input = nek.i
@@ -17,6 +16,7 @@
                   "solution (on the GLL points versus on the mesh mirror). This verifies "
                   "correct extraction of the NekRS solution with the 'output' parameter feature."
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md NekRSMesh.md NekFieldVariable.md NekTimeStepper.md NekVolumeExtremeValue.md NekSideIntegral.md NekVolumeIntegral.md NekSideExtremeValue.md NekVolumeAverage.md NekSideAverage.md'
   []
   [boundary]
     type = CSVDiff
@@ -34,5 +34,6 @@
                   "solution (on the GLL points versus on the mesh mirror). This verifies "
                   "correct extraction of the NekRS solution with the 'output' parameter feature."
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md NekRSMesh.md NekFieldVariable.md NekTimeStepper.md NekSideExtremeValue.md NekSideAverage.md'
   []
 []

--- a/test/tests/nek_standalone/start_time/tests
+++ b/test/tests/nek_standalone/start_time/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekTimeStepper.md NekRSProblem.md'
   [wrapper]
     type = CSVDiff
     input = force_start.i

--- a/test/tests/nek_stochastic/device/tests
+++ b/test/tests/nek_stochastic/device/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekScalarValue.md NekRSProblem.md'
   [precompile]
     type = RunCommand
     command = '${NEKRS_HOME}/bin/nrspre pyramid 1'

--- a/test/tests/nek_stochastic/device/tests
+++ b/test/tests/nek_stochastic/device/tests
@@ -1,11 +1,11 @@
 [Tests]
-  design = 'NekScalarValue.md NekRSProblem.md'
   [precompile]
     type = RunCommand
     command = '${NEKRS_HOME}/bin/nrspre pyramid 1'
     requirement = "The system shall precompile a NekRS case."
     capabilities = 'nekrs'
     use_shell = True
+    design = 'NekRSProblem.md'
   []
   [device]
     type = CSVDiff
@@ -18,5 +18,6 @@
                   "temperature on the boundary using postprocessors."
     capabilities = 'nekrs'
     mesh_mode = replicated
+    design = 'NekScalarValue.md'
   []
 []

--- a/test/tests/nek_stochastic/quiet_init/tests
+++ b/test/tests/nek_stochastic/quiet_init/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekScalarValue.md NekRSProblem.md'
   [clear0]
     type = RunCommand
     command = 'rm -rf .cache/'

--- a/test/tests/nek_stochastic/quiet_init/tests
+++ b/test/tests/nek_stochastic/quiet_init/tests
@@ -1,11 +1,11 @@
 [Tests]
-  design = 'NekScalarValue.md NekRSProblem.md'
   [clear0]
     type = RunCommand
     command = 'rm -rf .cache/'
     requirement = "The system shall clear the cache before attempting the test with another set of ranks."
     capabilities = 'nekrs'
     use_shell = True
+    design = 'NekRSProblem.md'
   []
   [driver_multi_1]
     type = CSVDiff
@@ -19,6 +19,7 @@
                   "are properly received in the scratch space by using that value to set a dummy scalar01. We purposefully "
                   "put this test in its own directory to prove that there are no requirements on precompilation."
     capabilities = 'nekrs'
+    design = 'NekScalarValue.md'
   []
   [clear1]
     type = RunCommand
@@ -26,6 +27,7 @@
     requirement = "The system shall clear the cache before attempting the test with another set of ranks."
     capabilities = 'nekrs'
     use_shell = True
+    design = 'NekRSProblem.md'
   []
   [driver_multi_2]
     type = CSVDiff
@@ -40,6 +42,7 @@
                   "are properly received in the scratch space by using that value to set a dummy scalar01. We purposefully "
                   "put this test in its own directory to prove that there are no requirements on precompilation."
     capabilities = 'nekrs'
+    design = 'NekScalarValue.md'
   []
   [clear2]
     type = RunCommand
@@ -48,6 +51,7 @@
     requirement = "The system shall clear the cache before attempting the test with another set of ranks."
     capabilities = 'nekrs'
     use_shell = True
+    design = 'NekRSProblem.md'
   []
   [driver_multi_3]
     type = CSVDiff
@@ -62,6 +66,7 @@
                   "are properly received in the scratch space by using that value to set a dummy scalar01. We purposefully "
                   "put this test in its own directory to prove that there are no requirements on precompilation."
     capabilities = 'nekrs'
+    design = 'NekScalarValue.md'
   []
   [clear3]
     type = RunCommand
@@ -70,6 +75,7 @@
     requirement = "The system shall clear the cache before attempting the test with another set of ranks."
     capabilities = 'nekrs'
     use_shell = True
+    design = 'NekRSProblem.md'
   []
   [driver_multi_4]
     type = CSVDiff
@@ -84,5 +90,6 @@
                   "put this test in its own directory to prove that there are no requirements on precompilation."
     capabilities = 'nekrs'
     skip = 'Need to resolve random failure'
+    design = 'NekScalarValue.md'
   []
 []

--- a/test/tests/nek_stochastic/shift/tests
+++ b/test/tests/nek_stochastic/shift/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekScalarValue.md NekRSProblem.md'
   [initial_offset]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_stochastic/shift/tests
+++ b/test/tests/nek_stochastic/shift/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekScalarValue.md NekRSProblem.md'
+  design = 'NekScalarValue.md'
   [initial_offset]
     type = CSVDiff
     input = nek.i

--- a/test/tests/nek_temp/exact/tests
+++ b/test/tests/nek_temp/exact/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSMesh.md NekFieldVariable.md'
   [exact_temperature]
     type = Exodiff
     input = exact.i

--- a/test/tests/nek_temp/exact/tests
+++ b/test/tests/nek_temp/exact/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekRSMesh.md NekFieldVariable.md'
+  design = 'NekFieldVariable.md NekRSMesh.md'
   [exact_temperature]
     type = Exodiff
     input = exact.i

--- a/test/tests/nek_temp/first_order/tests
+++ b/test/tests/nek_temp/first_order/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSMesh.md NekFieldVariable.md'
   [first_order_temperature]
     type = Exodiff
     input = nek.i

--- a/test/tests/nek_temp/first_order/tests
+++ b/test/tests/nek_temp/first_order/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekRSMesh.md NekFieldVariable.md'
+  design = 'NekFieldVariable.md NekRSMesh.md'
   [first_order_temperature]
     type = Exodiff
     input = nek.i

--- a/test/tests/nek_temp/second_order/tests
+++ b/test/tests/nek_temp/second_order/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekRSMesh.md NekFieldVariable.md'
   [second_order_temperature]
     type = Exodiff
     input = nek.i

--- a/test/tests/neutronics/density/tests
+++ b/test/tests/neutronics/density/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [openmc]
     type = Exodiff
     input = openmc.i

--- a/test/tests/neutronics/feedback/different_units/tests
+++ b/test/tests/neutronics/feedback/different_units/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [different_units]
     type = Exodiff
     input = openmc_master.i

--- a/test/tests/neutronics/feedback/interchangeable/tests
+++ b/test/tests/neutronics/feedback/interchangeable/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md CellTally.md'
   [no_feedback_tally]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/neutronics/feedback/lattice/tests
+++ b/test/tests/neutronics/feedback/lattice/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md CellTally.md'
   [pincell]
     type = Exodiff
     input = openmc_master.i

--- a/test/tests/neutronics/feedback/multi_component_density/multi/tests
+++ b/test/tests/neutronics/feedback/multi_component_density/multi/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [collate_density]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/neutronics/feedback/multi_component_density/tests
+++ b/test/tests/neutronics/feedback/multi_component_density/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [wrong_length]
     type = RunException
     input = openmc_incorrect_length.i

--- a/test/tests/neutronics/feedback/multi_component_temp/tests
+++ b/test/tests/neutronics/feedback/multi_component_temp/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [wrong_length]
     type = RunException
     input = openmc_incorrect_length.i

--- a/test/tests/neutronics/feedback/multiple_levels/tests
+++ b/test/tests/neutronics/feedback/multiple_levels/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [multiple_layers]
     type = Exodiff
     input = openmc.i

--- a/test/tests/neutronics/feedback/single_level/tests
+++ b/test/tests/neutronics/feedback/single_level/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [pincell]
     type = Exodiff
     input = openmc_master.i

--- a/test/tests/neutronics/feedback/temperature/one_one/tests
+++ b/test/tests/neutronics/feedback/temperature/one_one/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [one_to_one]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/neutronics/feedback/temperature/one_two/tests
+++ b/test/tests/neutronics/feedback/temperature/one_two/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [one_to_two]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/neutronics/feedback/temperature/two_one/tests
+++ b/test/tests/neutronics/feedback/temperature/two_one/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [two_to_one]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/neutronics/feedback/universes/fill_in_flat/tests
+++ b/test/tests/neutronics/feedback/universes/fill_in_flat/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [universe_in_flat_geom]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/neutronics/feedback/unmapped_moose/tests
+++ b/test/tests/neutronics/feedback/unmapped_moose/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [unmapped]
     type = Exodiff
     input = openmc_master.i

--- a/test/tests/neutronics/fixed_source/tests
+++ b/test/tests/neutronics/fixed_source/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md CellTally.md'
   [mapping_all]
     type = CSVDiff
     input = mapping_all.i

--- a/test/tests/neutronics/fixed_source/tests
+++ b/test/tests/neutronics/fixed_source/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'OpenMCCellAverageProblem.md CellTally.md'
+  design = 'OpenMCCellAverageProblem.md'
   [mapping_all]
     type = CSVDiff
     input = mapping_all.i

--- a/test/tests/neutronics/flux/tests
+++ b/test/tests/neutronics/flux/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'OpenMCCellAverageProblem.md CellTally.md'
+  design = 'MeshTally.md CellTally.md'
   [flux]
     type = CSVDiff
     input = flux.i

--- a/test/tests/neutronics/flux/tests
+++ b/test/tests/neutronics/flux/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md CellTally.md'
   [flux]
     type = CSVDiff
     input = flux.i

--- a/test/tests/neutronics/heat_source/distrib_cell/tests
+++ b/test/tests/neutronics/heat_source/distrib_cell/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md CellTally.md'
   [solid]
     type = Exodiff
     input = solid.i

--- a/test/tests/neutronics/output/tests
+++ b/test/tests/neutronics/output/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'CellTally.md MeshTally.md'
   [unrelaxed_tally_rel_error_cell]
     type = CSVDiff
     input = cell.i

--- a/test/tests/neutronics/solid/tests
+++ b/test/tests/neutronics/solid/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md CellTally.md'
   [zero_power]
     type = Exodiff
     input = openmc_master_zero.i

--- a/test/tests/neutronics/symmetry/rotational/tests
+++ b/test/tests/neutronics/symmetry/rotational/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'SymmetryPointGenerator.md OpenMCCellAverageProblem.md'
   [generate_mesh]
     type = RunApp
     input = solid_mesh.i

--- a/test/tests/neutronics/symmetry/tests
+++ b/test/tests/neutronics/symmetry/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'SymmetryPointGenerator.md OpenMCCellAverageProblem.md'
   [generate_mesh]
     type = RunApp
     input = solid_mesh.i

--- a/test/tests/neutronics/symmetry/triso/tests
+++ b/test/tests/neutronics/symmetry/triso/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'SymmetryPointGenerator.md OpenMCCellAverageProblem.md'
   [generate_mesh]
     type = RunApp
     input = solid_mesh.i

--- a/test/tests/neutronics/tallies/tritium/tests
+++ b/test/tests/neutronics/tallies/tritium/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'CellTally.md OpenMCCellAverageProblem.md'
+  design = 'CellTally.md MeshTally.md'
   [tritium]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/neutronics/tallies/tritium/tests
+++ b/test/tests/neutronics/tallies/tritium/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'CellTally.md OpenMCCellAverageProblem.md'
   [tritium]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/openmc_errors/block_mappings/tests
+++ b/test/tests/openmc_errors/block_mappings/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md CellTally.md'
   [nonexistent_block]
     type = RunException
     input = nonexistent_block.i

--- a/test/tests/openmc_errors/block_mappings/tests
+++ b/test/tests/openmc_errors/block_mappings/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'OpenMCCellAverageProblem.md CellTally.md'
+  design = 'OpenMCCellAverageProblem.md'
   [nonexistent_block]
     type = RunException
     input = nonexistent_block.i

--- a/test/tests/openmc_errors/densities/tests
+++ b/test/tests/openmc_errors/densities/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [zero_density]
     type = RunException
     input = zero_density.i

--- a/test/tests/openmc_errors/fixed_source/tests
+++ b/test/tests/openmc_errors/fixed_source/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'KEigenvalue.md OpenMCCellAverageProblem.md'
   [k]
     type = RunException
     input = k.i

--- a/test/tests/openmc_errors/input_params/tests
+++ b/test/tests/openmc_errors/input_params/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [invalid_batches]
     type = RunException
     input = invalid_batches.i

--- a/test/tests/openmc_errors/level/phase_too_high/tests
+++ b/test/tests/openmc_errors/level/phase_too_high/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [fluid_too_high]
     type = RunException
     input = fluid_too_high.i

--- a/test/tests/openmc_errors/level/total_too_high/tests
+++ b/test/tests/openmc_errors/level/total_too_high/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [level_too_high]
     type = RunException
     input = level_too_high.i

--- a/test/tests/openmc_errors/mesh_tally/tests
+++ b/test/tests/openmc_errors/mesh_tally/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'MeshTally.md'
   [incorrect_scaling]
     type = RunException
     input = incorrect_scaling.i

--- a/test/tests/openmc_errors/mesh_translations/tests
+++ b/test/tests/openmc_errors/mesh_translations/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'MeshTally.md'
   [invalid_row]
     type = RunException
     input = invalid_row.i

--- a/test/tests/openmc_errors/mode/particle/tests
+++ b/test/tests/openmc_errors/mode/particle/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [volume]
     type = RunException
     input = particle.i

--- a/test/tests/openmc_errors/mode/plot/tests
+++ b/test/tests/openmc_errors/mode/plot/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [plot]
     type = RunException
     input = plot.i

--- a/test/tests/openmc_errors/mode/volume/tests
+++ b/test/tests/openmc_errors/mode/volume/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [volume]
     type = RunException
     input = volume.i

--- a/test/tests/openmc_errors/no_range/tests
+++ b/test/tests/openmc_errors/no_range/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [no_range]
     type = RunException
     input = openmc.i

--- a/test/tests/openmc_errors/xs_temperatures/tests
+++ b/test/tests/openmc_errors/xs_temperatures/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCellAverageProblem.md'
   [interpolation_min]
     type = RunException
     input = openmc.i

--- a/test/tests/openmc_errors/zero_tally/tests
+++ b/test/tests/openmc_errors/zero_tally/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'CellTally.md'
   [local_zero]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/openmc_errors/zero_tally/tests
+++ b/test/tests/openmc_errors/zero_tally/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'CellTally.md'
+  design = 'CellTally.md MeshTally.md'
   [local_zero]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/postprocessors/coupled_cells/tests
+++ b/test/tests/postprocessors/coupled_cells/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCCoupledCells.md'
   [cells]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/postprocessors/dimensionless_numbers/dimensional/tests
+++ b/test/tests/postprocessors/dimensionless_numbers/dimensional/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'PecletNumber.md ReynoldsNumber.md NekNumRanks.md'
   [dimensional_Re_Pe]
     type = CSVDiff
     input = nek.i

--- a/test/tests/postprocessors/dimensionless_numbers/dimensional/tests
+++ b/test/tests/postprocessors/dimensionless_numbers/dimensional/tests
@@ -1,11 +1,11 @@
 [Tests]
-  design = 'PecletNumber.md ReynoldsNumber.md NekNumRanks.md'
   [dimensional_Re_Pe]
     type = CSVDiff
     input = nek.i
     csvdiff = nek_out.csv
     requirement = "The system shall correctly compute the Reynolds and Peclet numbers for a dimensional NekRS case."
     capabilities = 'nekrs'
+    design = 'PecletNumber.md ReynoldsNumber.md'
   []
   [ranks]
     type = CSVDiff
@@ -14,5 +14,6 @@
     min_parallel = 3
     requirement = "The system shall correctly output the number of NekRS MPI ranks"
     capabilities = 'nekrs'
+    design = 'NekNumRanks.md'
   []
 []

--- a/test/tests/postprocessors/dimensionless_numbers/nondimensional/tests
+++ b/test/tests/postprocessors/dimensionless_numbers/nondimensional/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'PecletNumber.md ReynoldsNumber.md NekRSProblem.md'
   [nondimensional_Re_Pe]
     type = CSVDiff
     input = nek.i

--- a/test/tests/postprocessors/dimensionless_numbers/nondimensional/tests
+++ b/test/tests/postprocessors/dimensionless_numbers/nondimensional/tests
@@ -1,11 +1,11 @@
 [Tests]
-  design = 'PecletNumber.md ReynoldsNumber.md NekRSProblem.md'
   [nondimensional_Re_Pe]
     type = CSVDiff
     input = nek.i
     csvdiff = nek_out.csv
     requirement = "The system shall correctly compute the Reynolds and Peclet numbers for a nondimensional NekRS case."
     capabilities = 'nekrs'
+    design = 'PecletNumber.md ReynoldsNumber.md DimensionalizeAction.md'
   []
   [check_zero_scratch]
     type = RunApp
@@ -13,5 +13,6 @@
     cli_args = 'Problem/n_usrwrk_slots=0'
     requirement = "The system shall allow zero scratch space allocation."
     capabilities = 'nekrs'
+    design = 'NekRSProblem.md'
   []
 []

--- a/test/tests/postprocessors/eigenvalue/tests
+++ b/test/tests/postprocessors/eigenvalue/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'KEigenvalue.md'
   [k_eigenvalue]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/postprocessors/eigenvalue/xml_directory/tests
+++ b/test/tests/postprocessors/eigenvalue/xml_directory/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'KEigenvalue.md OpenMCCellAverageProblem.md'
   [xml_directory]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/postprocessors/eigenvalue/xml_directory/tests
+++ b/test/tests/postprocessors/eigenvalue/xml_directory/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'KEigenvalue.md OpenMCCellAverageProblem.md'
+  design = 'OpenMCCellAverageProblem.md'
   [xml_directory]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/postprocessors/nek_heat_flux_integral/tests
+++ b/test/tests/postprocessors/nek_heat_flux_integral/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekHeatFluxIntegral.md'
   [nek_heat_flux_integral]
     type = CSVDiff
     input = nek.i

--- a/test/tests/postprocessors/nek_pressure_surface_force/tests
+++ b/test/tests/postprocessors/nek_pressure_surface_force/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekPressureSurfaceForce.md'
   [pressure]
     type = CSVDiff
     input = nek.i

--- a/test/tests/postprocessors/nek_pressure_surface_force/tests
+++ b/test/tests/postprocessors/nek_pressure_surface_force/tests
@@ -1,5 +1,4 @@
 [Tests]
-  design = 'NekPressureSurfaceForce.md'
   [pressure]
     type = CSVDiff
     input = nek.i
@@ -7,14 +6,16 @@
     abs_zero = 1e-12
     requirement = "The system shall allow pressure drag to be computed in the x, y, and z directions in dimensional form. This test compares drag as computed via Nek with by-hand calculations using combinations of native MOOSE postprocessors acting on the NekRS pressure mapped to the mesh mirror, for dimensional form"
     capabilities = 'nekrs'
+    design = 'NekPressureSurfaceForce.md'
   []
   [pressure_nondim]
     type = CSVDiff
     input = nek_nondimensional.i
     csvdiff = nek_nondimensional_out.csv
     abs_zero = 1e-12
-    requirement = "The system shall allow pressure drag to be computed in the x, y, and z directions in dimensional form. This test compares drag as computed via Nek with by-hand calculations using combinations of native MOOSE postprocessors acting on the NekRS pressure mapped to the mesh mirror, for nondimensional form"
+    requirement = "The system shall allow pressure drag to be computed in the x, y, and z directions in non-dimensional form. This test compares drag as computed via Nek with by-hand calculations using combinations of native MOOSE postprocessors acting on the NekRS pressure mapped to the mesh mirror, for nondimensional form"
     capabilities = 'nekrs'
+    design = 'NekPressureSurfaceForce.md DimensionalizeAction.md'
   []
   [invalid_mesh]
     type = RunException
@@ -23,5 +24,6 @@
     expect_err = "The 'NekPressureSurfaceForce' postprocessor can only be applied to"
     requirement = "The system shall error if trying to compute pressure drag on non-fluid NekRS boundaries"
     capabilities = 'nekrs'
+    design = 'NekPressureSurfaceForce.md'
   []
 []

--- a/test/tests/postprocessors/nek_side_extrema/tests
+++ b/test/tests/postprocessors/nek_side_extrema/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekSideExtremeValue.md'
   [nek_side_extrema]
     type = CSVDiff
     input = nek.i

--- a/test/tests/postprocessors/nek_side_integral/tests
+++ b/test/tests/postprocessors/nek_side_integral/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekSideIntegral.md'
   [nek_side_integral]
     type = CSVDiff
     input = nek.i

--- a/test/tests/postprocessors/nek_usrwrk_boundary_integral/tests
+++ b/test/tests/postprocessors/nek_usrwrk_boundary_integral/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekUsrWrkBoundaryIntegral.md'
   [invalid_slot]
     type = RunException
     input = nek.i

--- a/test/tests/postprocessors/nek_volume_extrema/tests
+++ b/test/tests/postprocessors/nek_volume_extrema/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekVolumeExtremeValue.md'
   [nek_volume_extrema]
     type = CSVDiff
     input = nek.i

--- a/test/tests/postprocessors/nek_weighted_side_average/tests
+++ b/test/tests/postprocessors/nek_weighted_side_average/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekMassFluxWeightedSideAverage.md'
   [nek_weighted_side_average]
     type = CSVDiff
     input = nek.i

--- a/test/tests/postprocessors/nek_weighted_side_integral/tests
+++ b/test/tests/postprocessors/nek_weighted_side_integral/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekMassFluxWeightedSideIntegral.md'
   [nek_weighted_side_integral]
     type = CSVDiff
     input = nek.i

--- a/test/tests/postprocessors/openmc_particles/tests
+++ b/test/tests/postprocessors/openmc_particles/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCParticles.md'
   [particles]
     type = CSVDiff
     input = openmc.i

--- a/test/tests/symmetry/tests
+++ b/test/tests/symmetry/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'SymmetryPointGenerator.md OpenMCCellAverageProblem.md'
   [reflection]
     type = Exodiff
     input = reflection.i

--- a/test/tests/transfers/nek_postprocessor_value/tests
+++ b/test/tests/transfers/nek_postprocessor_value/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekPostprocessorValue.md'
   [nek]
     type = CSVDiff
     input = nek.i

--- a/test/tests/transfers/nek_scalar_value/tests
+++ b/test/tests/transfers/nek_scalar_value/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekScalarValue.md'
   [controls]
     type = CSVDiff
     input = nek.i

--- a/test/tests/userobjects/gap/nondimensional/tests
+++ b/test/tests/userobjects/gap/nondimensional/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekBinnedVolumeAverage.md NekBinnedVolumeIntegral.md'
   [nondim]
     type = Exodiff
     input = nek.i

--- a/test/tests/userobjects/gap/nondimensional/tests
+++ b/test/tests/userobjects/gap/nondimensional/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekBinnedVolumeAverage.md NekBinnedVolumeIntegral.md'
+  design = 'NekBinnedVolumeAverage.md NekBinnedVolumeIntegral.md DimensionalizeAction.md'
   [nondim]
     type = Exodiff
     input = nek.i

--- a/test/tests/userobjects/hexagonal_gap_bin/tests
+++ b/test/tests/userobjects/hexagonal_gap_bin/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'HexagonalSubchannelGapBin.md'
   [bin]
     type = Exodiff
     input = subchannel.i

--- a/test/tests/userobjects/hexagonal_gap_layered/normals/tests
+++ b/test/tests/userobjects/hexagonal_gap_layered/normals/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'HexagonalSubchannelGapBin.md LayeredGapBin.md NekBinnedPlaneAverage.md NekSpatialBinComponentAux.md'
   [normal_component]
     type = Exodiff
     input = nek.i

--- a/test/tests/userobjects/hexagonal_gap_layered/tests
+++ b/test/tests/userobjects/hexagonal_gap_layered/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'HexagonalSubchannelGapBin.md LayeredBin.md LayeredGapBin.md NekBinnedPlaneAverage.md NekBinnedPlaneIntegral.md'
   [type_error]
     type = RunException
     input = type_error.i

--- a/test/tests/userobjects/hexagonal_subchannel_bin/tests
+++ b/test/tests/userobjects/hexagonal_subchannel_bin/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'HexagonalSubchannelBin.md'
   [bin]
     type = Exodiff
     input = subchannel.i

--- a/test/tests/userobjects/layered_bin/tests
+++ b/test/tests/userobjects/layered_bin/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'LayeredBin.md'
   [bin]
     type = Exodiff
     input = layered.i

--- a/test/tests/userobjects/layered_gap_bin/tests
+++ b/test/tests/userobjects/layered_gap_bin/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'LayeredGapBin.md'
   [bin]
     type = Exodiff
     input = layered.i

--- a/test/tests/userobjects/layered_gap_bin/tests
+++ b/test/tests/userobjects/layered_gap_bin/tests
@@ -4,12 +4,12 @@
     type = Exodiff
     input = layered.i
     exodiff = layered_out.e
-    requirement = "A layered bin shall divide space according to 1-D layers in a given direction."
+    requirement = "A layered bin shall divide space according to 1-D layers in a given direction in a 3D mesh."
   []
   [axial_bin]
     type = Exodiff
     input = layered_mesh.i
     exodiff = layered_mesh_out.e
-    requirement = "A layered bin shall divide space according to 1-D layers in a given direction."
+    requirement = "A layered bin shall divide space according to 1-D layers in a given direction when the mesh contains a series of 2D planes."
   []
 []

--- a/test/tests/userobjects/layered_layered/tests
+++ b/test/tests/userobjects/layered_layered/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'LayeredBin.md LayeredGapBin.md NekBinnedVolumeIntegral.md NekBinnedVolumeAverage.md'
   [multiple_layers]
     type = Exodiff
     input = nek.i

--- a/test/tests/userobjects/openmc_nuclide_densities/tests
+++ b/test/tests/userobjects/openmc_nuclide_densities/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'OpenMCNuclideDensities.md'
+  design = 'OpenMCNuclideDensities.md OpenMCCellAverageProblem.md'
   [nonexistent_id]
     type = RunException
     input = openmc.i

--- a/test/tests/userobjects/openmc_nuclide_densities/tests
+++ b/test/tests/userobjects/openmc_nuclide_densities/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCNuclideDensities.md'
   [nonexistent_id]
     type = RunException
     input = openmc.i

--- a/test/tests/userobjects/radial_bin/tests
+++ b/test/tests/userobjects/radial_bin/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'RadialBin.md'
   [bin]
     type = Exodiff
     input = radial.i

--- a/test/tests/userobjects/radial_layered/tests
+++ b/test/tests/userobjects/radial_layered/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'RadialBin.md LayeredBin.md NekBinnedVolumeIntegral.md'
   [1d_output]
     type = CSVDiff
     input = 1d.i

--- a/test/tests/userobjects/side/nondimensional/tests
+++ b/test/tests/userobjects/side/nondimensional/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekBinnedSideAverage.md NekBinnedSideIntegral.md'
   [precompile]
     type = RunCommand
     command = '${NEKRS_HOME}/bin/nrspre sfr_7pin 1'

--- a/test/tests/userobjects/side/nondimensional/tests
+++ b/test/tests/userobjects/side/nondimensional/tests
@@ -1,11 +1,11 @@
 [Tests]
-  design = 'NekBinnedSideAverage.md NekBinnedSideIntegral.md'
   [precompile]
     type = RunCommand
     command = '${NEKRS_HOME}/bin/nrspre sfr_7pin 1'
     requirement = "The system shall precompile a Nek case in preparation for a multi-input simulation."
     capabilities = 'nekrs'
     use_shell = True
+    design = 'NekRSProblem.md'
   []
   [nondim]
     type = Exodiff
@@ -17,5 +17,6 @@
     prereq = precompile
     capabilities = 'nekrs'
     skip = 'Need to resolve precompile issues'
+    design = 'NekBinnedSideAverage.md NekBinnedSideIntegral.md DimensionalizeAction.md'
   []
 []

--- a/test/tests/userobjects/sideset_layered/tests
+++ b/test/tests/userobjects/sideset_layered/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekBinnedSideIntegral.md NekBinnedSideAverage.md LayeredBin.md'
   [invalid_boundary]
     type = RunException
     input = invalid_boundary.i

--- a/test/tests/userobjects/sideset_layered/tests
+++ b/test/tests/userobjects/sideset_layered/tests
@@ -1,11 +1,11 @@
 [Tests]
-  design = 'NekBinnedSideIntegral.md NekBinnedSideAverage.md LayeredBin.md'
   [invalid_boundary]
     type = RunException
     input = invalid_boundary.i
     expect_err = "Invalid 'boundary' entry: 5"
     requirement = "The system shall error if an invalid boundary ID is specified"
     capabilities = 'nekrs'
+    design = 'NekBinnedSideIntegral.md'
   []
   [z_bins]
     type = Exodiff
@@ -14,6 +14,7 @@
     rel_err = 5e-4
     requirement = "The system shall correctly integrate over a sideset in the NekRS domain when mapping space by the quadrature point"
     capabilities = 'nekrs'
+    design = 'NekBinnedSideIntegral.md NekBinnedSideAverage.md LayeredBin.md'
   []
   [z_bins_by_centroid]
     type = Exodiff
@@ -21,6 +22,7 @@
     exodiff = z_bins_by_centroid_out.e
     requirement = "The system shall correctly integrate over a sideset in the NekRS domain when mapping space by the face centroid"
     capabilities = 'nekrs'
+    design = 'NekBinnedSideIntegral.md NekBinnedSideAverage.md LayeredBin.md'
   []
   [side_average]
     type = Exodiff
@@ -28,5 +30,6 @@
     exodiff = side_average_out.e
     requirement = "The system shall correctly average over a sideset in the NekRS domain"
     capabilities = 'nekrs'
+    design = 'NekBinnedSideAverage.md LayeredBin.md'
   []
 []

--- a/test/tests/userobjects/subchannel_layered/tests
+++ b/test/tests/userobjects/subchannel_layered/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'HexagonalSubchannelBin.md LayeredBin.md NekBinnedVolumeAverage.md NekBinnedVolumeIntegral.md'
   [type_error]
     type = RunException
     input = type_error.i

--- a/test/tests/userobjects/subchannel_layered/tests
+++ b/test/tests/userobjects/subchannel_layered/tests
@@ -1,11 +1,12 @@
 [Tests]
-  design = 'HexagonalSubchannelBin.md LayeredBin.md NekBinnedVolumeAverage.md NekBinnedVolumeIntegral.md'
   [type_error]
     type = RunException
     input = type_error.i
     expect_err = "Bin user object with name 'dummy' either does not exist or is of the wrong type."
     requirement = "The system shall error if the userobjects aren't derived from the correct base class or if they are not found in the problem."
     capabilities = 'nekrs'
+    design = 'NekBinnedVolumeAverage.md'
+    issues = '#1407'
   []
   [subchannel_layered]
     type = Exodiff
@@ -14,7 +15,7 @@
     requirement = "A subchannel and 1-D layered bin shall be combined to give a multi-dimensional "
                   "binning and demonstrate correct results for volume integrals and averages."
     capabilities = 'nekrs'
-    issues = '#1407'
+    design = 'HexagonalSubchannelBin.md LayeredBin.md NekBinnedVolumeAverage.md NekBinnedVolumeIntegral.md'
   []
   [conflicting_bins]
     type = RunException
@@ -23,6 +24,7 @@
                  "Bin 'x_bins' conflicts with bin 'subchannel_binning'"
     requirement = "System shall error if user attemps to combine multiple bins that specify the same coordinate direction."
     capabilities = 'nekrs'
+    design = 'HexagonalSubchannelBin.md LayeredBin.md NekBinnedVolumeAverage.md NekBinnedVolumeIntegral.md'
   []
   [1d_output]
     type = CSVDiff
@@ -30,6 +32,7 @@
     csvdiff = 1d_out_from_uo_0002.csv
     requirement = "The output points shall be automatically output for a single-axis subchannel binning"
     capabilities = 'nekrs'
+    design = 'HexagonalSubchannelBin.md NekBinnedVolumeAverage.md'
   []
   [wrong_type]
     type = RunException
@@ -37,6 +40,7 @@
     expect_err = "This user object requires all bins to be volume distributions"
     requirement = "System shall error if a side user object is provided to a volume binning user object."
     capabilities = 'nekrs'
+    design = 'NekBinnedVolumeAverage.md'
   []
   [invalid_component]
     type = RunException
@@ -45,6 +49,7 @@
     expect_err = "Setting 'velocity_component = normal' is not supported"
     requirement = "System shall error if attempting to use a normal velocity component with a user object that does not have normals defined"
     capabilities = 'nekrs'
+    design = 'NekBinnedVolumeAverage.md'
   []
   [user_component]
     type = Exodiff
@@ -54,6 +59,7 @@
                   "binning and demonstrate correct results for volume averages of velocity projected "
                   "along a constant direction."
     capabilities = 'nekrs'
+    design = 'HexagonalSubchannelBin.md LayeredBin.md NekBinnedVolumeAverage.md NekBinnedVolumeIntegral.md'
   []
   [pin_1d]
     type = CSVDiff
@@ -61,5 +67,6 @@
     csvdiff = pin_1d_out_from_uo_0002.csv
     requirement = "A pin-centered subchannel bin shall give correct results for side averages of temperature."
     capabilities = 'nekrs'
+    design = 'HexagonalSubchannelBin.md NekBinnedVolumeAverage.md'
   []
 []

--- a/test/tests/userobjects/symmetry_point_generator/tests
+++ b/test/tests/userobjects/symmetry_point_generator/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'SymmetryPointGenerator.md'
   [non_perpendicular_axis]
     type = RunException
     input = test.i

--- a/test/tests/userobjects/volume/nondimensional/tests
+++ b/test/tests/userobjects/volume/nondimensional/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'NekBinnedVolumeAverage.md NekBinnedVolumeIntegral.md'
   [nondim]
     type = Exodiff
     input = nek.i

--- a/test/tests/userobjects/volume/nondimensional/tests
+++ b/test/tests/userobjects/volume/nondimensional/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'NekBinnedVolumeAverage.md NekBinnedVolumeIntegral.md'
+  design = 'NekBinnedVolumeAverage.md NekBinnedVolumeIntegral.md DimensionalizeAction.md'
   [nondim]
     type = Exodiff
     input = nek.i

--- a/test/tests/userobjects/volume_calculation/instances/tests
+++ b/test/tests/userobjects/volume_calculation/instances/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'OpenMCVolumeCalculation.md'
+  design = 'OpenMCVolumeCalculation.md OpenMCCellAverageProblem.md'
   [warn_instances]
     type = RunException
     input = openmc.i

--- a/test/tests/userobjects/volume_calculation/instances/tests
+++ b/test/tests/userobjects/volume_calculation/instances/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCVolumeCalculation.md'
   [warn_instances]
     type = RunException
     input = openmc.i

--- a/test/tests/userobjects/volume_calculation/tests
+++ b/test/tests/userobjects/volume_calculation/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'OpenMCVolumeCalculation.md'
   [invalid_box]
     type = RunException
     input = openmc.i

--- a/test/tests/userobjects/volume_calculation/tests
+++ b/test/tests/userobjects/volume_calculation/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'OpenMCVolumeCalculation.md'
+  design = 'OpenMCVolumeCalculation.md OpenMCCellAverageProblem.md'
   [invalid_box]
     type = RunException
     input = openmc.i


### PR DESCRIPTION
refs #1396 

Claude Opus 4.8 performed an audit on design documents and tests. These are the MATCH suggestions only from that audit. The full audit/assessment can be found in the linked issue.

Members of the CCB who are familiar with the different parts of the code should assess whether the added design documents are accurate here, or assign someone who is familiar with these tests to check it.