### PR TITLE
prevent function usage when not enabled.

### DIFF
--- a/src/postprocessors/NekPointValue.C
+++ b/src/postprocessors/NekPointValue.C
@@ -37,7 +37,10 @@ NekPointValue::NekPointValue(const InputParameters & parameters)
   : NekFieldPostprocessor(parameters), _point(getParam<Point>("point")), _value(0)
 {
   if (_function)
-    paramError("function", "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived classes! Please contact the Cardinal developer team to accelerate this feature addition.");
+    paramError(
+        "function",
+        "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived "
+        "classes! Please contact the Cardinal developer team to accelerate this feature addition.");
 }
 
 void

--- a/src/postprocessors/NekPointValue.C
+++ b/src/postprocessors/NekPointValue.C
@@ -36,6 +36,8 @@ NekPointValue::validParams()
 NekPointValue::NekPointValue(const InputParameters & parameters)
   : NekFieldPostprocessor(parameters), _point(getParam<Point>("point")), _value(0)
 {
+  if (_function)
+    paramError("function", "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived classes! Please contact the Cardinal developer team to accelerate this feature addition.");
 }
 
 void

--- a/src/postprocessors/NekSideFieldPostprocessor.C
+++ b/src/postprocessors/NekSideFieldPostprocessor.C
@@ -32,7 +32,10 @@ NekSideFieldPostprocessor::NekSideFieldPostprocessor(const InputParameters & par
   : NekSidePostprocessor(parameters), NekFieldInterface(this, parameters)
 {
   if (_function)
-    paramError("function", "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived classes! Please contact the Cardinal developer team to accelerate this feature addition.");
+    paramError(
+        "function",
+        "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived "
+        "classes! Please contact the Cardinal developer team to accelerate this feature addition.");
 }
 
 #endif

--- a/src/postprocessors/NekSideFieldPostprocessor.C
+++ b/src/postprocessors/NekSideFieldPostprocessor.C
@@ -31,6 +31,8 @@ NekSideFieldPostprocessor::validParams()
 NekSideFieldPostprocessor::NekSideFieldPostprocessor(const InputParameters & parameters)
   : NekSidePostprocessor(parameters), NekFieldInterface(this, parameters)
 {
+  if (_function)
+    paramError("function", "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived classes! Please contact the Cardinal developer team to accelerate this feature addition.");
 }
 
 #endif

--- a/src/postprocessors/NekVolumeExtremeValue.C
+++ b/src/postprocessors/NekVolumeExtremeValue.C
@@ -41,6 +41,9 @@ NekVolumeExtremeValue::NekVolumeExtremeValue(const InputParameters & parameters)
 {
   if (_field == field::velocity_component)
     mooseError("Setting 'field = velocity_component' is not yet implemented!");
+
+  if (_function)
+    paramError("function", "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived classes! Please contact the Cardinal developer team to accelerate this feature addition.");
 }
 
 Real

--- a/src/postprocessors/NekVolumeExtremeValue.C
+++ b/src/postprocessors/NekVolumeExtremeValue.C
@@ -43,7 +43,10 @@ NekVolumeExtremeValue::NekVolumeExtremeValue(const InputParameters & parameters)
     mooseError("Setting 'field = velocity_component' is not yet implemented!");
 
   if (_function)
-    paramError("function", "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived classes! Please contact the Cardinal developer team to accelerate this feature addition.");
+    paramError(
+        "function",
+        "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived "
+        "classes! Please contact the Cardinal developer team to accelerate this feature addition.");
 }
 
 Real

--- a/src/postprocessors/NekVolumeIntegral.C
+++ b/src/postprocessors/NekVolumeIntegral.C
@@ -34,7 +34,10 @@ NekVolumeIntegral::NekVolumeIntegral(const InputParameters & parameters)
   : NekFieldPostprocessor(parameters)
 {
   if (_function)
-    paramError("function", "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived classes! Please contact the Cardinal developer team to accelerate this feature addition.");
+    paramError(
+        "function",
+        "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived "
+        "classes! Please contact the Cardinal developer team to accelerate this feature addition.");
 }
 
 Real

--- a/src/postprocessors/NekVolumeIntegral.C
+++ b/src/postprocessors/NekVolumeIntegral.C
@@ -33,6 +33,8 @@ NekVolumeIntegral::validParams()
 NekVolumeIntegral::NekVolumeIntegral(const InputParameters & parameters)
   : NekFieldPostprocessor(parameters)
 {
+  if (_function)
+    paramError("function", "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived classes! Please contact the Cardinal developer team to accelerate this feature addition.");
 }
 
 Real

--- a/src/userobjects/NekSpatialBinUserObject.C
+++ b/src/userobjects/NekSpatialBinUserObject.C
@@ -69,7 +69,10 @@ NekSpatialBinUserObject::NekSpatialBinUserObject(const InputParameters & paramet
     _bin_partial_counts(nullptr)
 {
   if (_function)
-    paramError("function", "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived classes! Please contact the Cardinal developer team to accelerate this feature addition.");
+    paramError(
+        "function",
+        "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived "
+        "classes! Please contact the Cardinal developer team to accelerate this feature addition.");
 
   _fixed_mesh = !nekrs::hasMovingMesh();
 

--- a/src/userobjects/NekSpatialBinUserObject.C
+++ b/src/userobjects/NekSpatialBinUserObject.C
@@ -68,6 +68,9 @@ NekSpatialBinUserObject::NekSpatialBinUserObject(const InputParameters & paramet
     _bin_partial_values(nullptr),
     _bin_partial_counts(nullptr)
 {
+  if (_function)
+    paramError("function", "Providing a shifting function is not yet supported by the NekSpatialBinUserObject derived classes! Please contact the Cardinal developer team to accelerate this feature addition.");
+
   _fixed_mesh = !nekrs::hasMovingMesh();
 
   if (_bin_names.size() == 0)


### PR DESCRIPTION
Not exactly elegant, but I realized later that by adding `function` to the `NekFieldInterface`, that all the derived classes will show it on the documentation, but the parameter is not actually used yet. Planning to add it, so this is just a placeholder to ensure correct code behavior in the interim while those features are added.

 Refs #1046