### PR TITLE
Loosen tolerance for tests due to compiler optimization

### DIFF
--- a/test/tests/neutronics/dagmc/cell_tallies/skin.cmp
+++ b/test/tests/neutronics/dagmc/cell_tallies/skin.cmp
@@ -1,0 +1,5 @@
+GLOBAL VARIABLES (all)
+	k                   relative 2e-2
+
+ELEMENT VARIABLES (all)
+	kappa_fission       relative 5.5e-6 floor 3e-3

--- a/test/tests/neutronics/dagmc/cell_tallies/skin_null_density.cmp
+++ b/test/tests/neutronics/dagmc/cell_tallies/skin_null_density.cmp
@@ -1,0 +1,5 @@
+GLOBAL VARIABLES (all)
+	k                   relative 2e-2
+
+ELEMENT VARIABLES (all)
+	kappa_fission       relative 5.5e-6 floor 3e-3

--- a/test/tests/neutronics/dagmc/cell_tallies/tests
+++ b/test/tests/neutronics/dagmc/cell_tallies/tests
@@ -23,6 +23,10 @@
                   "directory."
     mesh_mode = 'replicated'
     capabilities = 'dagmc'
+    # diffs with -march=x86-64-v3; set:
+    # - k rel to 2e-2
+    # - kappa_fission elemental abs_zero to 3e-3 OR rel 2e-1
+    custom_cmp = skin.cmp
   []
   [skin_null_density]
     type = Exodiff
@@ -32,6 +36,10 @@
     requirement = "The system shall give identical Monte Carlo solution (file mesh tallies and k) when skinning with a single density bin when compared to a case without any density skinning at all."
     mesh_mode = 'replicated'
     capabilities = 'dagmc'
+    # diffs with -march=x86-64-v3; set:
+    # - k rel to 2e-2
+    # - kappa_fission elemental abs_zero to 3e-3 OR rel 2e-1
+    custom_cmp = skin_null_density.cmp
   []
   [scale_mesh]
     type = RunApp

--- a/test/tests/neutronics/dagmc/implicit_comp_material/tests
+++ b/test/tests/neutronics/dagmc/implicit_comp_material/tests
@@ -12,5 +12,11 @@
                   "directory. The result for k is within statistics of the CSG equivalent."
     mesh_mode = 'replicated'
     capabilities = 'dagmc'
+    # diffs with -march=x86-64-v3:
+    # k: 1.399e+00 ~ 1.400e+00 = 8.266e-04 (8.266e-04)
+    # k_std_dev: 3.711e-03 ~ 4.808e-03 = 2.283e-01 (2.283e-01)
+    override_columns = "k k_std_dev"
+    override_rel_err = "9e-4 4e-1"
+    override_abs_zero = "1e-10 1e-10" # default values
   []
 []

--- a/test/tests/neutronics/dagmc/implicit_comp_material/without_graveyard/tests
+++ b/test/tests/neutronics/dagmc/implicit_comp_material/without_graveyard/tests
@@ -14,5 +14,11 @@
                   "statistics to the CSG reference."
     mesh_mode = 'replicated'
     capabilities = 'dagmc'
+    # diffs with -march=x86-64-v3:
+    # k: 1.399e+00 ~ 1.400e+00 = 8.266e-04 (8.266e-04)
+    # k_std_dev: 3.711e-03 ~ 4.808e-03 = 2.283e-01 (2.283e-01)
+    override_columns = "k k_std_dev"
+    override_rel_err = "9e-4 4e-1"
+    override_abs_zero = "1e-10 1e-10" # default values
   []
 []

--- a/test/tests/neutronics/dagmc/mesh_tallies/disjoint_bins.cmp
+++ b/test/tests/neutronics/dagmc/mesh_tallies/disjoint_bins.cmp
@@ -1,0 +1,5 @@
+GLOBAL VARIABLES (all)
+	k                   relative 5e-3
+
+ELEMENT VARIABLES (all)
+	kappa_fission       relative 5.5e-6 floor 3e-3

--- a/test/tests/neutronics/dagmc/mesh_tallies/skin.cmp
+++ b/test/tests/neutronics/dagmc/mesh_tallies/skin.cmp
@@ -1,0 +1,5 @@
+GLOBAL VARIABLES (all)
+	k                   relative 3e-2
+
+ELEMENT VARIABLES (all)
+	kappa_fission       relative 5.5e-6 floor 4e-3

--- a/test/tests/neutronics/dagmc/mesh_tallies/skin_direct.cmp
+++ b/test/tests/neutronics/dagmc/mesh_tallies/skin_direct.cmp
@@ -1,0 +1,5 @@
+GLOBAL VARIABLES (all)
+	k                   relative 2e-2
+
+ELEMENT VARIABLES (all)
+	kappa_fission       relative 5.5e-6 floor 4e-3

--- a/test/tests/neutronics/dagmc/mesh_tallies/tests
+++ b/test/tests/neutronics/dagmc/mesh_tallies/tests
@@ -23,6 +23,10 @@
                   "directory."
     mesh_mode = 'replicated'
     capabilities = 'dagmc'
+    # diffs with -march=x86-64-v3; set:
+    # - k rel to 3e-2
+    # - kappa_fission elemental abs_zero to 4e-3 OR rel 7e-1
+    custom_cmp = skin.cmp
   []
   [skin_direct]
     type = Exodiff
@@ -34,6 +38,10 @@
                   "directory."
     mesh_mode = 'replicated'
     capabilities = 'dagmc'
+    # diffs with -march=x86-64-v3; set:
+    # - k rel to 5e-3
+    # - kappa_fission elemental abs_zero to 5e-5 OR rel 7e-1
+    custom_cmp = skin_direct.cmp
   []
   [disjoint_bins]
     type = Exodiff
@@ -45,6 +53,10 @@
                   "directory. For this case, a bin is split across disjoint elements."
     mesh_mode = 'replicated'
     capabilities = 'dagmc'
+    # diffs with -march=x86-64-v3; set:
+    # - k rel to 2e-2
+    # - kappa_fission elemental abs_zero to 4e-3 OR rel 8e-1
+    custom_cmp = disjoint_bins.cmp
   []
   [scale_mesh]
     type = RunApp

--- a/test/tests/neutronics/mg/rr_thermal_expansion/tests
+++ b/test/tests/neutronics/mg/rr_thermal_expansion/tests
@@ -10,5 +10,10 @@
                   "problem with OpenMC's random ray solver."
     mesh_mode = 'replicated'
     capabilities = 'dagmc'
+    # k_std_dev diffs at t=1: 1.297e-09 ~ 1.311e-09 = 1.107e-02 (1.107e-02)
+    # with -march=x86-64-v3; bump abs_zero
+    override_columns = "k_std_dev"
+    override_rel_err = "5.5e-6" # default value
+    override_abs_zero = "5e-9"
   []
 []


### PR DESCRIPTION
idaholab/moose#33466 introduces compiler optimization to the entire stack (petsc, libmesh, moose). This compiler optimization can lead to small differences in basic computation (for example, fuse multiply add which can do `a + b × c` in a single step. We don't want to regold these tests because cases like running in debug will disable these optimizations, leading then to diffs in debug.

This resolves the issues seen when adding optimization in https://civet.inl.gov/job/4068831/.

I tried to be as explicit as possible about what all of the diffs were when I changed the tests. This is on you guys to see what's appropriate. Unfortunately, this is the cost of potentially making things faster. There are also options to dig into the code to make certain cases more resilent to these kinds of optimizations, but there isn't time for that at the moment.

I don't understand the dagmc tests fully, but what I suspect is that with the optimization the meshes are no longer fully equivalent.

If anyone wants to actually test this configuration themselves, they can do it easily on linux by running in one of the container images from idaholab/moose#33466. Let me know if you'd like to.

The things that need to be looked at in detail most are for the kappa_fission tallies. In each test spec where I increased abs_zero, I also put in a comment in the test spec what we could set the relative tolerance to instead. I'm not sure if it's best here to filter out noise via abs_zero or rel_err.
