### PR TITLE
Link the nek_ci submodule tests to the RTM and VVR

### DIFF
--- a/doc/sqa_cardinal.yml
+++ b/doc/sqa_cardinal.yml
@@ -1,5 +1,6 @@
 directories:
     - ${ROOT_DIR}/test/tests
+    - ${ROOT_DIR}/test/tests/nek_ci
 specs:
     - tests
 dependencies: # commented-out categories are not available

--- a/doc/sqa_reports.yml
+++ b/doc/sqa_reports.yml
@@ -61,4 +61,5 @@ Requirements:
             - ${MOOSE_DIR}/modules/thermal_hydraulics/doc/content
         directories:
             - ${ROOT_DIR}/test
+            - ${ROOT_DIR}/test/tests/nek_ci
         show_warning: false


### PR DESCRIPTION
closes #1448 

Opening this now to be able to show the built website, but note the other PR in nek_ci needs to be merged first.

Order of operations for this PR:

1. Merge [this PR](https://github.com/neams-th-coe/nek_ci/pull/19) where the verification file links are added.
2. Let me update the nek_ci submod again here to point to the updated master branch (plan to edit last commit to do this)
3. Merge this PR.