### PR TITLE
Reset timers on each search iteration.

### DIFF
--- a/src/criticality/CriticalitySearchBase.C
+++ b/src/criticality/CriticalitySearchBase.C
@@ -132,8 +132,16 @@ CriticalitySearchBase::searchForCriticality(std::function<void()> step_callback)
       for (auto & t : openmc::model::tallies)
         t->set_active(false);
 
-    // re-run the model
+    // Need to reset timers after the first iteration.
     int err = 0;
+    if (_inputs.size() > 1)
+    {
+      err = openmc_reset_timers();
+      if (err)
+        mooseError(openmc_err_msg);
+    }
+
+    // re-run the model
     if (_openmc_problem->runRandomRay())
       openmc_run_random_ray();
     else


### PR DESCRIPTION
Before this fix (running `tests/criticality/rotation` on my machine):
```
Iteration 1:
 Total time elapsed                = 1.0462e+01 seconds
 Calculation Rate (inactive)       = 50890.2 particles/second
 Calculation Rate (active)         = 55627.2 particles/second
Iteration 2:
 Total time elapsed                = 2.0002e+01 seconds
 Calculation Rate (inactive)       = 25294 particles/second
 Calculation Rate (active)         = 27166.6 particles/second
Iteration 3:
 Total time elapsed                = 2.9199e+01 seconds
 Calculation Rate (inactive)       = 16932.3 particles/second
 Calculation Rate (active)         = 18222.3 particles/second
```

After the fix:
```
Iteration 1:
 Total time elapsed                = 9.4481e+00 seconds
 Calculation Rate (inactive)       = 52526.9 particles/second
 Calculation Rate (active)         = 55853.2 particles/second
Iteration 2:
 Total time elapsed                = 9.7503e+00 seconds
 Calculation Rate (inactive)       = 49890.3 particles/second
 Calculation Rate (active)         = 51752.5 particles/second
Iteration 3:
 Total time elapsed                = 9.3619e+00 seconds
 Calculation Rate (inactive)       = 49414.5 particles/second
 Calculation Rate (active)         = 54633.4 particles/second
```

Closes #1412