### PR TITLE
Adds mooseWarning for when a moving OpenMC problem is detected, but the moose mesh is fixed.

### DIFF
--- a/include/base/OpenMCProblemBase.h
+++ b/include/base/OpenMCProblemBase.h
@@ -437,6 +437,12 @@ protected:
   /// Whether OpenMC cell transforms are being applied to the geometry
   bool hasCellTransform() const;
 
+  /**
+   * Whether the OpenMC geometry is being moved by a cell transform
+   * or a geometry changing criticality search
+   */
+  bool movesOpenMCGeometry() const;
+
   /// Ensure that the IDs of OpenMC objects in UserObjects don't clash
   void checkOpenMCUserObjectIDs() const;
 

--- a/src/base/OpenMCCellAverageProblem.C
+++ b/src/base/OpenMCCellAverageProblem.C
@@ -568,19 +568,23 @@ OpenMCCellAverageProblem::initialSetup()
   }
 
   getOpenMCUserObjects();
+  if (_needs_to_map_cells)
+  {
+    if (_use_displaced && !_using_skinner && !movesOpenMCGeometry())
+      mooseWarning("Your problem has a moving mesh, but you have not provided a 'skinner', an "
+                   "OpenMCCellTransform user object, or a geometry changing criticality search "
+                   "(all of which move the OpenMC geometry). The [Mesh] will move, but the "
+                   "underlying OpenMC geometry will remain unchanged. Unexpected behavior may "
+                   "occur.");
+    else if (!_use_displaced && movesOpenMCGeometry())
+      mooseWarning("The OpenMC geometry is being moved (via an OpenMCCellTransform user object "
+                   "or a geometry changing criticality search), but your problem has a fixed "
+                   "mesh. The underlying OpenMC geometry will change, but the [Mesh] will not "
+                   "move. Unexpected behavior may occur.");
+  }
 
-  if (_use_displaced && !_using_skinner && !hasCellTransform())
-    mooseWarning("Your problem has a moving mesh, but you have not provided a 'skinner' or an "
-                 "OpenMCCellTransform user object (both of which move the OpenMC geometry). The "
-                 "[Mesh] will move, but the underlying OpenMC geometry will remain unchanged. "
-                 "Unexpected behavior may occur.");
-
-  // Coupling re-initialization should be triggered if we have cell transforms which can happen
-  // even if the mesh isn't moving or adaptive.
-  _need_to_reinit_coupling |= hasCellTransform();
-  // The criticality search may modify the geometry.
-  if (_criticality_search)
-    _need_to_reinit_coupling |= _criticality_search->changingGeometry();
+  // Coupling re-initialization should be triggered if the OpenMC geometry is being moved
+  _need_to_reinit_coupling |= movesOpenMCGeometry();
 
   if (!_needs_to_map_cells)
     checkUnusedParam(parameters(),

--- a/src/base/OpenMCProblemBase.C
+++ b/src/base/OpenMCProblemBase.C
@@ -989,6 +989,12 @@ OpenMCProblemBase::hasCellTransform() const
   return !_cell_transform_uos.empty();
 }
 
+bool
+OpenMCProblemBase::movesOpenMCGeometry() const
+{
+  return hasCellTransform() || (_criticality_search && _criticality_search->changingGeometry());
+}
+
 void
 OpenMCProblemBase::checkOpenMCUserObjectIDs() const
 {

--- a/test/tests/criticality/rotation/tests
+++ b/test/tests/criticality/rotation/tests
@@ -48,4 +48,12 @@
     requirement = 'The system shall error if the user disables tallies and does not request a critical state calculation.'
     capabilities = 'openmc'
   []
+  [rotation_mismatching_geometry]
+    type = RunException
+    input = coupling.i
+    cli_args = '--error'
+    expect_err = "The OpenMC geometry is being moved"
+    requirement = 'The system shall warn the user when a criticality search rotates the OpenMC geometry while the mesh remains stationary.'
+    capabilities = 'openmc'
+  []
 []

--- a/test/tests/userobjects/openmc_cell_transform/tests
+++ b/test/tests/userobjects/openmc_cell_transform/tests
@@ -68,4 +68,12 @@
     expect_err = "UserObjects/translate_cells/vector_value: Provide exactly 3 values/postprocessors: 'dx dy dz' in mesh units for translationtransform or 'φ, θ, ψ' in degrees for rotation transform."
     capabilities = 'openmc'
   []
+  [mismatching_geometry_and_mesh]
+    type = RunException
+    input = cells_shadow.i
+    cli_args = '--error'
+    expect_err = "The OpenMC geometry is being moved \(via an OpenMCCellTransform user object or a geometry changing criticality search\), but your problem has a fixed mesh. The underlying OpenMC geometry will change, but the \[Mesh\] will not move. Unexpected behavior may occur."
+    requirement = 'The system shall warn the user when the OpenMC geometry is moved by a cell transform while the mesh remains stationary.'
+    capabilities = 'openmc'
+  []
 []


### PR DESCRIPTION

closes #1335