### PR TITLE
try optimization for large problems to avoid unecessary subdomain-material table print

### DIFF
--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -789,7 +789,7 @@ OpenMCCellAverageProblem::setupProblem()
   // will probably go away once we update the skinner to more modern approach of density
   // multipliers rather than unique materials per bin). For large problems, determining
   // how the subdomains map to OpenMC materials can be costly, so we should make this optional
-  if (_verbose || _skinner)
+  if (_verbose || _using_skinner)
     subdomainsToMaterials();
 
   initializeTallies();

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -784,7 +784,13 @@ OpenMCCellAverageProblem::setupProblem()
   for (const auto & c : _cell_to_elem)
     _cell_to_n_contained[c.first] = numContainedMaterialCells(c.first);
 
-  subdomainsToMaterials();
+  // the _subdomain_to_material member variable is only used if printing out verbose
+  // information or if the skinner is used (TODO: though, that statement about the skinner
+  // will probably go away once we update the skinner to more modern approach of density
+  // multipliers rather than unique materials per bin). For large problems, determining
+  // how the subdomains map to OpenMC materials can be costly, so we should make this optional
+  if (_verbose || _skinner)
+    subdomainsToMaterials();
 
   initializeTallies();
 }


### PR DESCRIPTION
The `_subdomain_to_material` variable is only _required_ when using the skinner - for problems without the skinner, this variable is used to print a helpful table showing the mapping of subdomains to OpenMC materials. However, this can be expensive for large CSG problems - to help @lewisgross1296 with his TRISO model, this makes the computation of this variable optional (it will only be computed if `verbose = true`).

Estimated this will save @lewisgross1296 25% runtime associated with Cardinal model setup 