### PR TITLE
Fix duplicate cell-instance when using Skinner with non-root DAGMC Universe

### DIFF
--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -2905,6 +2905,10 @@ OpenMCCellAverageProblem::reloadDAGMC()
   _console << "Re-generating OpenMC model with " << openmc::model::cells.size() << " cells... "
            << std::endl;
 
+  // Clear cells on all surviving universes
+  for (auto & universe : openmc::model::universes)
+    universe->cells_.clear();
+  
   // Add cells to universes
   openmc::populate_universes();
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -2908,7 +2908,7 @@ OpenMCCellAverageProblem::reloadDAGMC()
   // Clear cells on all surviving universes
   for (auto & universe : openmc::model::universes)
     universe->cells_.clear();
-  
+
   // Add cells to universes
   openmc::populate_universes();
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -2905,7 +2905,7 @@ OpenMCCellAverageProblem::reloadDAGMC()
   _console << "Re-generating OpenMC model with " << openmc::model::cells.size() << " cells... "
            << std::endl;
 
-  // Clear cells on all surviving universes
+  // Clear cells on all surviving universes.
   for (auto & universe : openmc::model::universes)
     universe->cells_.clear();
 

--- a/test/tests/neutronics/dagmc/with_csg/tests
+++ b/test/tests/neutronics/dagmc/with_csg/tests
@@ -11,3 +11,20 @@
     capabilities = 'dagmc'
   []
 []
+
+[Tests]
+  issues = '#1400'
+  design = 'MoabSkinner.md OpenMCCellAverageProblem.md'
+
+  [cell_instances_stable_across_reskins]
+    type = RunApp
+    input = openmc.i
+    expect_out = 'of 1\)'
+    absent_out = 'of [2-9]\)'
+    requirement = "The system shall not artificially inflate an OpenMC cell's instance count "
+                  "when the MOAB skinner reloads DAGMC geometry multiple times for a "
+                  "CSG-wrapped DAGMC universe."
+    mesh_mode = 'replicated'
+    capabilities = 'dagmc'
+  []
+[]


### PR DESCRIPTION
Closes [#1400](https://github.com/neams-th-coe/cardinal/issues/1400)